### PR TITLE
Allow zoom even with overwritten default FOV

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -494,12 +494,12 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 			m_fov_transition_active = false;
 			m_curr_fov_degrees = m_target_fov_degrees;
 		}
-	} else if (m_server_sent_fov) {
-		// Instantaneous FOV change
-		m_curr_fov_degrees = m_target_fov_degrees;
 	} else if (player->getPlayerControl().zoom && player->getZoomFOV() > 0.001f) {
 		// Player requests zoom, apply zoom FOV
 		m_curr_fov_degrees = player->getZoomFOV();
+	} else if (m_server_sent_fov) {
+		// Instantaneous FOV change
+		m_curr_fov_degrees = m_target_fov_degrees;
 	} else {
 		// Set to client's selected FOV
 		m_curr_fov_degrees = m_cache_fov;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2502,7 +2502,7 @@ void Game::toggleFullViewRange()
 void Game::checkZoomEnabled()
 {
 	LocalPlayer *player = client->getEnv().getLocalPlayer();
-	if (player->getZoomFOV() < 0.001f || player->getFov().fov > 0.0f)
+	if (player->getZoomFOV() < 0.001f)
 		m_game_ui->showTranslatedStatusText("Zoom currently disabled by game or mod");
 }
 


### PR DESCRIPTION
Fixes #12951

Zoom can still be disabled using the player object properties. I created a PR in case someone thinks that the `set_fov` value should be enforced (i.e. whether disabling zoom is intentional).

## To do

This PR is Ready for Review.

## How to test
Based on code from #12951

```Lua
minetest.register_on_joinplayer(function(player)
	player:set_properties({
		zoom_fov = 60.0, -- enables zoom
	})
end)

minetest.register_chatcommand("p", {
	func = function(name, param)
		local player = minetest.get_player_by_name(name)
		-- the following line can be commented out to remove the message
		player:set_fov(tonumber(param) or 0, true, 0.1)
	end
})
```
