### PR TITLE
Add transfer_player function to request client move to new server

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -61,7 +61,17 @@ function ui.update()
 	local formspec = {}
 
 	-- handle errors
-	if gamedata ~= nil and gamedata.reconnect_requested then
+	if gamedata ~= nil and gamedata.reconnect_requested and #gamedata.transfer_address > 0 then
+		gamedata.reconnect_requested = false
+		gamedata.errormessage = nil
+		-- This is technically -not- a reconnect at this point
+		gamedata.do_reconnect = false
+		gamedata.address = gamedata.transfer_address
+		gamedata.port = gamedata.transfer_port
+		gamedata.playername = gamedata.transfer_playername
+		gamedata.password = gamedata.transfer_password
+		core.start()
+	elseif gamedata ~= nil and gamedata.reconnect_requested then
 		local error_message = core.formspec_escape(gamedata.errormessage)
 				or fgettext("<none available>")
 		formspec = {

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6589,6 +6589,9 @@ Bans
   optional reason, this will not prefix with 'Kicked: ' like kick_player.
   If no reason is given, it will default to 'Disconnected.'
     * Returns boolean indicating success (false if player nonexistent)
+* `minetest.transfer_player(name, address, port)`: Disconnect a player and
+  request the client re-connect at a new address and port. The connection
+  to the new server will occur using the same player name and password.
 
 Particles
 ---------

--- a/games/devtest/mods/testtransferplayer/README.md
+++ b/games/devtest/mods/testtransferplayer/README.md
@@ -1,0 +1,4 @@
+# Test Command for `transfer_player`
+
+Command to allow test of call `transfer_player`.
+

--- a/games/devtest/mods/testtransferplayer/init.lua
+++ b/games/devtest/mods/testtransferplayer/init.lua
@@ -1,0 +1,21 @@
+
+minetest.register_chatcommand("transfer_player", {
+	params = "<server_ip/url> <port>",
+	description = "Test transfer_player by disconnect and reconnect.",
+	func = function(player_name, param)
+		local player = minetest.get_player_by_name(player_name);
+		if not player then return end
+
+		local url, port = string.match(param, "([a-z0-9%.%/%-]+) (%d+)")
+
+		if not url or not port then
+			return false, "Bad IP/URL or/and port."
+		end
+
+		minetest.chat_send_all("Player "..player_name.." is being transfered to "..url.." port "..port..".")
+
+		minetest.transfer_player(player_name, url, port)
+		return true, "Transfering the connection..."
+	end
+})
+

--- a/games/devtest/mods/testtransferplayer/mod.conf
+++ b/games/devtest/mods/testtransferplayer/mod.conf
@@ -1,0 +1,2 @@
+name = testtransferplayer
+description = command to check transfer_player function

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -327,6 +327,9 @@ public:
 
 	bool reconnectRequested() const { return m_access_denied_reconnect; }
 
+	std::string getReconnectAddress() const { return m_access_denied_reconnect_address; }
+	std::string getReconnectPort() const { return m_access_denied_reconnect_port; }
+
 	void setFatalError(const std::string &reason)
 	{
 		m_access_denied = true;
@@ -541,6 +544,8 @@ private:
 
 	bool m_access_denied = false;
 	bool m_access_denied_reconnect = false;
+	std::string m_access_denied_reconnect_address = "";
+	std::string m_access_denied_reconnect_port = "";
 	std::string m_access_denied_reason = "";
 	std::queue<ClientEvent *> m_client_event_queue;
 	bool m_itemdef_received = false;

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -199,6 +199,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	std::string error_message;
 	bool reconnect_requested = false;
 
+	std::string reconnect_address;
+	std::string reconnect_port;
+
 	bool first_loop = true;
 
 	/*
@@ -228,10 +231,13 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				core::rect<s32>(0, 0, 10000, 10000));
 
 			bool game_has_run = launch_game(error_message, reconnect_requested,
-				start_data, cmd_args);
+				reconnect_address, reconnect_port, start_data, cmd_args);
 
 			// Reset the reconnect_requested flag
 			reconnect_requested = false;
+
+			reconnect_address = "";
+			reconnect_port = "";
 
 			// If skip_main_menu, we only want to startup once
 			if (skip_main_menu && !first_loop)
@@ -268,7 +274,9 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				start_data,
 				error_message,
 				chat_backend,
-				&reconnect_requested
+				&reconnect_requested,
+				reconnect_address,
+				reconnect_port
 			);
 		} //try
 		catch (con::PeerNotFoundException &e) {
@@ -367,7 +375,8 @@ void ClientLauncher::init_input()
 }
 
 bool ClientLauncher::launch_game(std::string &error_message,
-		bool reconnect_requested, GameStartData &start_data,
+		bool reconnect_requested, std::string reconnect_address,
+		std::string reconnect_port, GameStartData &start_data,
 		const Settings &cmd_args)
 {
 	// Prepare and check the start data to launch a game
@@ -413,6 +422,10 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		menudata.port                            = itos(start_data.socket_port);
 		menudata.script_data.errormessage        = std::move(error_message_lua);
 		menudata.script_data.reconnect_requested = reconnect_requested;
+		menudata.script_data.transfer_address    = reconnect_address;
+		menudata.script_data.transfer_port       = reconnect_port;
+		menudata.script_data.transfer_playername = start_data.name;
+		menudata.script_data.transfer_password   = start_data.password;
 
 		main_menu(&menudata);
 

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -40,6 +40,7 @@ private:
 	void init_input();
 
 	bool launch_game(std::string &error_message, bool reconnect_requested,
+		std::string reconnect_address, std::string reconnect_port,
 		GameStartData &start_data, const Settings &cmd_args);
 
 	void main_menu(MainMenuData *menudata);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1135,7 +1135,7 @@ bool Game::startup(bool *kill,
 	this->error_message       = &error_message;
 	this->reconnect_requested = reconnect;
 	this->reconnect_address   = &reconnect_address;
-	this->reconnect_port = &reconnect_port;
+	this->reconnect_port      = &reconnect_port;
 	this->input               = input;
 	this->chat_backend        = chat_backend;
 	simple_singleplayer_mode  = start_data.isSinglePlayer();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -724,6 +724,8 @@ public:
 			const GameStartData &game_params,
 			std::string &error_message,
 			bool *reconnect,
+			std::string &reconnect_address,
+			std::string &reconnect_port,
 			ChatBackend *chat_backend);
 
 	void run();
@@ -942,6 +944,8 @@ private:
 	bool *kill;
 	std::string *error_message;
 	bool *reconnect_requested;
+	std::string *reconnect_address;
+	std::string *reconnect_port;
 	scene::ISceneNode *skybox;
 	PausedNodesList paused_animated_nodes;
 
@@ -1119,6 +1123,8 @@ bool Game::startup(bool *kill,
 		const GameStartData &start_data,
 		std::string &error_message,
 		bool *reconnect,
+		std::string &reconnect_address,
+		std::string &reconnect_port,
 		ChatBackend *chat_backend)
 {
 
@@ -1127,7 +1133,9 @@ bool Game::startup(bool *kill,
 	device                    = m_rendering_engine->get_raw_device();
 	this->kill                = kill;
 	this->error_message       = &error_message;
-	reconnect_requested       = reconnect;
+	this->reconnect_requested = reconnect;
+	this->reconnect_address   = &reconnect_address;
+	this->reconnect_port = &reconnect_port;
 	this->input               = input;
 	this->chat_backend        = chat_backend;
 	simple_singleplayer_mode  = start_data.isSinglePlayer();
@@ -1645,12 +1653,8 @@ bool Game::connectToServer(const GameStartData &start_data,
 			if (*connection_aborted)
 				break;
 
-			if (client->accessDenied()) {
-				*error_message = fmtgettext("Access denied. Reason: %s", client->accessDeniedReason().c_str());
-				*reconnect_requested = client->reconnectRequested();
-				errorstream << *error_message << std::endl;
+			if (!checkConnection())
 				break;
-			}
 
 			if (input->cancelPressed()) {
 				*connection_aborted = true;
@@ -1788,6 +1792,8 @@ inline bool Game::checkConnection()
 	if (client->accessDenied()) {
 		*error_message = fmtgettext("Access denied. Reason: %s", client->accessDeniedReason().c_str());
 		*reconnect_requested = client->reconnectRequested();
+		*reconnect_address = client->getReconnectAddress();
+		*reconnect_port = client->getReconnectPort();
 		errorstream << *error_message << std::endl;
 		return false;
 	}
@@ -4525,7 +4531,9 @@ void the_game(bool *kill,
 		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
-		bool *reconnect_requested) // Used for local game
+		bool *reconnect_requested,
+		std::string &reconnect_address,
+		std::string &reconnect_port) // Used for local game
 {
 	Game game;
 
@@ -4536,8 +4544,8 @@ void the_game(bool *kill,
 
 	try {
 
-		if (game.startup(kill, input, rendering_engine, start_data,
-				error_message, reconnect_requested, &chat_backend)) {
+		if (game.startup(kill, input, rendering_engine, start_data, error_message,
+				reconnect_requested, reconnect_address, reconnect_port, &chat_backend)) {
 			game.run();
 		}
 

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -50,4 +50,6 @@ void the_game(bool *kill,
 		const GameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
-		bool *reconnect_requested);
+		bool *reconnect_requested,
+		std::string &reconnect_address,
+		std::string &reconnect_port);

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -1210,3 +1210,4 @@ void LocalPlayer::handleAutojump(f32 dtime, Environment *env,
 		m_autojump_time = 0.1f;
 	}
 }
+

--- a/src/gui/guiMainMenu.h
+++ b/src/gui/guiMainMenu.h
@@ -31,6 +31,11 @@ struct MainMenuDataForScript {
 	// Whether the server has requested a reconnect
 	bool reconnect_requested = false;
 	std::string errormessage = "";
+
+	std::string transfer_address;
+	std::string transfer_port;
+	std::string transfer_playername;
+	std::string transfer_password;
 };
 
 struct MainMenuData {

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -219,6 +219,16 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 		u8 reconnect;
 		*pkt >> reconnect;
 		m_access_denied_reconnect = reconnect & 1;
+	} else if (denyCode == SERVER_ACCESSDENIED_TRANSFER) {
+		std::string addressPack;
+		*pkt >> addressPack;
+
+		m_access_denied_reason = accessDeniedStrings[denyCode];
+		m_access_denied_reconnect = true;
+
+		size_t splitAt = addressPack.find(';');
+		m_access_denied_reconnect_address = addressPack.substr(0, splitAt);
+		m_access_denied_reconnect_port = addressPack.substr(splitAt + 1);
 	} else if (denyCode == SERVER_ACCESSDENIED_CUSTOM_STRING) {
 		*pkt >> m_access_denied_reason;
 	} else if (denyCode == SERVER_ACCESSDENIED_TOO_MANY_USERS) {

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -1133,6 +1133,7 @@ enum AccessDeniedCode : u8 {
 	SERVER_ACCESSDENIED_CUSTOM_STRING,
 	SERVER_ACCESSDENIED_SHUTDOWN,
 	SERVER_ACCESSDENIED_CRASH,
+	SERVER_ACCESSDENIED_TRANSFER,
 	SERVER_ACCESSDENIED_MAX,
 };
 
@@ -1152,8 +1153,9 @@ const static std::string accessDeniedStrings[SERVER_ACCESSDENIED_MAX] = {
 	"Another client is connected with this name.  If your client closed unexpectedly, try again in a minute.",
 	"Internal server error",
 	"",
-	"Server shutting down",
-	"The server has experienced an internal error.  You will now be disconnected."
+	"Server shutting down.",
+	"This server has experienced an internal error. You will now be disconnected.",
+	"Server is requesting a transfer."
 };
 
 enum PlayerListModifer : u8

--- a/src/script/cpp_api/s_mainmenu.cpp
+++ b/src/script/cpp_api/s_mainmenu.cpp
@@ -35,6 +35,12 @@ void ScriptApiMainMenu::setMainMenuData(MainMenuDataForScript *data)
 	}
 	lua_settable(L, gamedata_idx);
 	setboolfield(L, gamedata_idx, "reconnect_requested", data->reconnect_requested);
+
+	setstringfield(L, gamedata_idx, "transfer_address", data->transfer_address);
+	setstringfield(L, gamedata_idx, "transfer_port", data->transfer_port);
+	setstringfield(L, gamedata_idx, "transfer_playername", data->transfer_playername);
+	setstringfield(L, gamedata_idx, "transfer_password", data->transfer_password);
+
 	lua_pop(L, 1);
 }
 

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -42,6 +42,18 @@ int ModApiServer::l_request_shutdown(lua_State *L)
 	return 0;
 }
 
+int ModApiServer::l_transfer_player(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	const char *playerName = lua_tolstring(L, 1, NULL);
+	const char *address = lua_tolstring(L, 2, NULL);
+	const char *port = lua_tolstring(L, 3, NULL);
+
+	getServer(L)->getEnv().transferPlayer(playerName, address, port);
+	return 0;
+}
+
 // get_server_status()
 int ModApiServer::l_get_server_status(lua_State *L)
 {
@@ -669,6 +681,7 @@ int ModApiServer::l_serialize_roundtrip(lua_State *L)
 void ModApiServer::Initialize(lua_State *L, int top)
 {
 	API_FCT(request_shutdown);
+	API_FCT(transfer_player);
 	API_FCT(get_server_status);
 	API_FCT(get_server_uptime);
 	API_FCT(get_server_max_lag);

--- a/src/script/lua_api/l_server.h
+++ b/src/script/lua_api/l_server.h
@@ -27,6 +27,8 @@ private:
 	// request_shutdown([message], [reconnect])
 	static int l_request_shutdown(lua_State *L);
 
+	static int l_transfer_player(lua_State *L);
+
 	// get_server_status()
 	static int l_get_server_status(lua_State *L);
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1435,7 +1435,8 @@ void Server::SendAccessDenied(session_t peer_id, AccessDeniedCode reason,
 
 	NetworkPacket pkt(TOCLIENT_ACCESS_DENIED, 1, peer_id);
 	pkt << (u8)reason;
-	if (reason == SERVER_ACCESSDENIED_CUSTOM_STRING)
+	if (reason == SERVER_ACCESSDENIED_CUSTOM_STRING ||
+			reason == SERVER_ACCESSDENIED_TRANSFER)
 		pkt << custom_reason;
 	else if (reason == SERVER_ACCESSDENIED_SHUTDOWN ||
 			reason == SERVER_ACCESSDENIED_CRASH)

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -603,6 +603,17 @@ void ServerEnvironment::kickAllPlayers(AccessDeniedCode reason,
 		m_server->DenyAccess(player->getPeerId(), reason, str_reason, reconnect);
 }
 
+void ServerEnvironment::transferPlayer(const std::string &name, const std::string &address, const std::string &port)
+{
+	auto addressPack = address + ";" + port;
+
+	for (RemotePlayer *player : m_players) {
+		if (name.compare(player->getName()) == 0) {
+			m_server->DenyAccess(player->getPeerId(), SERVER_ACCESSDENIED_TRANSFER, "Transfer denied.");
+		}
+	}
+}
+
 void ServerEnvironment::saveLoadedPlayers(bool force)
 {
 	for (RemotePlayer *player : m_players) {

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -609,7 +609,7 @@ void ServerEnvironment::transferPlayer(const std::string &name, const std::strin
 
 	for (RemotePlayer *player : m_players) {
 		if (name.compare(player->getName()) == 0) {
-			m_server->DenyAccess(player->getPeerId(), SERVER_ACCESSDENIED_TRANSFER, "Transfer denied.");
+			m_server->DenyAccess(player->getPeerId(), SERVER_ACCESSDENIED_TRANSFER, addressPack, false);
 		}
 	}
 }

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -240,6 +240,7 @@ public:
 
 	void kickAllPlayers(AccessDeniedCode reason,
 		const std::string &str_reason, bool reconnect);
+	void transferPlayer(const std::string &name, const std::string &address, const std::string &port);
 	// Save players
 	void saveLoadedPlayers(bool force = false);
 	void savePlayer(RemotePlayer *player);


### PR DESCRIPTION
This is the adoption of #11175.

I have rebased the original @grapereader code. Is compilable, and looks to works well on my Linux system.

This is related to #5813 and #4428 at least.

## To do

This PR is a Work in Progress.

- [x] Add test command or API to devtest game.
- [ ] See feedback and apply potentially required changes

## How to test

1) Create or reuse existing world in devtest game
2) Host server of it
3) Run the second Minetest instance, join the hosted server
4) run command /transfer_player 127.0.0.1 YOUR_PORT_NUMBER
5) you should be disconnected and reconnected

You can also host the game in the second Minetest instance with the same player_name and password as on the first server and reconnect by the same function from it.
