### PR TITLE
Android: Persistent notification while ingame

### DIFF
--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -22,14 +22,17 @@ package net.minetest.minetest;
 
 import org.libsdl.app.SDLActivity;
 
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.content.ActivityNotFoundException;
 import android.net.Uri;
-import android.os.Bundle;
+import android.os.Build;
 import android.text.InputType;
 import android.util.Log;
 import android.view.KeyEvent;
-import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
@@ -90,6 +93,8 @@ public class GameActivity extends SDLActivity {
 		// lifecycle documentation.
 		saveSettings();
 	}
+
+	private NotificationManager mNotifyManager;
 
 	public void showTextInputDialog(String hint, String current, int editType) {
 		runOnUiThread(() -> showTextInputDialogUI(hint, current, editType));
@@ -262,5 +267,40 @@ public class GameActivity extends SDLActivity {
 
 	public boolean hasPhysicalKeyboard() {
 		return getContext().getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS;
+	}
+
+	public void setPlayingNowNotification(boolean show) {
+		if (mNotifyManager == null) {
+			mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+		}
+		int notificationId = 2;
+
+		if (!show) {
+			mNotifyManager.cancel(notificationId);
+			return;
+		}
+
+		Notification.Builder builder;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			builder = new Notification.Builder(this, MainActivity.NOTIFICATION_CHANNEL_ID);
+		} else {
+			builder = new Notification.Builder(this);
+		}
+
+		Intent notificationIntent = new Intent(this, GameActivity.class);
+		notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+		int pendingIntentFlag = 0;
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+			pendingIntentFlag = PendingIntent.FLAG_MUTABLE;
+		}
+		PendingIntent intent = PendingIntent.getActivity(this, 0,
+			notificationIntent, pendingIntentFlag);
+
+		builder.setContentTitle(getString(R.string.game_notification_title))
+			.setSmallIcon(R.mipmap.ic_launcher)
+			.setContentIntent(intent)
+			.setOngoing(true);
+
+		mNotifyManager.notify(notificationId, builder.build());
 	}
 }

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -304,10 +304,11 @@ public class GameActivity extends SDLActivity {
 			.setSmallIcon(R.mipmap.ic_launcher)
 			.setContentIntent(intent)
 			.setOngoing(true)
-			// This avoids a stuck notification after closing the app from the
-			// "Recents" screen while in-game.
+			// This avoids a stuck notification if the app is killed while
+			// in-game: (1) if the user closes the app from the "Recents" screen
+			// or (2) if the system kills the app while it is in background.
 			// onStop is called too early to remove the notification and
-			// onDestroy is often not called, so there's this hack instead.
+			// onDestroy is often not called at all, so there's this hack instead.
 			.setTimeoutAfter(11000);
 
 		mNotifyManager.notify(MainActivity.NOTIFICATION_ID_GAME, builder.build());

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -269,14 +269,14 @@ public class GameActivity extends SDLActivity {
 		return getContext().getResources().getConfiguration().keyboard != Configuration.KEYBOARD_NOKEYS;
 	}
 
+	// TODO: share code with UnzipService.createNotification
 	public void setPlayingNowNotification(boolean show) {
 		if (mNotifyManager == null) {
 			mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 		}
-		int notificationId = 2;
 
 		if (!show) {
-			mNotifyManager.cancel(notificationId);
+			mNotifyManager.cancel(MainActivity.NOTIFICATION_ID_GAME);
 			return;
 		}
 
@@ -288,7 +288,8 @@ public class GameActivity extends SDLActivity {
 		}
 
 		Intent notificationIntent = new Intent(this, GameActivity.class);
-		notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+		notificationIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
+			| Intent.FLAG_ACTIVITY_SINGLE_TOP);
 		int pendingIntentFlag = 0;
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
 			pendingIntentFlag = PendingIntent.FLAG_MUTABLE;
@@ -301,6 +302,6 @@ public class GameActivity extends SDLActivity {
 			.setContentIntent(intent)
 			.setOngoing(true);
 
-		mNotifyManager.notify(notificationId, builder.build());
+		mNotifyManager.notify(MainActivity.NOTIFICATION_ID_GAME, builder.build());
 	}
 }

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -309,10 +309,12 @@ public class GameActivity extends SDLActivity {
 			// or (2) if the system kills the app while it is in background.
 			// onStop is called too early to remove the notification and
 			// onDestroy is often not called at all, so there's this hack instead.
-			.setTimeoutAfter(11000);
+			.setTimeoutAfter(16000);
 
 		mNotifyManager.notify(MainActivity.NOTIFICATION_ID_GAME, builder.build());
 
+		// Replace the notification just before it expires as long as the app is.
+		// still running.
 		final Handler handler = new Handler(Looper.getMainLooper());
 		handler.postDelayed(new Runnable() {
 			@Override
@@ -321,7 +323,7 @@ public class GameActivity extends SDLActivity {
 					updateGameNotification();
 				}
 			}
-		}, 10000);
+		}, 15000);
 	}
 
 

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -313,7 +313,7 @@ public class GameActivity extends SDLActivity {
 
 		mNotifyManager.notify(MainActivity.NOTIFICATION_ID_GAME, builder.build());
 
-		// Replace the notification just before it expires as long as the app is.
+		// Replace the notification just before it expires as long as the app is
 		// still running.
 		final Handler handler = new Handler(Looper.getMainLooper());
 		handler.postDelayed(new Runnable() {

--- a/android/app/src/main/java/net/minetest/minetest/GameActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/GameActivity.java
@@ -303,27 +303,30 @@ public class GameActivity extends SDLActivity {
 		builder.setContentTitle(getString(R.string.game_notification_title))
 			.setSmallIcon(R.mipmap.ic_launcher)
 			.setContentIntent(intent)
-			.setOngoing(true)
+			.setOngoing(true);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			// This avoids a stuck notification if the app is killed while
 			// in-game: (1) if the user closes the app from the "Recents" screen
 			// or (2) if the system kills the app while it is in background.
 			// onStop is called too early to remove the notification and
 			// onDestroy is often not called at all, so there's this hack instead.
-			.setTimeoutAfter(16000);
+			builder.setTimeoutAfter(16000);
+
+			// Replace the notification just before it expires as long as the app is
+			// running (and we're still in-game).
+			final Handler handler = new Handler(Looper.getMainLooper());
+			handler.postDelayed(new Runnable() {
+				@Override
+				public void run() {
+					if (gameNotificationShown) {
+						updateGameNotification();
+					}
+				}
+			}, 15000);
+		}
 
 		mNotifyManager.notify(MainActivity.NOTIFICATION_ID_GAME, builder.build());
-
-		// Replace the notification just before it expires as long as the app is
-		// still running.
-		final Handler handler = new Handler(Looper.getMainLooper());
-		handler.postDelayed(new Runnable() {
-			@Override
-			public void run() {
-				if (gameNotificationShown) {
-					updateGameNotification();
-				}
-			}
-		}, 15000);
 	}
 
 

--- a/android/app/src/main/java/net/minetest/minetest/MainActivity.java
+++ b/android/app/src/main/java/net/minetest/minetest/MainActivity.java
@@ -43,6 +43,8 @@ import static net.minetest.minetest.UnzipService.*;
 
 public class MainActivity extends AppCompatActivity {
 	public static final String NOTIFICATION_CHANNEL_ID = "Minetest channel";
+	public static final int NOTIFICATION_ID_UNZIP = 1;
+	public static final int NOTIFICATION_ID_GAME = 2;
 
 	private final static int versionCode = BuildConfig.VERSION_CODE;
 	private static final String SETTINGS = "MinetestSettings";

--- a/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -103,8 +103,9 @@ public class UnzipService extends IntentService {
 	@NonNull
 	private Notification.Builder createNotification() {
 		Notification.Builder builder;
-		if (mNotifyManager == null)
+		if (mNotifyManager == null) {
 			mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+		}
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			builder = new Notification.Builder(this, MainActivity.NOTIFICATION_CHANNEL_ID);
 		} else {

--- a/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -99,7 +99,7 @@ public class UnzipService extends IntentService {
 		}
 	}
 
-	// TODO: share code with GameActivity.setPlayingNowNotification
+	// TODO: share code with GameActivity.updateGameNotification
 	@NonNull
 	private Notification.Builder createNotification() {
 		if (mNotifyManager == null) {

--- a/android/app/src/main/java/net/minetest/minetest/UnzipService.java
+++ b/android/app/src/main/java/net/minetest/minetest/UnzipService.java
@@ -51,7 +51,6 @@ public class UnzipService extends IntentService {
 	public static final int SUCCESS = -1;
 	public static final int FAILURE = -2;
 	public static final int INDETERMINATE = -3;
-	private final int id = 1;
 	private NotificationManager mNotifyManager;
 	private boolean isSuccess = true;
 	private String failureMessage;
@@ -100,12 +99,14 @@ public class UnzipService extends IntentService {
 		}
 	}
 
+	// TODO: share code with GameActivity.setPlayingNowNotification
 	@NonNull
 	private Notification.Builder createNotification() {
-		Notification.Builder builder;
 		if (mNotifyManager == null) {
 			mNotifyManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 		}
+
+		Notification.Builder builder;
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
 			builder = new Notification.Builder(this, MainActivity.NOTIFICATION_CHANNEL_ID);
 		} else {
@@ -129,7 +130,7 @@ public class UnzipService extends IntentService {
 				.setOngoing(true)
 				.setProgress(0, 0, true);
 
-		mNotifyManager.notify(id, builder.build());
+		mNotifyManager.notify(MainActivity.NOTIFICATION_ID_UNZIP, builder.build());
 		return builder;
 	}
 
@@ -201,14 +202,14 @@ public class UnzipService extends IntentService {
 			} else {
 				notificationBuilder.setProgress(100, progress, false);
 			}
-			mNotifyManager.notify(id, notificationBuilder.build());
+			mNotifyManager.notify(MainActivity.NOTIFICATION_ID_UNZIP, notificationBuilder.build());
 		}
 	}
 
 	@Override
 	public void onDestroy() {
 		super.onDestroy();
-		mNotifyManager.cancel(id);
+		mNotifyManager.cancel(MainActivity.NOTIFICATION_ID_UNZIP);
 		publishProgress(null, R.string.loading, isSuccess ? SUCCESS : FAILURE);
 	}
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
 	<string name="notification_channel_description">Notifications from Luanti</string>
 	<string name="unzip_notification_title">Loading Luanti</string>
 	<string name="unzip_notification_description">Less than 1 minute&#8230;</string>
-	<string name="game_notification_title">Minetest is running</string>
+	<string name="game_notification_title">Luanti is running</string>
 	<string name="ime_dialog_done">Done</string>
 	<string name="no_web_browser">No web browser found</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 	<string name="notification_channel_description">Notifications from Luanti</string>
 	<string name="unzip_notification_title">Loading Luanti</string>
 	<string name="unzip_notification_description">Less than 1 minute&#8230;</string>
+	<string name="game_notification_title">Minetest is running</string>
 	<string name="ime_dialog_done">Done</string>
 	<string name="no_web_browser">No web browser found</string>
 </resources>

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1023,6 +1023,10 @@ void Game::run()
 
 	auto framemarker = FrameMarker("Game::run()-frame").started();
 
+#ifdef __ANDROID__
+	porting::setPlayingNowNotification(true);
+#endif
+
 	while (m_rendering_engine->run()
 			&& !(*kill || g_gamecallback->shutdown_requested
 			|| (server && server->isShutdownRequested()))) {
@@ -1102,6 +1106,10 @@ void Game::run()
 	}
 
 	framemarker.end();
+
+#ifdef __ANDROID__
+	porting::setPlayingNowNotification(false);
+#endif
 
 	RenderingEngine::autosaveScreensizeAndCo(initial_screen_size, initial_window_maximized);
 }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1021,11 +1021,11 @@ void Game::run()
 	const bool initial_window_maximized = !g_settings->getBool("fullscreen") &&
 			g_settings->getBool("window_maximized");
 
-	auto framemarker = FrameMarker("Game::run()-frame").started();
-
 #ifdef __ANDROID__
 	porting::setPlayingNowNotification(true);
 #endif
+
+	auto framemarker = FrameMarker("Game::run()-frame").started();
 
 	while (m_rendering_engine->run()
 			&& !(*kill || g_gamecallback->shutdown_requested

--- a/src/porting_android.cpp
+++ b/src/porting_android.cpp
@@ -187,6 +187,18 @@ void shareFileAndroid(const std::string &path)
 	jnienv->CallVoidMethod(activity, url_open, jurl);
 }
 
+void setPlayingNowNotification(bool show)
+{
+	jmethodID play_notification = jnienv->GetMethodID(activityClass,
+			"setPlayingNowNotification", "(Z)V");
+
+	FATAL_ERROR_IF(play_notification == nullptr,
+			"porting::setPlayingNowNotification unable to find Java setPlayingNowNotification method");
+
+	jboolean jshow = show;
+	jnienv->CallVoidMethod(activity, play_notification, jshow);
+}
+
 AndroidDialogType getLastInputDialogType()
 {
 	jmethodID lastdialogtype = jnienv->GetMethodID(activityClass,

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -36,6 +36,13 @@ void showComboBoxDialog(const std::string *optionList, s32 listSize, s32 selecte
  */
 void shareFileAndroid(const std::string &path);
 
+/**
+ * Shows/hides notification that the player is playing in a world
+ *
+ * @param show whether to show/hide the notification
+ */
+void setPlayingNowNotification(bool show);
+
 /*
  * Types of Android input dialog:
  * 1. Text input (single/multi-line text and password field)

--- a/src/porting_android.h
+++ b/src/porting_android.h
@@ -37,7 +37,7 @@ void showComboBoxDialog(const std::string *optionList, s32 listSize, s32 selecte
 void shareFileAndroid(const std::string &path);
 
 /**
- * Shows/hides notification that the player is playing in a world
+ * Shows/hides notification that the game is running
  *
  * @param show whether to show/hide the notification
  */


### PR DESCRIPTION
**Goal of the PR**
This PR adds a notification for Android player when playing inside a world/server.

**How does the PR work?**
Notify player before the main game loop and remove notification after the main game loop.

**Does it resolve any reported issue?**
Yes, this PR tries to fix #13115 (read the alternatives).

**Does this relate to a goal in the roadmap?**
Probably, this PR tries to fix a reported UX issue.

## To do
This PR is Ready for Review.

Known issue: The notification still exists after removing Minetest from the recent application list while the player is still inside a world/server. Restarting Minetest (or via tapping the notification) will clear it up. This issue also exists in other application and seems to be OEM-dependent.

## How to test
1. Run Minetest and play a world/server.
2. Check that a Minetest notification exists.
3. Press Home or go to recent application list.
4. Check that the Minetest notification still exists.
5. Enter Minetest application.
6. Go back to main menu.
7. Check that the Minetest notification has been removed.
8. Play a world/server again.
9. Check that a Minetest notification exists.
10. Exit to OS.
11. Check that the Minetest notification has been removed.