### PR TITLE
Change the way how password is stored in C++ engine.

### DIFF
--- a/games/devtest/mods/util_commands/init.lua
+++ b/games/devtest/mods/util_commands/init.lua
@@ -301,3 +301,11 @@ core.register_chatcommand("set_saturation", {
 		core.get_player_by_name(player_name):set_lighting({saturation = saturation })
 	end
 })
+
+core.register_chatcommand("shutdown_with_reconnect", {
+	params = "",
+	description = "Shutdown server with reconnect request.",
+	func = function(player_name, param)
+		minetest.request_shutdown("Shutdown with reconnect.", true, 5)
+	end
+})

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -40,6 +40,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/activeobjectmgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/camera.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/client.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/clientauth.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/clientenvironment.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/clientlauncher.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/clientmap.cpp

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -123,8 +123,9 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 */
 
 Client::Client(
-		const char *playername,
-		const std::string &password,
+		const std::string &playername,
+		//const std::string &password,
+		ClientAuth *auth,
 		MapDrawControl &control,
 		IWritableTextureSource *tsrc,
 		IWritableShaderSource *shsrc,
@@ -153,14 +154,14 @@ Client::Client(
 	m_allow_login_or_register(allow_login_or_register),
 	m_server_ser_ver(SER_FMT_VER_INVALID),
 	m_last_chat_message_sent(time(NULL)),
-	m_password(password),
+	m_auth(auth),
 	m_chosen_auth_mech(AUTH_MECHANISM_NONE),
 	m_media_downloader(std::make_unique<ClientMediaDownloader>()),
 	m_state(LC_Created),
 	m_modchannel_mgr(new ModChannelMgr())
 {
 	// Add local player
-	m_env.setLocalPlayer(new LocalPlayer(this, playername));
+	m_env.setLocalPlayer(new LocalPlayer(this, playername.c_str()));
 
 	// Make the mod storage database and begin the save for later
 	m_mod_storage_database =
@@ -1187,20 +1188,7 @@ void Client::interact(InteractAction action, const PointedThing& pointed)
 
 void Client::deleteAuthData()
 {
-	if (!m_auth_data)
-		return;
-
-	switch (m_chosen_auth_mech) {
-		case AUTH_MECHANISM_FIRST_SRP:
-			break;
-		case AUTH_MECHANISM_SRP:
-		case AUTH_MECHANISM_LEGACY_PASSWORD:
-			srp_user_delete((SRPUser *) m_auth_data);
-			m_auth_data = NULL;
-			break;
-		case AUTH_MECHANISM_NONE:
-			break;
-	}
+	m_auth->clearSessionData();
 	m_chosen_auth_mech = AUTH_MECHANISM_NONE;
 }
 
@@ -1239,36 +1227,34 @@ void Client::startAuth(AuthMechanism chosen_auth_mechanism)
 	switch (chosen_auth_mechanism) {
 		case AUTH_MECHANISM_FIRST_SRP: {
 			// send srp verifier to server
-			std::string verifier;
-			std::string salt;
-			generate_srp_verifier_and_salt(playername, m_password,
-				&verifier, &salt);
+			const std::string &verifier = m_auth->getSrpVerifier();
+			const std::string &salt = m_auth->getSrpSalt();
 
 			NetworkPacket resp_pkt(TOSERVER_FIRST_SRP, 0);
-			resp_pkt << salt << verifier << (u8)((m_password.empty()) ? 1 : 0);
+			resp_pkt << salt << verifier << (u8)((m_auth->getIsEmpty()) ? 1 : 0);
 
 			Send(&resp_pkt);
 			break;
 		}
 		case AUTH_MECHANISM_SRP:
 		case AUTH_MECHANISM_LEGACY_PASSWORD: {
-			u8 based_on = 1;
+			u8 based_on;
+			SRPUser *auth_data;
 
 			if (chosen_auth_mechanism == AUTH_MECHANISM_LEGACY_PASSWORD) {
-				m_password = translate_password(playername, m_password);
 				based_on = 0;
+				auth_data = m_auth->getLegacyAuthData();
+			}
+			else {
+				based_on = 1;
+				auth_data = m_auth->getSrpAuthData();
 			}
 
-			std::string playername_u = lowercase(playername);
-			m_auth_data = srp_user_new(SRP_SHA256, SRP_NG_2048,
-				playername.c_str(), playername_u.c_str(),
-				(const unsigned char *) m_password.c_str(),
-				m_password.length(), NULL, NULL);
 			char *bytes_A = 0;
 			size_t len_A = 0;
 			SRP_Result res = srp_user_start_authentication(
-				(struct SRPUser *) m_auth_data, NULL, NULL, 0,
-				(unsigned char **) &bytes_A, &len_A);
+				auth_data, NULL, NULL, 0,
+				reinterpret_cast<unsigned char **>(&bytes_A), &len_A);
 			FATAL_ERROR_IF(res != SRP_OK, "Creating local SRP user failed.");
 
 			NetworkPacket resp_pkt(TOSERVER_SRP_BYTES_A, 0);
@@ -1420,16 +1406,25 @@ void Client::clearOutChatQueue()
 	m_out_chat_queue = std::queue<std::wstring>();
 }
 
-void Client::sendChangePassword(const std::string &oldpassword,
-	const std::string &newpassword)
+void Client::sendChangePassword(std::string &oldpassword,
+	std::string &newpassword)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
-	if (player == NULL)
+	if (player == NULL) {
+		porting::secure_clear_string(oldpassword);
+		porting::secure_clear_string(newpassword);
 		return;
+	}
 
 	// get into sudo mode and then send new password to server
-	m_password = oldpassword;
-	m_new_password = newpassword;
+	std::string playername = m_env.getLocalPlayer()->getName();
+	m_auth->applyPassword(playername, oldpassword);
+	m_new_auth.applyPassword(playername, newpassword);
+
+	// we do not need to keep passwords in memory
+	porting::secure_clear_string(oldpassword);
+	porting::secure_clear_string(newpassword);
+
 	startAuth(choseAuthMech(m_sudo_auth_methods));
 }
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -125,7 +125,7 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 Client::Client(
 		const std::string &playername,
 		//const std::string &password,
-		ClientAuth &auth,
+		ClientAuth auth,
 		MapDrawControl &control,
 		IWritableTextureSource *tsrc,
 		IWritableShaderSource *shsrc,
@@ -154,7 +154,7 @@ Client::Client(
 	m_allow_login_or_register(allow_login_or_register),
 	m_server_ser_ver(SER_FMT_VER_INVALID),
 	m_last_chat_message_sent(time(NULL)),
-	m_auth(auth),
+	m_auth(std::move(auth)),
 	m_chosen_auth_mech(AUTH_MECHANISM_NONE),
 	m_media_downloader(std::make_unique<ClientMediaDownloader>()),
 	m_state(LC_Created),

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -124,7 +124,6 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 
 Client::Client(
 		const std::string &playername,
-		//const std::string &password,
 		ClientAuth auth,
 		MapDrawControl &control,
 		IWritableTextureSource *tsrc,
@@ -1244,8 +1243,7 @@ void Client::startAuth(AuthMechanism chosen_auth_mechanism)
 			if (chosen_auth_mechanism == AUTH_MECHANISM_LEGACY_PASSWORD) {
 				based_on = 0;
 				auth_data = m_auth.getLegacyAuthData();
-			}
-			else {
+			} else {
 				based_on = 1;
 				auth_data = m_auth.getSrpAuthData();
 			}
@@ -1410,7 +1408,7 @@ void Client::sendChangePassword(SecureString &oldpassword,
 	SecureString &newpassword)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
-	if (player) {
+	if (!player) {
 		oldpassword.safeClear();
 		newpassword.safeClear();
 		return;

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -125,7 +125,7 @@ static void enrich_exception(BaseException &e, const NetworkPacket &pkt, bool in
 Client::Client(
 		const std::string &playername,
 		//const std::string &password,
-		ClientAuth *auth,
+		ClientAuth &auth,
 		MapDrawControl &control,
 		IWritableTextureSource *tsrc,
 		IWritableShaderSource *shsrc,
@@ -1188,7 +1188,7 @@ void Client::interact(InteractAction action, const PointedThing& pointed)
 
 void Client::deleteAuthData()
 {
-	m_auth->clearSessionData();
+	m_auth.clearSessionData();
 	m_chosen_auth_mech = AUTH_MECHANISM_NONE;
 }
 
@@ -1227,11 +1227,11 @@ void Client::startAuth(AuthMechanism chosen_auth_mechanism)
 	switch (chosen_auth_mechanism) {
 		case AUTH_MECHANISM_FIRST_SRP: {
 			// send srp verifier to server
-			const std::string &verifier = m_auth->getSrpVerifier();
-			const std::string &salt = m_auth->getSrpSalt();
+			const std::string &verifier = m_auth.getSrpVerifier();
+			const std::string &salt = m_auth.getSrpSalt();
 
 			NetworkPacket resp_pkt(TOSERVER_FIRST_SRP, 0);
-			resp_pkt << salt << verifier << (u8)((m_auth->getIsEmpty()) ? 1 : 0);
+			resp_pkt << salt << verifier << (u8)((m_auth.getIsEmpty()) ? 1 : 0);
 
 			Send(&resp_pkt);
 			break;
@@ -1243,17 +1243,17 @@ void Client::startAuth(AuthMechanism chosen_auth_mechanism)
 
 			if (chosen_auth_mechanism == AUTH_MECHANISM_LEGACY_PASSWORD) {
 				based_on = 0;
-				auth_data = m_auth->getLegacyAuthData();
+				auth_data = m_auth.getLegacyAuthData();
 			}
 			else {
 				based_on = 1;
-				auth_data = m_auth->getSrpAuthData();
+				auth_data = m_auth.getSrpAuthData();
 			}
 
 			char *bytes_A = 0;
 			size_t len_A = 0;
 			SRP_Result res = srp_user_start_authentication(
-				auth_data, NULL, NULL, 0,
+				auth_data, nullptr, nullptr, 0,
 				reinterpret_cast<unsigned char **>(&bytes_A), &len_A);
 			FATAL_ERROR_IF(res != SRP_OK, "Creating local SRP user failed.");
 
@@ -1406,24 +1406,24 @@ void Client::clearOutChatQueue()
 	m_out_chat_queue = std::queue<std::wstring>();
 }
 
-void Client::sendChangePassword(std::string &oldpassword,
-	std::string &newpassword)
+void Client::sendChangePassword(SecureString &oldpassword,
+	SecureString &newpassword)
 {
 	LocalPlayer *player = m_env.getLocalPlayer();
-	if (player == NULL) {
-		porting::secure_clear_string(oldpassword);
-		porting::secure_clear_string(newpassword);
+	if (player) {
+		oldpassword.safeClear();
+		newpassword.safeClear();
 		return;
 	}
 
 	// get into sudo mode and then send new password to server
 	std::string playername = m_env.getLocalPlayer()->getName();
-	m_auth->applyPassword(playername, oldpassword);
+	m_auth.applyPassword(playername, oldpassword);
 	m_new_auth.applyPassword(playername, newpassword);
 
 	// we do not need to keep passwords in memory
-	porting::secure_clear_string(oldpassword);
-	porting::secure_clear_string(newpassword);
+	oldpassword.safeClear();
+	newpassword.safeClear();
 
 	startAuth(choseAuthMech(m_sudo_auth_methods));
 }

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -12,9 +12,6 @@
 #include "network/address.h"
 #include "network/networkprotocol.h" // multiple enums
 #include "network/peerhandler.h"
-//#include "gameparams.h"
-//#include "script/common/c_types.h" // LuaError
-//#include "clientdynamicinfo.h"
 #include "clientauth.h"
 #include "util/numeric.h"
 #include "util/string.h" // StringMap

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -12,6 +12,10 @@
 #include "network/address.h"
 #include "network/networkprotocol.h" // multiple enums
 #include "network/peerhandler.h"
+//#include "gameparams.h"
+//#include "script/common/c_types.h" // LuaError
+//#include "clientdynamicinfo.h"
+#include "clientauth.h"
 #include "util/numeric.h"
 #include "util/string.h" // StringMap
 
@@ -111,8 +115,9 @@ public:
 	*/
 
 	Client(
-			const char *playername,
-			const std::string &password,
+			const std::string &playername,
+			//const std::string &password,
+			ClientAuth *auth,
 			MapDrawControl &control,
 			IWritableTextureSource *tsrc,
 			IWritableShaderSource *shsrc,
@@ -228,8 +233,8 @@ public:
 	void sendInventoryAction(InventoryAction *a);
 	void sendChatMessage(const std::wstring &message);
 	void clearOutChatQueue();
-	void sendChangePassword(const std::string &oldpassword,
-		const std::string &newpassword);
+	void sendChangePassword(std::string &oldpassword,
+		std::string &newpassword);
 	void sendDamage(u16 damage);
 	void sendRespawnLegacy();
 	void sendReady();
@@ -520,12 +525,11 @@ private:
 
 	// Auth data
 	std::string m_playername;
-	std::string m_password;
+	ClientAuth *m_auth;
 	// If set, this will be sent (and cleared) upon a TOCLIENT_ACCEPT_SUDO_MODE
-	std::string m_new_password;
+	ClientAuth m_new_auth;
 	// Usable by auth mechanisms.
 	AuthMechanism m_chosen_auth_mech;
-	void *m_auth_data = nullptr;
 
 	bool m_access_denied = false;
 	bool m_access_denied_reconnect = false;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -15,6 +15,7 @@
 #include "clientauth.h"
 #include "util/numeric.h"
 #include "util/string.h" // StringMap
+#include "util/secure_string.h"
 
 #include <map>
 #include <memory>
@@ -113,8 +114,8 @@ public:
 
 	Client(
 			const std::string &playername,
-			//const std::string &password,
-			ClientAuth *auth,
+			// auth data created from password
+			ClientAuth &auth,
 			MapDrawControl &control,
 			IWritableTextureSource *tsrc,
 			IWritableShaderSource *shsrc,
@@ -230,8 +231,8 @@ public:
 	void sendInventoryAction(InventoryAction *a);
 	void sendChatMessage(const std::wstring &message);
 	void clearOutChatQueue();
-	void sendChangePassword(std::string &oldpassword,
-		std::string &newpassword);
+	void sendChangePassword(SecureString &oldpassword,
+		SecureString &newpassword);
 	void sendDamage(u16 damage);
 	void sendRespawnLegacy();
 	void sendReady();
@@ -522,7 +523,7 @@ private:
 
 	// Auth data
 	std::string m_playername;
-	ClientAuth *m_auth;
+	ClientAuth m_auth;
 	// If set, this will be sent (and cleared) upon a TOCLIENT_ACCEPT_SUDO_MODE
 	ClientAuth m_new_auth;
 	// Usable by auth mechanisms.

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -115,7 +115,7 @@ public:
 	Client(
 			const std::string &playername,
 			// auth data created from password
-			ClientAuth &auth,
+			ClientAuth auth,
 			MapDrawControl &control,
 			IWritableTextureSource *tsrc,
 			IWritableShaderSource *shsrc,

--- a/src/client/clientauth.cpp
+++ b/src/client/clientauth.cpp
@@ -1,0 +1,113 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024-2025 SFENCE, <sfence.software@gmail.com>
+
+#include "clientauth.h"
+#include "exceptions.h"
+#include "util/auth.h"
+#include "util/srp.h"
+#include "util/string.h"
+
+ClientAuth::ClientAuth() :
+		m_is_empty(true)
+{
+}
+
+ClientAuth::ClientAuth(const std::string &player_name, const std::string &password)
+{
+	applyPassword(player_name, password);
+}
+
+ClientAuth::~ClientAuth()
+{
+	clear();
+}
+
+ClientAuth &ClientAuth::operator=(ClientAuth &&other)
+{
+	clear();
+
+	m_is_empty = other.m_is_empty;
+
+	m_srp_verifier = other.m_srp_verifier;
+	m_srp_salt = other.m_srp_salt;
+
+	m_legacy_auth_data = other.m_legacy_auth_data;
+	m_srp_auth_data = other.m_srp_auth_data;
+
+	other.m_legacy_auth_data = nullptr;
+	other.m_srp_auth_data = nullptr;
+
+	other.clear();
+
+	return *this;
+}
+
+void ClientAuth::applyPassword(const std::string &player_name, const std::string &password)
+{
+	clear();
+	// AUTH_MECHANISM_FIRST_SRP
+	generate_srp_verifier_and_salt(player_name, password, &m_srp_verifier, &m_srp_salt);
+	m_is_empty = password.empty();
+
+	std::string player_name_u = lowercase(player_name);
+	// AUTH_MECHANISM_SRP
+	m_srp_auth_data = srp_user_new(SRP_SHA256, SRP_NG_2048,
+			player_name.c_str(), player_name_u.c_str(),
+			reinterpret_cast<const unsigned char *>(password.c_str()),
+			password.length(), NULL, NULL);
+	// AUTH_MECHANISM_LEGACY_PASSWORD
+	std::string translated = translate_password(player_name, password);
+	m_legacy_auth_data = srp_user_new(SRP_SHA256, SRP_NG_2048,
+			player_name.c_str(), player_name_u.c_str(),
+			reinterpret_cast<const unsigned char *>(translated.c_str()),
+			translated.length(), NULL, NULL);
+}
+
+SRPUser * ClientAuth::getAuthData(AuthMechanism chosen_auth_mech) const
+{
+	SRPUser *chosen = nullptr;
+	switch (chosen_auth_mech) {
+		case AUTH_MECHANISM_LEGACY_PASSWORD:
+			chosen = m_legacy_auth_data;
+			break;
+		case AUTH_MECHANISM_SRP:
+			chosen = m_srp_auth_data;
+			break;
+		case AUTH_MECHANISM_FIRST_SRP:
+			return nullptr;
+		default:
+			throw AuthError("Not valid auth data request.");
+	}
+	if (!chosen)
+		throw AuthError("Not valid autch data found.");
+	return chosen;
+}
+
+void ClientAuth::clear()
+{
+	if (m_legacy_auth_data != nullptr) {
+		srp_user_delete(m_legacy_auth_data);
+		m_legacy_auth_data = nullptr;
+	}
+	if (m_srp_auth_data != nullptr) {
+		srp_user_delete(m_srp_auth_data);
+		m_srp_auth_data = nullptr;
+	}
+	m_srp_verifier.clear();
+	m_srp_salt.clear();
+}
+
+void ClientAuth::clearSessionData()
+{
+	if (m_legacy_auth_data != nullptr) {
+		srp_user_clear_sessiondata(m_legacy_auth_data);
+	}
+	if (m_srp_auth_data != nullptr) {
+		srp_user_clear_sessiondata(m_srp_auth_data);
+	}
+	// This is need only for first login to server.
+	// So, there is no need to keep this for reconnect purposes.
+	m_srp_verifier.clear();
+	m_srp_salt.clear();
+}

--- a/src/client/clientauth.cpp
+++ b/src/client/clientauth.cpp
@@ -13,7 +13,7 @@ ClientAuth::ClientAuth() :
 {
 }
 
-ClientAuth::ClientAuth(const std::string &player_name, const std::string &password)
+ClientAuth::ClientAuth(const std::string &player_name, const SecureString &password)
 {
 	applyPassword(player_name, password);
 }
@@ -23,27 +23,7 @@ ClientAuth::~ClientAuth()
 	clear();
 }
 
-ClientAuth &ClientAuth::operator=(ClientAuth &&other)
-{
-	clear();
-
-	m_is_empty = other.m_is_empty;
-
-	m_srp_verifier = other.m_srp_verifier;
-	m_srp_salt = other.m_srp_salt;
-
-	m_legacy_auth_data = other.m_legacy_auth_data;
-	m_srp_auth_data = other.m_srp_auth_data;
-
-	other.m_legacy_auth_data = nullptr;
-	other.m_srp_auth_data = nullptr;
-
-	other.clear();
-
-	return *this;
-}
-
-void ClientAuth::applyPassword(const std::string &player_name, const std::string &password)
+void ClientAuth::applyPassword(const std::string &player_name, const SecureString &password)
 {
 	clear();
 	// AUTH_MECHANISM_FIRST_SRP
@@ -55,13 +35,13 @@ void ClientAuth::applyPassword(const std::string &player_name, const std::string
 	m_srp_auth_data = srp_user_new(SRP_SHA256, SRP_NG_2048,
 			player_name.c_str(), player_name_u.c_str(),
 			reinterpret_cast<const unsigned char *>(password.c_str()),
-			password.length(), NULL, NULL);
+			password.length(), nullptr, nullptr);
 	// AUTH_MECHANISM_LEGACY_PASSWORD
 	std::string translated = translate_password(player_name, password);
 	m_legacy_auth_data = srp_user_new(SRP_SHA256, SRP_NG_2048,
 			player_name.c_str(), player_name_u.c_str(),
 			reinterpret_cast<const unsigned char *>(translated.c_str()),
-			translated.length(), NULL, NULL);
+			translated.length(), nullptr, nullptr);
 }
 
 SRPUser * ClientAuth::getAuthData(AuthMechanism chosen_auth_mech) const
@@ -77,20 +57,20 @@ SRPUser * ClientAuth::getAuthData(AuthMechanism chosen_auth_mech) const
 		case AUTH_MECHANISM_FIRST_SRP:
 			return nullptr;
 		default:
-			throw AuthError("Not valid auth data request.");
+			throw AuthError("Unknown auth mechanism.");
 	}
 	if (!chosen)
-		throw AuthError("Not valid autch data found.");
+		throw AuthError("No valid auth data found.");
 	return chosen;
 }
 
 void ClientAuth::clear()
 {
-	if (m_legacy_auth_data != nullptr) {
+	if (m_legacy_auth_data) {
 		srp_user_delete(m_legacy_auth_data);
 		m_legacy_auth_data = nullptr;
 	}
-	if (m_srp_auth_data != nullptr) {
+	if (m_srp_auth_data) {
 		srp_user_delete(m_srp_auth_data);
 		m_srp_auth_data = nullptr;
 	}
@@ -100,10 +80,10 @@ void ClientAuth::clear()
 
 void ClientAuth::clearSessionData()
 {
-	if (m_legacy_auth_data != nullptr) {
+	if (m_legacy_auth_data) {
 		srp_user_clear_sessiondata(m_legacy_auth_data);
 	}
-	if (m_srp_auth_data != nullptr) {
+	if (m_srp_auth_data) {
 		srp_user_clear_sessiondata(m_srp_auth_data);
 	}
 	// This is need only for first login to server.

--- a/src/client/clientauth.cpp
+++ b/src/client/clientauth.cpp
@@ -8,6 +8,11 @@
 #include "util/srp.h"
 #include "util/string.h"
 
+void SRPUserDeleter::operator()(SRPUser *usr) const
+{
+	srp_user_delete(usr);
+}
+
 ClientAuth::ClientAuth() :
 		m_is_empty(true)
 {
@@ -32,16 +37,16 @@ void ClientAuth::applyPassword(const std::string &player_name, const SecureStrin
 
 	std::string player_name_u = lowercase(player_name);
 	// AUTH_MECHANISM_SRP
-	m_srp_auth_data = srp_user_new(SRP_SHA256, SRP_NG_2048,
+	m_srp_auth_data.reset(srp_user_new(SRP_SHA256, SRP_NG_2048,
 			player_name.c_str(), player_name_u.c_str(),
 			reinterpret_cast<const unsigned char *>(password.c_str()),
-			password.length(), nullptr, nullptr);
+			password.length(), nullptr, nullptr));
 	// AUTH_MECHANISM_LEGACY_PASSWORD
 	std::string translated = translate_password(player_name, password);
-	m_legacy_auth_data = srp_user_new(SRP_SHA256, SRP_NG_2048,
+	m_legacy_auth_data.reset(srp_user_new(SRP_SHA256, SRP_NG_2048,
 			player_name.c_str(), player_name_u.c_str(),
 			reinterpret_cast<const unsigned char *>(translated.c_str()),
-			translated.length(), nullptr, nullptr);
+			translated.length(), nullptr, nullptr));
 }
 
 SRPUser * ClientAuth::getAuthData(AuthMechanism chosen_auth_mech) const
@@ -49,10 +54,10 @@ SRPUser * ClientAuth::getAuthData(AuthMechanism chosen_auth_mech) const
 	SRPUser *chosen = nullptr;
 	switch (chosen_auth_mech) {
 		case AUTH_MECHANISM_LEGACY_PASSWORD:
-			chosen = m_legacy_auth_data;
+			chosen = m_legacy_auth_data.get();
 			break;
 		case AUTH_MECHANISM_SRP:
-			chosen = m_srp_auth_data;
+			chosen = m_srp_auth_data.get();
 			break;
 		case AUTH_MECHANISM_FIRST_SRP:
 			return nullptr;
@@ -66,14 +71,8 @@ SRPUser * ClientAuth::getAuthData(AuthMechanism chosen_auth_mech) const
 
 void ClientAuth::clear()
 {
-	if (m_legacy_auth_data) {
-		srp_user_delete(m_legacy_auth_data);
-		m_legacy_auth_data = nullptr;
-	}
-	if (m_srp_auth_data) {
-		srp_user_delete(m_srp_auth_data);
-		m_srp_auth_data = nullptr;
-	}
+	m_legacy_auth_data.reset();
+	m_srp_auth_data.reset();
 	m_srp_verifier.clear();
 	m_srp_salt.clear();
 }
@@ -81,10 +80,10 @@ void ClientAuth::clear()
 void ClientAuth::clearSessionData()
 {
 	if (m_legacy_auth_data) {
-		srp_user_clear_sessiondata(m_legacy_auth_data);
+		srp_user_clear_sessiondata(m_legacy_auth_data.get());
 	}
 	if (m_srp_auth_data) {
-		srp_user_clear_sessiondata(m_srp_auth_data);
+		srp_user_clear_sessiondata(m_srp_auth_data.get());
 	}
 	// This is need only for first login to server.
 	// So, there is no need to keep this for reconnect purposes.

--- a/src/client/clientauth.h
+++ b/src/client/clientauth.h
@@ -1,0 +1,44 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024-2025 SFENCE, <sfence.software@gmail.com>
+
+#pragma once
+
+#include <string>
+#include "network/networkprotocol.h"
+#include "util/basic_macros.h"
+
+struct SRPUser;
+
+class ClientAuth
+{
+public:
+	ClientAuth();
+	ClientAuth(const std::string &player_name, const std::string &password);
+
+	~ClientAuth();
+	DISABLE_CLASS_COPY(ClientAuth);
+
+	ClientAuth(ClientAuth &&other) { *this = std::move(other); }
+	ClientAuth &operator=(ClientAuth &&other);
+
+	void applyPassword(const std::string &player_name, const std::string &password);
+
+	bool getIsEmpty() const { return m_is_empty; }
+	const std::string &getSrpVerifier() const { return m_srp_verifier; }
+	const std::string &getSrpSalt() const { return m_srp_salt; }
+	SRPUser * getLegacyAuthData() const { return m_legacy_auth_data; }
+	SRPUser * getSrpAuthData() const { return m_srp_auth_data; }
+	SRPUser * getAuthData(AuthMechanism chosen_auth_mech) const;
+
+	void clear();
+	void clearSessionData();
+private:
+	bool m_is_empty;
+
+	std::string m_srp_verifier;
+	std::string m_srp_salt;
+
+	SRPUser *m_legacy_auth_data = nullptr;
+	SRPUser *m_srp_auth_data = nullptr;
+};

--- a/src/client/clientauth.h
+++ b/src/client/clientauth.h
@@ -7,6 +7,7 @@
 #include <string>
 #include "network/networkprotocol.h"
 #include "util/basic_macros.h"
+#include "util/secure_string.h"
 
 struct SRPUser;
 
@@ -14,15 +15,11 @@ class ClientAuth
 {
 public:
 	ClientAuth();
-	ClientAuth(const std::string &player_name, const std::string &password);
+	ClientAuth(const std::string &player_name, const SecureString &password);
 
 	~ClientAuth();
-	DISABLE_CLASS_COPY(ClientAuth);
 
-	ClientAuth(ClientAuth &&other) { *this = std::move(other); }
-	ClientAuth &operator=(ClientAuth &&other);
-
-	void applyPassword(const std::string &player_name, const std::string &password);
+	void applyPassword(const std::string &player_name, const SecureString &password);
 
 	bool getIsEmpty() const { return m_is_empty; }
 	const std::string &getSrpVerifier() const { return m_srp_verifier; }

--- a/src/client/clientauth.h
+++ b/src/client/clientauth.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include "network/networkprotocol.h"
 #include "util/basic_macros.h"
@@ -11,11 +12,20 @@
 
 struct SRPUser;
 
+struct SRPUserDeleter {
+	void operator()(SRPUser *usr) const;
+};
+
+using SRPUserPtr = std::unique_ptr<SRPUser, SRPUserDeleter>;
+
 class ClientAuth
 {
 public:
 	ClientAuth();
 	ClientAuth(const std::string &player_name, const SecureString &password);
+
+	ClientAuth(ClientAuth &&) = default;
+	ClientAuth &operator=(ClientAuth &&) = default;
 
 	~ClientAuth();
 
@@ -24,8 +34,8 @@ public:
 	bool getIsEmpty() const { return m_is_empty; }
 	const std::string &getSrpVerifier() const { return m_srp_verifier; }
 	const std::string &getSrpSalt() const { return m_srp_salt; }
-	SRPUser * getLegacyAuthData() const { return m_legacy_auth_data; }
-	SRPUser * getSrpAuthData() const { return m_srp_auth_data; }
+	SRPUser * getLegacyAuthData() const { return m_legacy_auth_data.get(); }
+	SRPUser * getSrpAuthData() const { return m_srp_auth_data.get(); }
 	SRPUser * getAuthData(AuthMechanism chosen_auth_mech) const;
 
 	void clear();
@@ -36,6 +46,6 @@ private:
 	std::string m_srp_verifier;
 	std::string m_srp_salt;
 
-	SRPUser *m_legacy_auth_data = nullptr;
-	SRPUser *m_srp_auth_data = nullptr;
+	SRPUserPtr m_legacy_auth_data;
+	SRPUserPtr m_srp_auth_data;
 };

--- a/src/client/clientgamestartdata.h
+++ b/src/client/clientgamestartdata.h
@@ -1,0 +1,34 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2024-2025 SFENCE, <sfence.software@gmail.com>
+
+#pragma once
+
+#include "gameparams.h"
+#include "clientauth.h"
+
+// Information processed by main menu
+struct ClientGameStartData : GameParams
+{
+	ClientGameStartData(const GameStartData &start_data):
+		GameParams(start_data),
+		name(start_data.name),
+		address(start_data.address),
+		local_server(start_data.local_server),
+		allow_login_or_register(start_data.allow_login_or_register),
+		world_spec(start_data.world_spec)
+	{
+	}
+
+	bool isSinglePlayer() const { return address.empty() && !local_server; }
+
+	std::string name;
+	ClientAuth auth;
+	std::string address;
+	bool local_server;
+
+	ELoginRegister allow_login_or_register = ELoginRegister::Any;
+
+	// "world_path" must be kept in sync!
+	WorldSpec world_spec;
+};

--- a/src/client/clientgamestartdata.h
+++ b/src/client/clientgamestartdata.h
@@ -10,25 +10,13 @@
 // Information processed by main menu
 struct ClientGameStartData : GameParams
 {
-	ClientGameStartData(const GameStartData &start_data):
-		GameParams(start_data),
-		name(start_data.name),
-		address(start_data.address),
-		local_server(start_data.local_server),
-		allow_login_or_register(start_data.allow_login_or_register),
-		world_spec(start_data.world_spec)
+	ClientGameStartData(const GameStartData &set_start_data):
+		start_data(set_start_data)
 	{
 	}
 
-	bool isSinglePlayer() const { return address.empty() && !local_server; }
+	bool isSinglePlayer() const { return start_data.address.empty() && !start_data.local_server; }
 
-	std::string name;
+	GameStartData start_data;
 	ClientAuth auth;
-	std::string address;
-	bool local_server;
-
-	ELoginRegister allow_login_or_register = ELoginRegister::Any;
-
-	// "world_path" must be kept in sync!
-	WorldSpec world_spec;
 };

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -95,7 +95,8 @@ ClientLauncher::~ClientLauncher()
 
 bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 {
-	init_args(start_data, cmd_args);
+	ClientGameStartData client_start_data(start_data);
+	init_args(client_start_data, cmd_args);
 
 	try {
 		init_engine();
@@ -203,7 +204,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				core::rect<s32>(0, 0, 10000, 10000));
 
 			bool should_run_game = launch_game(error_message, reconnect_requested,
-				start_data, cmd_args);
+				client_start_data, cmd_args);
 
 			// Reset the reconnect_requested flag
 			reconnect_requested = false;
@@ -227,7 +228,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 				kill,
 				input,
 				m_rendering_engine,
-				start_data,
+				client_start_data,
 				error_message,
 				chat_backend,
 				&reconnect_requested
@@ -273,7 +274,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	return retval;
 }
 
-void ClientLauncher::init_args(GameStartData &start_data, const Settings &cmd_args)
+void ClientLauncher::init_args(ClientGameStartData &start_data, const Settings &cmd_args)
 {
 	skip_main_menu = cmd_args.getFlag("go");
 
@@ -413,20 +414,22 @@ void ClientLauncher::config_guienv()
 }
 
 bool ClientLauncher::launch_game(std::string &error_message,
-		bool reconnect_requested, GameStartData &start_data,
+		bool reconnect_requested, ClientGameStartData &start_data,
 		const Settings &cmd_args)
 {
 	// Prepare and check the start data to launch a game
 	std::string error_message_lua = error_message;
 	error_message.clear();
 
+	std::string password;
+
 	if (cmd_args.exists("password"))
-		start_data.password = cmd_args.get("password");
+		password = cmd_args.get("password");
 
 	if (cmd_args.exists("password-file")) {
 		std::ifstream passfile(cmd_args.get("password-file"));
 		if (passfile.good()) {
-			std::getline(passfile, start_data.password);
+			std::getline(passfile, password);
 		} else {
 			error_message = gettext("Provided password file "
 					"failed to open: ")
@@ -446,7 +449,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		MainMenuData menudata;
 		menudata.address                         = start_data.address;
 		menudata.name                            = start_data.name;
-		menudata.password                        = start_data.password;
+		menudata.password                        = password;
 		menudata.port                            = itos(start_data.socket_port);
 		menudata.script_data.errormessage        = std::move(error_message_lua);
 		menudata.script_data.reconnect_requested = reconnect_requested;
@@ -479,11 +482,14 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		}
 
 		start_data.name = menudata.name;
-		start_data.password = menudata.password;
+		password = menudata.password;
 		start_data.address = std::move(menudata.address);
 		start_data.allow_login_or_register = menudata.allow_login_or_register;
 		server_name = menudata.servername;
 		server_description = menudata.serverdescription;
+
+		// make sure that password will not stay somewhere in memory
+		porting::secure_clear_string(menudata.password);
 
 		start_data.local_server = !menudata.simple_singleplayer_mode &&
 			start_data.address.empty();
@@ -495,17 +501,26 @@ bool ClientLauncher::launch_game(std::string &error_message,
 	if (!start_data.isSinglePlayer() && start_data.name.empty()) {
 		error_message = gettext("Please choose a name!");
 		errorstream << error_message << std::endl;
+		// make sure that password will not stay somewhere in memory
+		porting::secure_clear_string(password);
 		return false;
 	}
 
 	// If using simple singleplayer mode, override
 	if (start_data.isSinglePlayer()) {
 		start_data.name = "singleplayer";
-		start_data.password = "";
+		password = "";
 		start_data.socket_port = myrand_range(49152, 65535);
 	} else {
 		g_settings->set("name", start_data.name);
 	}
+
+	if (!reconnect_requested) {
+		// This should not be call on reconnect request, because password has been erased.
+		start_data.auth.applyPassword(start_data.name, password);
+	}
+	// make sure that password will not stay somewhere in memory
+	porting::secure_clear_string(password);
 
 	if (start_data.name.length() > PLAYERNAME_SIZE - 1) {
 		error_message = gettext("Player name too long.");

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -23,6 +23,7 @@
 #include "gettime.h"
 #include "util/numeric.h"
 #include "util/tracy_wrapper.h"
+#include "util/secure_string.h"
 #include <IGUISpriteBank.h>
 #include <ICameraSceneNode.h>
 #include <unordered_map>
@@ -421,7 +422,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 	std::string error_message_lua = error_message;
 	error_message.clear();
 
-	std::string password;
+	SecureString password;
 
 	if (cmd_args.exists("password"))
 		password = cmd_args.get("password");
@@ -429,7 +430,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 	if (cmd_args.exists("password-file")) {
 		std::ifstream passfile(cmd_args.get("password-file"));
 		if (passfile.good()) {
-			std::getline(passfile, password);
+			getline(passfile, password);
 		} else {
 			error_message = gettext("Provided password file "
 					"failed to open: ")
@@ -489,7 +490,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		server_description = menudata.serverdescription;
 
 		// make sure that password will not stay somewhere in memory
-		porting::secure_clear_string(menudata.password);
+		menudata.password.safeClear();
 
 		start_data.local_server = !menudata.simple_singleplayer_mode &&
 			start_data.address.empty();
@@ -502,7 +503,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		error_message = gettext("Please choose a name!");
 		errorstream << error_message << std::endl;
 		// make sure that password will not stay somewhere in memory
-		porting::secure_clear_string(password);
+		password.safeClear();
 		return false;
 	}
 
@@ -520,7 +521,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 		start_data.auth.applyPassword(start_data.name, password);
 	}
 	// make sure that password will not stay somewhere in memory
-	porting::secure_clear_string(password);
+	password.safeClear();
 
 	if (start_data.name.length() > PLAYERNAME_SIZE - 1) {
 		error_message = gettext("Player name too long.");

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -275,9 +275,11 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	return retval;
 }
 
-void ClientLauncher::init_args(ClientGameStartData &start_data, const Settings &cmd_args)
+void ClientLauncher::init_args(ClientGameStartData &client_start_data, const Settings &cmd_args)
 {
 	skip_main_menu = cmd_args.getFlag("go");
+
+	GameStartData &start_data = client_start_data.start_data;
 
 	start_data.address = g_settings->get("address");
 	if (cmd_args.exists("address")) {
@@ -415,7 +417,7 @@ void ClientLauncher::config_guienv()
 }
 
 bool ClientLauncher::launch_game(std::string &error_message,
-		bool reconnect_requested, ClientGameStartData &start_data,
+		bool reconnect_requested, ClientGameStartData &client_start_data,
 		const Settings &cmd_args)
 {
 	// Prepare and check the start data to launch a game
@@ -439,6 +441,8 @@ bool ClientLauncher::launch_game(std::string &error_message,
 			return false;
 		}
 	}
+
+	GameStartData &start_data = client_start_data.start_data;
 
 	/*
 	 * Show the GUI menu
@@ -518,7 +522,7 @@ bool ClientLauncher::launch_game(std::string &error_message,
 
 	if (!reconnect_requested) {
 		// This should not be call on reconnect request, because password has been erased.
-		start_data.auth.applyPassword(start_data.name, password);
+		client_start_data.auth.applyPassword(start_data.name, password);
 	}
 	// make sure that password will not stay somewhere in memory
 	password.safeClear();

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -11,6 +11,7 @@ class Settings;
 class MyEventReceiver;
 class InputHandler;
 struct GameStartData;
+struct ClientGameStartData;
 struct MainMenuData;
 
 class ClientLauncher
@@ -23,7 +24,7 @@ public:
 	bool run(GameStartData &start_data, const Settings &cmd_args);
 
 private:
-	void init_args(GameStartData &start_data, const Settings &cmd_args);
+	void init_args(ClientGameStartData &start_data, const Settings &cmd_args);
 	void init_engine();
 	void init_input();
 	void init_joysticks();
@@ -32,7 +33,7 @@ private:
 	void config_guienv();
 
 	bool launch_game(std::string &error_message, bool reconnect_requested,
-		GameStartData &start_data, const Settings &cmd_args);
+		ClientGameStartData &start_data, const Settings &cmd_args);
 
 	void main_menu(MainMenuData *menudata);
 

--- a/src/client/clientlauncher.h
+++ b/src/client/clientlauncher.h
@@ -24,7 +24,7 @@ public:
 	bool run(GameStartData &start_data, const Settings &cmd_args);
 
 private:
-	void init_args(ClientGameStartData &start_data, const Settings &cmd_args);
+	void init_args(ClientGameStartData &client_start_data, const Settings &cmd_args);
 	void init_engine();
 	void init_input();
 	void init_joysticks();
@@ -33,7 +33,7 @@ private:
 	void config_guienv();
 
 	bool launch_game(std::string &error_message, bool reconnect_requested,
-		ClientGameStartData &start_data, const Settings &cmd_args);
+		ClientGameStartData &client_start_data, const Settings &cmd_args);
 
 	void main_menu(MainMenuData *menudata);
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -22,6 +22,8 @@
 #include "fontengine.h"
 #include "itemdef.h"
 #include "gameparams.h"
+#include "filesys.h"
+#include "client/clientgamestartdata.h"
 #include "gettext.h"
 #include "gui/guiChatConsole.h"
 #include "texturesource.h"
@@ -422,7 +424,7 @@ Game::~Game()
 bool Game::startup(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		const GameStartData &start_data,
+		ClientGameStartData &start_data,
 		std::string &error_message,
 		bool *reconnect,
 		ChatBackend *chat_backend)
@@ -823,7 +825,7 @@ void Game::copyServerClientCache()
 		<< std::endl;
 }
 
-bool Game::createClient(const GameStartData &start_data)
+bool Game::createClient(ClientGameStartData &start_data)
 {
 	showOverlayMessage(N_("Creating client..."), 0, 10);
 
@@ -954,7 +956,7 @@ bool Game::initGui()
 	return true;
 }
 
-bool Game::connectToServer(const GameStartData &start_data,
+bool Game::connectToServer(ClientGameStartData &start_data,
 		bool *connect_ok, bool *connection_aborted)
 {
 	*connect_ok = false;	// Let's not be overly optimistic
@@ -1009,8 +1011,8 @@ bool Game::connectToServer(const GameStartData &start_data,
 
 
 	try {
-		client = new Client(start_data.name.c_str(),
-				start_data.password,
+		client = new Client(start_data.name,
+				&start_data.auth,
 				*draw_control, texture_src, shader_src,
 				itemdef_manager, nodedef_manager, sound_manager.get(), eventmgr,
 				m_rendering_engine,
@@ -3748,7 +3750,7 @@ void Game::readSettings()
 void the_game(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		const GameStartData &start_data,
+		ClientGameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
 		bool *reconnect_requested) // Used for local game

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -424,13 +424,15 @@ Game::~Game()
 bool Game::startup(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		ClientGameStartData &start_data,
+		ClientGameStartData &client_start_data,
 		std::string &error_message,
 		bool *reconnect,
 		ChatBackend *chat_backend)
 {
 
 	// "cache"
+	GameStartData &start_data = client_start_data.start_data;
+
 	m_rendering_engine        = rendering_engine;
 	device                    = m_rendering_engine->get_raw_device();
 	this->kill                = kill;
@@ -465,7 +467,7 @@ bool Game::startup(volatile std::sig_atomic_t *kill,
 			start_data.socket_port, start_data.game_spec))
 		return false;
 
-	if (!createClient(start_data))
+	if (!createClient(client_start_data))
 		return false;
 
 	m_rendering_engine->initialize(client, hud);
@@ -956,9 +958,11 @@ bool Game::initGui()
 	return true;
 }
 
-bool Game::connectToServer(ClientGameStartData &start_data,
+bool Game::connectToServer(ClientGameStartData &client_start_data,
 		bool *connect_ok, bool *connection_aborted)
 {
+	GameStartData &start_data = client_start_data.start_data;
+
 	*connect_ok = false;	// Let's not be overly optimistic
 	*connection_aborted = false;
 	const auto &address_name = start_data.address;
@@ -1012,7 +1016,7 @@ bool Game::connectToServer(ClientGameStartData &start_data,
 
 	try {
 		client = new Client(start_data.name,
-				std::move(start_data.auth),
+				std::move(client_start_data.auth),
 				*draw_control, texture_src, shader_src,
 				itemdef_manager, nodedef_manager, sound_manager.get(), eventmgr,
 				m_rendering_engine,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1012,7 +1012,7 @@ bool Game::connectToServer(ClientGameStartData &start_data,
 
 	try {
 		client = new Client(start_data.name,
-				start_data.auth,
+				std::move(start_data.auth),
 				*draw_control, texture_src, shader_src,
 				itemdef_manager, nodedef_manager, sound_manager.get(), eventmgr,
 				m_rendering_engine,

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1012,7 +1012,7 @@ bool Game::connectToServer(ClientGameStartData &start_data,
 
 	try {
 		client = new Client(start_data.name,
-				&start_data.auth,
+				start_data.auth,
 				*draw_control, texture_src, shader_src,
 				itemdef_manager, nodedef_manager, sound_manager.get(), eventmgr,
 				m_rendering_engine,

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -8,6 +8,7 @@
 #include "config.h"
 #include <csignal>
 #include <string>
+#include "client/clientgamestartdata.h"
 
 #if !IS_CLIENT_BUILD
 #error Do not include in server builds
@@ -39,7 +40,7 @@ struct CameraOrientation {
 void the_game(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		const GameStartData &start_data,
+		ClientGameStartData &start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
 		bool *reconnect_requested);

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -40,7 +40,7 @@ struct CameraOrientation {
 void the_game(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		ClientGameStartData &start_data,
+		ClientGameStartData &client_start_data,
 		std::string &error_message,
 		ChatBackend &chat_backend,
 		bool *reconnect_requested);

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -98,7 +98,7 @@ public:
 	bool startup(volatile std::sig_atomic_t *kill,
 			InputHandler *input,
 			RenderingEngine *rendering_engine,
-			const GameStartData &game_params,
+			ClientGameStartData &game_params,
 			std::string &error_message,
 			bool *reconnect,
 			ChatBackend *chat_backend);
@@ -122,11 +122,11 @@ protected:
 	void copyServerClientCache();
 
 	// Client creation
-	bool createClient(const GameStartData &start_data);
+	bool createClient(ClientGameStartData &start_data);
 	bool initGui();
 
 	// Client connection
-	bool connectToServer(const GameStartData &start_data,
+	bool connectToServer(ClientGameStartData &start_data,
 			bool *connect_ok, bool *aborted);
 	bool getServerContent(bool *aborted);
 

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -98,6 +98,11 @@ public:
 	MisbehavedSSCSMException(const std::string &s): BaseException(s) {}
 };
 
+class AuthError : public BaseException {
+public:
+	AuthError(const std::string &s): BaseException(s) {}
+};
+
 
 /*
 	Some "old-style" interrupts:

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -6,6 +6,7 @@
 
 #include "irrlichttypes.h"
 #include "content/subgames.h"
+#include "porting.h"
 
 // Information provided from "main"
 struct GameParams
@@ -33,7 +34,6 @@ struct GameStartData : GameParams
 	bool isSinglePlayer() const { return address.empty() && !local_server; }
 
 	std::string name;
-	std::string password;
 	// If empty, we're hosting a server.
 	// This may or may not be in "simple singleplayer mode".
 	std::string address;

--- a/src/gui/guiMainMenu.h
+++ b/src/gui/guiMainMenu.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "gameparams.h"
+#include "util/secure_string.h"
 #include <string>
 
 struct MainMenuDataForScript {
@@ -26,7 +27,7 @@ struct MainMenuData {
 	std::string address;
 	std::string port;
 	std::string name;
-	std::string password;
+	SecureString password;
 	// Whether to reconnect
 	bool do_reconnect = false;
 

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -175,12 +175,20 @@ void GUIPasswordChange::acceptInput()
 bool GUIPasswordChange::processInput()
 {
 	if (m_newpass != m_newpass_confirm) {
+		porting::secure_clear_string(m_oldpass);
+		porting::secure_clear_string(m_newpass);
+		porting::secure_clear_string(m_newpass_confirm);
 		gui::IGUIElement *e = getElementFromId(ID_message);
 		if (e != NULL)
 			e->setVisible(true);
 		return false;
 	}
-	m_client->sendChangePassword(wide_to_utf8(m_oldpass), wide_to_utf8(m_newpass));
+	std::string old_pass = wide_to_utf8(m_oldpass);
+	std::string new_pass = wide_to_utf8(m_newpass);
+	porting::secure_clear_string(m_oldpass);
+	porting::secure_clear_string(m_newpass);
+	porting::secure_clear_string(m_newpass_confirm);
+	m_client->sendChangePassword(old_pass, new_pass);
 	return true;
 }
 

--- a/src/gui/guiPasswordChange.cpp
+++ b/src/gui/guiPasswordChange.cpp
@@ -175,19 +175,19 @@ void GUIPasswordChange::acceptInput()
 bool GUIPasswordChange::processInput()
 {
 	if (m_newpass != m_newpass_confirm) {
-		porting::secure_clear_string(m_oldpass);
-		porting::secure_clear_string(m_newpass);
-		porting::secure_clear_string(m_newpass_confirm);
+		m_oldpass.safeClear();
+		m_newpass.safeClear();
+		m_newpass_confirm.safeClear();
 		gui::IGUIElement *e = getElementFromId(ID_message);
 		if (e != NULL)
 			e->setVisible(true);
 		return false;
 	}
-	std::string old_pass = wide_to_utf8(m_oldpass);
-	std::string new_pass = wide_to_utf8(m_newpass);
-	porting::secure_clear_string(m_oldpass);
-	porting::secure_clear_string(m_newpass);
-	porting::secure_clear_string(m_newpass_confirm);
+	SecureString old_pass = secure_wide_to_utf8(m_oldpass);
+	SecureString new_pass = secure_wide_to_utf8(m_newpass);
+	m_oldpass.safeClear();
+	m_newpass.safeClear();
+	m_newpass_confirm.safeClear();
 	m_client->sendChangePassword(old_pass, new_pass);
 	return true;
 }

--- a/src/gui/guiPasswordChange.h
+++ b/src/gui/guiPasswordChange.h
@@ -19,6 +19,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #pragma once
 
 #include "modalMenu.h"
+#include "util/secure_string.h"
 #include <string>
 
 class Client;
@@ -53,8 +54,8 @@ protected:
 
 private:
 	Client *m_client;
-	std::wstring m_oldpass = L"";
-	std::wstring m_newpass = L"";
-	std::wstring m_newpass_confirm = L"";
+	SecureWString m_oldpass = L"";
+	SecureWString m_newpass = L"";
+	SecureWString m_newpass_confirm = L"";
 	ISimpleTextureSource *m_tsrc;
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -97,8 +97,7 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 			<< "(chosen_mech=" << m_chosen_auth_mech << ")." << std::endl;
 		if (m_chosen_auth_mech == AUTH_MECHANISM_SRP ||
 				m_chosen_auth_mech == AUTH_MECHANISM_LEGACY_PASSWORD) {
-			srp_user_delete((SRPUser *) m_auth_data);
-			m_auth_data = 0;
+			m_auth->clear();
 		}
 	}
 
@@ -167,9 +166,7 @@ void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
 
 void Client::handleCommand_AcceptSudoMode(NetworkPacket* pkt)
 {
-	deleteAuthData();
-
-	m_password = m_new_password;
+	*m_auth = std::move(m_new_auth);
 
 	verbosestream << "Client: Received TOCLIENT_ACCEPT_SUDO_MODE." << std::endl;
 
@@ -195,6 +192,8 @@ void Client::handleCommand_AccessDenied(NetworkPacket* pkt)
 	// to be processed even if the serialization format has
 	// not been agreed yet, the same as TOCLIENT_AUTH_ACCEPT.
 	m_access_denied = true;
+
+	deleteAuthData();
 
 	if (pkt->getCommand() != TOCLIENT_ACCESS_DENIED) {
 		// Servers older than 5.6 still send TOCLIENT_ACCESS_DENIED_LEGACY sometimes.
@@ -1617,16 +1616,23 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 
 	char *bytes_M = 0;
 	size_t len_M = 0;
-	SRPUser *usr = (SRPUser *) m_auth_data;
+	SRPUser *usr = nullptr;
+	try
+	{
+		usr = m_auth->getAuthData(m_chosen_auth_mech);
+	} catch (AuthError &e) {
+		errorstream << "Client: Bad SRP data: " << e.what() << std::endl;
+		return;
+	}
 	std::string s;
 	std::string B;
 	*pkt >> s >> B;
 
 	infostream << "Client: Received TOCLIENT_SRP_BYTES_S_B." << std::endl;
 
-	srp_user_process_challenge(usr, (const unsigned char *) s.c_str(), s.size(),
-		(const unsigned char *) B.c_str(), B.size(),
-		(unsigned char **) &bytes_M, &len_M);
+	srp_user_process_challenge(usr, reinterpret_cast<const unsigned char *>(s.c_str()), s.size(),
+		reinterpret_cast<const unsigned char *>(B.c_str()), B.size(),
+		reinterpret_cast<unsigned char **>(&bytes_M), &len_M);
 
 	if ( !bytes_M ) {
 		errorstream << "Client: SRP-6a S_B safety check violation!" << std::endl;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1617,8 +1617,7 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 	char *bytes_M = 0;
 	size_t len_M = 0;
 	SRPUser *usr = nullptr;
-	try
-	{
+	try {
 		usr = m_auth.getAuthData(m_chosen_auth_mech);
 	} catch (AuthError &e) {
 		errorstream << "Client: Bad SRP data: " << e.what() << std::endl;

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -97,7 +97,7 @@ void Client::handleCommand_Hello(NetworkPacket* pkt)
 			<< "(chosen_mech=" << m_chosen_auth_mech << ")." << std::endl;
 		if (m_chosen_auth_mech == AUTH_MECHANISM_SRP ||
 				m_chosen_auth_mech == AUTH_MECHANISM_LEGACY_PASSWORD) {
-			m_auth->clear();
+			m_auth.clear();
 		}
 	}
 
@@ -166,7 +166,7 @@ void Client::handleCommand_AuthAccept(NetworkPacket* pkt)
 
 void Client::handleCommand_AcceptSudoMode(NetworkPacket* pkt)
 {
-	*m_auth = std::move(m_new_auth);
+	m_auth = std::move(m_new_auth);
 
 	verbosestream << "Client: Received TOCLIENT_ACCEPT_SUDO_MODE." << std::endl;
 
@@ -1619,7 +1619,7 @@ void Client::handleCommand_SrpBytesSandB(NetworkPacket* pkt)
 	SRPUser *usr = nullptr;
 	try
 	{
-		usr = m_auth->getAuthData(m_chosen_auth_mech);
+		usr = m_auth.getAuthData(m_chosen_auth_mech);
 	} catch (AuthError &e) {
 		errorstream << "Client: Bad SRP data: " << e.what() << std::endl;
 		return;

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -8,6 +8,9 @@
 	See comments in porting.h
 */
 
+// enable include of memset_s function
+#define __STDC_WANT_LIB_EXT1__ 1
+
 #include "porting.h"
 
 #if defined(__FreeBSD__)  || defined(__NetBSD__) || defined(__DragonFly__) || defined(__OpenBSD__)
@@ -986,5 +989,34 @@ void TriggerMemoryTrim()
 }
 
 #endif
+
+/// Override every byte before clearing
+void secure_clear_memory(volatile void *ptr, size_t size)
+{
+#ifdef __STDC_LIB_EXT1__
+	memset_s(ptr, size, '0', size);
+#elif _WIN32
+	SecureZeroMemory((PVOID)ptr, size);
+#else
+	volatile char *ch = (char *)ptr;
+	for (;size>0;size--) {
+		*ch = 0;
+		ch++;
+	}
+#endif
+}
+
+/// Override every character before clearing
+void secure_clear_string(std::string &text)
+{
+	secure_clear_memory((void *)text.data(), text.size());
+	text.clear();
+}
+
+void secure_clear_string(std::wstring &text)
+{
+	secure_clear_memory((void *)text.data(), text.size() * sizeof(wchar_t));
+	text.clear();
+}
 
 } //namespace porting

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -994,7 +994,7 @@ void TriggerMemoryTrim()
 void secure_clear_memory(volatile void *ptr, size_t size)
 {
 #ifdef __STDC_LIB_EXT1__
-	memset_s(ptr, size, '0', size);
+	memset_s(ptr, size, '\0', size);
 #elif _WIN32
 	SecureZeroMemory((PVOID)ptr, size);
 #else
@@ -1004,19 +1004,6 @@ void secure_clear_memory(volatile void *ptr, size_t size)
 		ch++;
 	}
 #endif
-}
-
-/// Override every character before clearing
-void secure_clear_string(std::string &text)
-{
-	secure_clear_memory((void *)text.data(), text.size());
-	text.clear();
-}
-
-void secure_clear_string(std::wstring &text)
-{
-	secure_clear_memory((void *)text.data(), text.size() * sizeof(wchar_t));
-	text.clear();
 }
 
 } //namespace porting

--- a/src/porting.h
+++ b/src/porting.h
@@ -346,6 +346,14 @@ bool open_url(const std::string &url);
  */
 bool open_directory(const std::string &path);
 
+
+/// Clear memory by overwriting every character (used for security)
+void secure_clear_memory(volatile void *ptr, size_t size);
+
+/// Clear string by overwriting every character (used for security)
+void secure_clear_string(std::string &text);
+void secure_clear_string(std::wstring &text);
+
 } // namespace porting
 
 #ifdef __ANDROID__

--- a/src/porting.h
+++ b/src/porting.h
@@ -350,10 +350,6 @@ bool open_directory(const std::string &path);
 /// Clear memory by overwriting every character (used for security)
 void secure_clear_memory(volatile void *ptr, size_t size);
 
-/// Clear string by overwriting every character (used for security)
-void secure_clear_string(std::string &text);
-void secure_clear_string(std::wstring &text);
-
 } // namespace porting
 
 #ifdef __ANDROID__

--- a/src/util/auth.cpp
+++ b/src/util/auth.cpp
@@ -16,13 +16,13 @@
 // blank, we send a blank password - this is for backwards
 // compatibility with password-less players).
 std::string translate_password(const std::string &name,
-	const std::string &password)
+	const SecureString &password)
 {
 	if (password.length() == 0)
 		return "";
 
-	std::string slt = name + password;
-	std::string digest = hashing::sha1(slt);
+	SecureString slt = name + password;
+	std::string digest = hashing::sha1(slt.str());
 	std::string pwd = base64_encode(digest);
 	return pwd;
 }
@@ -32,7 +32,7 @@ std::string translate_password(const std::string &name,
 // and error checking common to all srp verifier generation code.
 // See docs of srp_create_salted_verification_key for more info.
 static inline void gen_srp_v(const std::string &name,
-	const std::string &password, char **salt, size_t *salt_len,
+	const SecureString &password, char **salt, size_t *salt_len,
 	char **bytes_v, size_t *len_v)
 {
 	std::string n_name = lowercase(name);
@@ -45,7 +45,7 @@ static inline void gen_srp_v(const std::string &name,
 
 /// Creates a verification key with given salt and password.
 std::string generate_srp_verifier(const std::string &name,
-	const std::string &password, const std::string &salt)
+	const SecureString &password, const std::string &salt)
 {
 	size_t salt_len = salt.size();
 	// The API promises us that the salt doesn't
@@ -62,7 +62,7 @@ std::string generate_srp_verifier(const std::string &name,
 
 /// Creates a verification key and salt with given password.
 void generate_srp_verifier_and_salt(const std::string &name,
-	const std::string &password, std::string *verifier,
+	const SecureString &password, std::string *verifier,
 	std::string *salt)
 {
 	char *bytes_v = nullptr;
@@ -79,7 +79,7 @@ void generate_srp_verifier_and_salt(const std::string &name,
 /// Gets an SRP verifier, generating a salt,
 /// and encodes it as DB-ready string.
 std::string get_encoded_srp_verifier(const std::string &name,
-	const std::string &password)
+	const SecureString &password)
 {
 	std::string verifier;
 	std::string salt;

--- a/src/util/auth.h
+++ b/src/util/auth.h
@@ -4,23 +4,25 @@
 
 #pragma once
 
+#include "secure_string.h"
+
 /// Gets the base64 encoded legacy password db entry.
 std::string translate_password(const std::string &name,
-	const std::string &password);
+	const SecureString &password);
 
 /// Creates a verification key with given salt and password.
 std::string generate_srp_verifier(const std::string &name,
-	const std::string &password, const std::string &salt);
+	const SecureString &password, const std::string &salt);
 
 /// Creates a verification key and salt with given password.
 void generate_srp_verifier_and_salt(const std::string &name,
-	const std::string &password, std::string *verifier,
+	const SecureString &password, std::string *verifier,
 	std::string *salt);
 
 /// Gets an SRP verifier, generating a salt,
 /// and encodes it as DB-ready string.
 std::string get_encoded_srp_verifier(const std::string &name,
-	const std::string &password);
+	const SecureString &password);
 
 /// Converts the passed SRP verifier into a DB-ready format.
 std::string encode_srp_verifier(const std::string &verifier,

--- a/src/util/secure_string.h
+++ b/src/util/secure_string.h
@@ -1,0 +1,208 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 SFENCE <sfence.software@gmail.com>
+
+#pragma once
+
+#include "porting.h"
+#include <istream>
+#include <string>
+#include <string_view>
+
+template <typename StringT>
+class BasicSecureString {
+public:
+	using string_type = StringT;
+	using value_type = typename StringT::value_type;
+	using view_type = std::basic_string_view<value_type>;
+	using iterator = typename StringT::iterator;
+	using const_iterator = typename StringT::const_iterator;
+
+	BasicSecureString() = default;
+
+	BasicSecureString(const string_type &s) :
+		m_string(s)
+	{
+	}
+
+	BasicSecureString(view_type s) :
+		m_string(s)
+	{
+	}
+
+	BasicSecureString(const value_type *s) :
+		m_string(s)
+	{
+	}
+
+	BasicSecureString(const BasicSecureString &other) :
+		m_string(other.m_string)
+	{
+	}
+
+	BasicSecureString(BasicSecureString &&other) noexcept :
+		m_string(std::move(other.m_string))
+	{
+	}
+
+	~BasicSecureString()
+	{
+		safeClear();
+	}
+
+	BasicSecureString &operator=(const string_type &s)
+	{
+		m_string = s;
+		return *this;
+	}
+
+	BasicSecureString &operator=(view_type s)
+	{
+		m_string = s;
+		return *this;
+	}
+
+	BasicSecureString &operator=(const value_type *s)
+	{
+		m_string = s;
+		return *this;
+	}
+
+	BasicSecureString &operator=(const BasicSecureString &other)
+	{
+		m_string = other.m_string;
+		return *this;
+	}
+
+	BasicSecureString &operator=(BasicSecureString &&other) noexcept
+	{
+		m_string = std::move(other.m_string);
+		return *this;
+	}
+
+	value_type &operator[](size_t pos) { return m_string[pos]; }
+	const value_type &operator[](size_t pos) const { return m_string[pos]; }
+
+	BasicSecureString &operator+=(const BasicSecureString &other)
+	{
+		m_string += other.m_string;
+		return *this;
+	}
+
+	BasicSecureString &operator+=(view_type s)
+	{
+		m_string += s;
+		return *this;
+	}
+
+	BasicSecureString &operator+=(value_type c)
+	{
+		m_string += c;
+		return *this;
+	}
+
+	bool operator==(const BasicSecureString &other) const { return m_string == other.m_string; }
+	bool operator!=(const BasicSecureString &other) const { return m_string != other.m_string; }
+	bool operator==(view_type s) const { return m_string == s; }
+	bool operator!=(view_type s) const { return m_string != s; }
+
+	// Overwrite memory with zeros and then clear
+	void safeClear()
+	{
+		porting::secure_clear_memory(
+				(void *)m_string.data(),
+				m_string.size() * sizeof(value_type));
+		m_string.clear();
+	}
+
+	const value_type *c_str() const { return m_string.c_str(); }
+	const value_type *data() const { return m_string.data(); }
+	value_type *data() { return m_string.data(); }
+	size_t size() const { return m_string.size(); }
+	size_t length() const { return m_string.length(); }
+	bool empty() const { return m_string.empty(); }
+
+	void clear() { m_string.clear(); }
+	void reserve(size_t n) { m_string.reserve(n); }
+	void resize(size_t n) { m_string.resize(n); }
+	void push_back(value_type c) { m_string.push_back(c); }
+
+	iterator begin() { return m_string.begin(); }
+	iterator end() { return m_string.end(); }
+	const_iterator begin() const { return m_string.begin(); }
+	const_iterator end() const { return m_string.end(); }
+
+	const string_type &str() const { return m_string; }
+
+	// Hidden friends: operator+
+	friend BasicSecureString operator+(const BasicSecureString &lhs, const BasicSecureString &rhs)
+	{
+		BasicSecureString result(lhs);
+		result += rhs;
+		return result;
+	}
+
+	friend BasicSecureString operator+(const BasicSecureString &lhs, const string_type &rhs)
+	{
+		BasicSecureString result(lhs);
+		result += view_type(rhs);
+		return result;
+	}
+
+	friend BasicSecureString operator+(const string_type &lhs, const BasicSecureString &rhs)
+	{
+		BasicSecureString result(lhs);
+		result += rhs;
+		return result;
+	}
+
+	friend BasicSecureString operator+(const BasicSecureString &lhs, view_type rhs)
+	{
+		BasicSecureString result(lhs);
+		result += rhs;
+		return result;
+	}
+
+	friend BasicSecureString operator+(view_type lhs, const BasicSecureString &rhs)
+	{
+		BasicSecureString result(lhs);
+		result += rhs;
+		return result;
+	}
+
+	friend BasicSecureString operator+(const BasicSecureString &lhs, const value_type *rhs)
+	{
+		BasicSecureString result(lhs);
+		result += view_type(rhs);
+		return result;
+	}
+
+	friend BasicSecureString operator+(const value_type *lhs, const BasicSecureString &rhs)
+	{
+		BasicSecureString result(lhs);
+		result += rhs;
+		return result;
+	}
+
+	// Hidden friends: allow std::getline to read directly into the internal string
+	friend std::basic_istream<value_type, typename StringT::traits_type> &
+	getline(std::basic_istream<value_type, typename StringT::traits_type> &is,
+			BasicSecureString &str)
+	{
+		return std::getline(is, str.m_string);
+	}
+
+	friend std::basic_istream<value_type, typename StringT::traits_type> &
+	getline(std::basic_istream<value_type, typename StringT::traits_type> &is,
+			BasicSecureString &str,
+			value_type delim)
+	{
+		return std::getline(is, str.m_string, delim);
+	}
+
+private:
+	string_type m_string;
+};
+
+using SecureString = BasicSecureString<std::string>;
+using SecureWString = BasicSecureString<std::wstring>;

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -231,8 +231,7 @@ struct SRPUser {
 
 	char *username;
 	char *username_verifier;
-	unsigned char *password;
-	size_t password_len;
+	unsigned char ucp_hash[CSRP_MAX_HASH];
 
 	unsigned char M[CSRP_MAX_HASH];
 	unsigned char H_AMK[CSRP_MAX_HASH];
@@ -412,11 +411,9 @@ static SRP_Result H_ns(mpz_t result, SRP_HashAlgorithm alg, const unsigned char 
 	return SRP_OK;
 }
 
-static int calculate_x(mpz_t result, SRP_HashAlgorithm alg, const unsigned char *salt,
-	size_t salt_len, const char *username, const unsigned char *password,
-	size_t password_len)
+static void precalculate_x(SRP_HashAlgorithm alg, const char *username,
+	const unsigned char *password, size_t password_len, unsigned char *ucp_hash)
 {
-	unsigned char ucp_hash[CSRP_MAX_HASH];
 	HashCTX ctx;
 	hash_init(alg, &ctx);
 
@@ -427,8 +424,11 @@ static int calculate_x(mpz_t result, SRP_HashAlgorithm alg, const unsigned char 
 	hash_update(alg, &ctx, password, password_len);
 
 	hash_final(alg, &ctx, ucp_hash);
-
-	return H_ns(result, alg, salt, salt_len, ucp_hash, hash_length(alg));
+}
+static int calculate_x(mpz_t result, SRP_HashAlgorithm alg, const unsigned char *salt,
+	size_t salt_len, const unsigned char *ucp_hash)
+{
+	return H_ns(result, alg, salt, salt_len, (const unsigned char *)ucp_hash, hash_length(alg));
 }
 
 static SRP_Result update_hash_n(SRP_HashAlgorithm alg, HashCTX *ctx, const mpz_t n)
@@ -552,8 +552,11 @@ SRP_Result srp_create_salted_verification_key( SRP_HashAlgorithm alg,
 			goto error_and_exit;
 	}
 
+	unsigned char ucp_hash[CSRP_MAX_HASH];
+	precalculate_x(alg, username_for_verifier,
+			password, len_password, ucp_hash);
 	if (!calculate_x(
-			x, alg, *bytes_s, *len_s, username_for_verifier, password, len_password))
+			x, alg, *bytes_s, *len_s, ucp_hash))
 		goto error_and_exit;
 
 	srp_dbg_num(x, "Server calculated x: ");
@@ -767,14 +770,13 @@ struct SRPUser *srp_user_new(SRP_HashAlgorithm alg, SRP_NGType ng_type,
 
 	usr->username = (char *)malloc(ulen);
 	usr->username_verifier = (char *)malloc(uvlen);
-	usr->password = (unsigned char *)malloc(len_password);
-	usr->password_len = len_password;
 
-	if (!usr->username || !usr->password || !usr->username_verifier) goto err_exit;
+	if (!usr->username || !usr->username_verifier) goto err_exit;
 
 	memcpy(usr->username, username, ulen);
 	memcpy(usr->username_verifier, username_for_verifier, uvlen);
-	memcpy(usr->password, bytes_password, len_password);
+
+	precalculate_x(alg, username_for_verifier, bytes_password, len_password, usr->ucp_hash);
 
 	usr->authenticated = 0;
 
@@ -790,10 +792,6 @@ err_exit:
 		delete_ng(usr->ng);
 		free(usr->username);
 		free(usr->username_verifier);
-		if (usr->password) {
-			memset(usr->password, 0, usr->password_len);
-			free(usr->password);
-		}
 		free(usr);
 	}
 
@@ -809,16 +807,25 @@ void srp_user_delete(struct SRPUser *usr)
 
 		delete_ng(usr->ng);
 
-		memset(usr->password, 0, usr->password_len);
-
 		free(usr->username);
 		free(usr->username_verifier);
-		free(usr->password);
 
 		if (usr->bytes_A) free(usr->bytes_A);
 
 		memset(usr, 0, sizeof(*usr));
 		free(usr);
+	}
+}
+
+void srp_user_clear_sessiondata(struct SRPUser *usr)
+{
+	if (usr) {
+		if (usr->bytes_A) free(usr->bytes_A);
+		usr->bytes_A = nullptr;
+
+		memset(usr->M, 0, CSRP_MAX_HASH);
+		memset(usr->H_AMK, 0, CSRP_MAX_HASH);
+		memset(usr->session_key, 0, CSRP_MAX_HASH);
 	}
 }
 
@@ -898,8 +905,7 @@ void  srp_user_process_challenge(struct SRPUser *usr,
 
 	srp_dbg_num(u, "Client calculated u: ");
 
-	if (!calculate_x(x, usr->hash_alg, bytes_s, len_s, usr->username_verifier,
-			usr->password, usr->password_len))
+	if (!calculate_x(x, usr->hash_alg, bytes_s, len_s, usr->ucp_hash))
 		goto cleanup_and_exit;
 
 	srp_dbg_num(x, "Client calculated x: ");

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -819,14 +819,14 @@ void srp_user_delete(struct SRPUser *usr)
 
 void srp_user_clear_sessiondata(struct SRPUser *usr)
 {
-	if (usr) {
-		if (usr->bytes_A) free(usr->bytes_A);
-		usr->bytes_A = nullptr;
+	if (!usr) return;
 
-		memset(usr->M, 0, CSRP_MAX_HASH);
-		memset(usr->H_AMK, 0, CSRP_MAX_HASH);
-		memset(usr->session_key, 0, CSRP_MAX_HASH);
-	}
+	if (usr->bytes_A) free(usr->bytes_A);
+	usr->bytes_A = nullptr;
+
+	memset(usr->M, 0, CSRP_MAX_HASH);
+	memset(usr->H_AMK, 0, CSRP_MAX_HASH);
+	memset(usr->session_key, 0, CSRP_MAX_HASH);
 }
 
 int srp_user_is_authenticated(struct SRPUser *usr)

--- a/src/util/srp.h
+++ b/src/util/srp.h
@@ -150,6 +150,8 @@ struct SRPUser *srp_user_new(SRP_HashAlgorithm alg, SRP_NGType ng_type,
 
 void srp_user_delete(struct SRPUser *usr);
 
+void srp_user_clear_sessiondata(struct SRPUser *usr);
+
 int srp_user_is_authenticated(struct SRPUser *usr);
 
 const char *srp_user_get_username(struct SRPUser *usr);

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -12,6 +12,8 @@
 #include "translation.h"
 #include "strfnd.h"
 
+#include "util/secure_string.h"
+
 #include <algorithm>
 #include <array>
 #include <sstream>
@@ -139,6 +141,35 @@ std::string wide_to_utf8(std::wstring_view input)
 	return out;
 }
 
+SecureString secure_wide_to_utf8(const SecureWString &input)
+{
+	thread_local IconvSmartPointer cd;
+	if (!cd)
+		cd.reset(iconv_open("UTF-8", DEFAULT_ENCODING));
+
+	const size_t inbuf_size = input.length() * sizeof(wchar_t);
+	// maximum possible size: utf-8 encodes codepoints using 1 up to 4 bytes
+	size_t outbuf_size = input.length() * 4;
+
+	char *inbuf = new char[inbuf_size]; // intentionally NOT null-terminated
+	memcpy(inbuf, input.data(), inbuf_size);
+	SecureString out;
+	out.resize(outbuf_size);
+
+	if (!convert(cd.get(), &out[0], &outbuf_size, inbuf, inbuf_size)) {
+		infostream << "Couldn't convert SecureWString"
+			<< " into UTF-8 string" << std::endl;
+		porting::secure_clear_memory(inbuf, inbuf_size);
+		delete[] inbuf;
+		return "<invalid wide string>";
+	}
+	porting::secure_clear_memory(inbuf, inbuf_size);
+	delete[] inbuf;
+
+	out.resize(outbuf_size);
+	return out;
+}
+
 #else // _WIN32
 
 std::wstring utf8_to_wide(std::string_view input)
@@ -161,6 +192,19 @@ std::string wide_to_utf8(std::wstring_view input)
 	WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
 		outbuf, outbuf_size, NULL, NULL);
 	std::string out(outbuf);
+	delete[] outbuf;
+	return out;
+}
+
+SecureString secure_wide_to_utf8(const SecureWString &input)
+{
+	size_t outbuf_size = (input.size() + 1) * 6;
+	char *outbuf = new char[outbuf_size];
+	memset(outbuf, 0, outbuf_size);
+	WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
+		outbuf, outbuf_size, NULL, NULL);
+	SecureString out(outbuf);
+	porting::secure_clear_memory(outbuf, outbuf_size);
 	delete[] outbuf;
 	return out;
 }
@@ -730,7 +774,7 @@ static void translate_string(std::wstring_view s, Translations *translations,
 			// This is an escape sequence *inside* the template string to translate itself.
 			// This should not happen, show an error message.
 			errorstream << "Ignoring escape sequence '"
-				<< wide_to_utf8(escape_sequence) << "' in translation" << std::endl;
+				<< wide_to_utf8(std::wstring_view(escape_sequence)) << "' in translation" << std::endl;
 		}
 	}
 
@@ -961,7 +1005,7 @@ std::string sanitizeDirName(std::string_view str, std::string_view optional_pref
 			safe_name[i] = L'_';
 	}
 
-	return wide_to_utf8(safe_name);
+	return wide_to_utf8(std::wstring_view(safe_name));
 }
 
 template <class F>

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "util/secure_string.h"
 #include "irrlichttypes_bloated.h"
 #include "config.h" // IS_CLIENT_BUILD
 #if IS_CLIENT_BUILD
@@ -74,6 +75,7 @@ struct FlagDesc {
 // input/output stuff via Irrlicht
 [[nodiscard]] std::wstring utf8_to_wide(std::string_view input);
 [[nodiscard]] std::string wide_to_utf8(std::wstring_view input);
+[[nodiscard]] SecureString secure_wide_to_utf8(const SecureWString &input);
 
 void wide_add_codepoint(std::wstring &result, char32_t codepoint);
 


### PR DESCRIPTION
In the discussion about the implementation of `transfer_player` (#14129) was recognized that the password is stored as pure text in the Minetest engine during all game sessions. Because it allows potential attackers to easily find the password in a memory dump, this PR has been created.

- Goal of the PR
This PR should improve the safety of passwords.
- How does the PR work?
This PR erases every password storage in C++ as soon as possible.
Password is no longer kept in `struct GameStartData` and `class Client` as pure text for all time the client is connected to the server.
The New `class ClientAuth` accepts the password and player name and immediately calculates the hash and everything that can be necessary in the future for authorization and what requires the password to be known.
- Does it resolve any reported issue?
I don't think so.
- Does this relate to a goal in the roadmap?
Probably not.
- If not a bug fix, why is this PR needed? What usecases doas it solve?
This improves safety on the client side. It can be marked as a bugfix, probably.

## To do

This PR is a Ready for Review.

## How to test

**Basic check:**
- Test if auth is working.

**Reconnect check:**
- Host/create the server.
- Connect to the server.
- Shut down the server by command /shutdown_with_reconnect (included in DevTest).
- Restart the server.
- Use the reconnect button on the client.