### PR TITLE
Fix waving water not rendered correctly through glass underwater 

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -619,6 +619,7 @@ void Client::step(float dtime)
 					else {
 						// Replace with the new mesh
 						block->mesh = r.mesh;
+						getEnv().getClientMap().updateMesh(block->mesh);
 						if (r.urgent)
 							force_update_shadows = true;
 					}

--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -137,7 +137,8 @@ ClientMap::~ClientMap()
 
 void ClientMap::updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset, video::SColor light_color)
 {
-	v3s16 previous_node = floatToInt(m_camera_position, BS) + m_camera_offset;
+	v3s16 prev_pos = floatToInt(m_camera_position, BS);
+	v3s16 previous_node = prev_pos + m_camera_offset;
 	v3s16 previous_block = getContainerPos(previous_node, MAP_BLOCKSIZE);
 
 	m_camera_position = pos;
@@ -146,7 +147,8 @@ void ClientMap::updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset, video::SCo
 	m_camera_offset = offset;
 	m_camera_light_color = light_color;
 
-	v3s16 current_node = floatToInt(m_camera_position, BS) + m_camera_offset;
+	v3s16 curr_pos = floatToInt(m_camera_position, BS);
+	v3s16 current_node = curr_pos + m_camera_offset;
 	v3s16 current_block = getContainerPos(current_node, MAP_BLOCKSIZE);
 
 	// reorder the blocks when camera crosses block boundary
@@ -156,6 +158,30 @@ void ClientMap::updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset, video::SCo
 	// reorder transparent meshes when camera crosses node boundary
 	if (previous_node != current_node)
 		m_needs_update_transparent_meshes = true;
+
+	// regenerate mapblocks meshes if neccessary
+	if (prev_pos != curr_pos) {
+		MapNode prev_node = getNode(prev_pos);
+		MapNode curr_node = getNode(curr_pos);
+
+		const NodeDefManager *ndef = m_client->getNodeDefManager();
+		const ContentFeatures &prev_f = ndef->get(prev_node.getContent());
+		const ContentFeatures &curr_f = ndef->get(curr_node.getContent());
+
+		if ( (prev_f.liquid_alternative_source_id != curr_f.liquid_alternative_source_id) ||
+				(prev_f.liquid_alternative_flowing_id != curr_f.liquid_alternative_flowing_id)) {
+			m_camera_liquid_source_id = curr_f.liquid_alternative_source_id;
+			m_camera_liquid_flowing_id = curr_f.liquid_alternative_flowing_id;
+			for (auto &i : m_drawlist) {
+				i.second->mesh->updateHiddable(m_camera_liquid_source_id, m_camera_liquid_flowing_id);
+			}
+		}
+	}
+}
+
+void ClientMap::updateMesh(MapBlockMesh *mesh)
+{
+	mesh->updateHiddable(m_camera_liquid_source_id, m_camera_liquid_flowing_id);
 }
 
 MapSector * ClientMap::emergeSector(v2s16 p2d)
@@ -399,6 +425,7 @@ void ClientMap::updateDrawList()
 				} else if (mesh) {
 					// without mesh chunking we can add the block to the drawlist
 					block->refGrab();
+					block->mesh->updateHiddable(m_camera_liquid_source_id, m_camera_liquid_flowing_id);
 					m_drawlist.emplace(block->getPos(), block);
 				}
 			}
@@ -507,6 +534,7 @@ void ClientMap::updateDrawList()
 			} else if (mesh) {
 				// without mesh chunking we can add the block to the drawlist
 				block->refGrab();
+				block->mesh->updateHiddable(m_camera_liquid_source_id, m_camera_liquid_flowing_id);
 				m_drawlist.emplace(block_coord, block);
 			}
 
@@ -619,6 +647,7 @@ void ClientMap::updateDrawList()
 		MapBlock *block = getBlockNoCreateNoEx(pos);
 		if (block) {
 			block->refGrab();
+			block->mesh->updateHiddable(m_camera_liquid_source_id, m_camera_liquid_flowing_id);
 			m_drawlist.emplace(pos, block);
 		}
 	}

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -126,6 +126,8 @@ private:
 	// update the vertex order in transparent mesh buffers
 	void updateTransparentMeshBuffers();
 
+	// help method for updateDrawList
+	void addBlockToDrawList(v3s16 pos, MapBlock *block);
 
 	// Orders blocks by distance to the camera
 	class MapBlockComparer

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -63,6 +63,7 @@ public:
 	}
 
 	void updateCamera(v3f pos, v3f dir, f32 fov, v3s16 offset, video::SColor light_color);
+	void updateMesh(MapBlockMesh *mesh);
 
 	/*
 		Forcefully get a sector from somewhere
@@ -180,6 +181,9 @@ private:
 	v3s16 m_camera_offset;
 	video::SColor m_camera_light_color = video::SColor(0xFFFFFFFF);
 	bool m_needs_update_transparent_meshes = true;
+
+	content_t m_camera_liquid_source_id = CONTENT_IGNORE;
+	content_t m_camera_liquid_flowing_id = CONTENT_IGNORE;
 
 	std::map<v3s16, MapBlock*, MapBlockComparer> m_drawlist;
 	std::vector<MapBlock*> m_keeplist;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -426,7 +426,7 @@ void MapblockMeshGenerator::drawSolidNode()
 		MapNode neighbor = data->m_vmanip.getNodeNoEx(p2);
 		content_t n2 = neighbor.getContent();
 		bool backface_culling = cur_node.f->drawtype == NDT_NORMAL;
-		bool is_hiddable = false;
+		bool is_hideable = false;
 		if (n2 == n1)
 			continue;
 		if (n2 == CONTENT_IGNORE)
@@ -439,7 +439,7 @@ void MapblockMeshGenerator::drawSolidNode()
 				if (cur_node.f->sameLiquidRender(f2))
 					continue;
 				if (f2.drawtype == NDT_GLASSLIKE) {
-					is_hiddable = true;
+					is_hideable = true;
 				}
 				backface_culling = f2.solidness || f2.visual_solidness;
 			}
@@ -451,7 +451,7 @@ void MapblockMeshGenerator::drawSolidNode()
 				layer.material_flags |= MATERIAL_FLAG_BACKFACE_CULLING;
 			layer.material_flags |= MATERIAL_FLAG_TILEABLE_HORIZONTAL;
 			layer.material_flags |= MATERIAL_FLAG_TILEABLE_VERTICAL;
-			if (is_hiddable) {
+			if (is_hideable) {
 				layer.material_flags |= MATERIAL_FLAG_HIDDABLE;
 				layer.liquid_source_id = cur_node.f->liquid_alternative_source_id;
 				layer.liquid_flowing_id = cur_node.f->liquid_alternative_flowing_id;

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -83,6 +83,7 @@ MapblockMeshGenerator::MapblockMeshGenerator(MeshMakeData *input, MeshCollector 
 	enable_mesh_cache(g_settings->getBool("enable_mesh_cache") &&
 			!data->m_smooth_lighting) // Mesh cache is not supported with smooth lighting
 {
+	cam_f = &nodedef->get(data->m_cameranode);
 }
 
 void MapblockMeshGenerator::useTile(int index, u8 set_flags, u8 reset_flags, bool special)
@@ -425,6 +426,7 @@ void MapblockMeshGenerator::drawSolidNode()
 		MapNode neighbor = data->m_vmanip.getNodeNoEx(p2);
 		content_t n2 = neighbor.getContent();
 		bool backface_culling = cur_node.f->drawtype == NDT_NORMAL;
+		bool is_hiddable = false;
 		if (n2 == n1)
 			continue;
 		if (n2 == CONTENT_IGNORE)
@@ -436,6 +438,9 @@ void MapblockMeshGenerator::drawSolidNode()
 			if (cur_node.f->drawtype == NDT_LIQUID) {
 				if (cur_node.f->sameLiquidRender(f2))
 					continue;
+				if (f2.drawtype == NDT_GLASSLIKE) {
+					is_hiddable = true;
+				}
 				backface_culling = f2.solidness || f2.visual_solidness;
 			}
 		}
@@ -446,6 +451,11 @@ void MapblockMeshGenerator::drawSolidNode()
 				layer.material_flags |= MATERIAL_FLAG_BACKFACE_CULLING;
 			layer.material_flags |= MATERIAL_FLAG_TILEABLE_HORIZONTAL;
 			layer.material_flags |= MATERIAL_FLAG_TILEABLE_VERTICAL;
+			if (is_hiddable) {
+				layer.material_flags |= MATERIAL_FLAG_HIDDABLE;
+				layer.liquid_source_id = cur_node.f->liquid_alternative_source_id;
+				layer.liquid_flowing_id = cur_node.f->liquid_alternative_flowing_id;
+			}
 		}
 		if (!data->m_smooth_lighting) {
 			lights[face] = getFaceLight(cur_node.n, neighbor, nodedef);

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -91,6 +91,9 @@ private:
 		f32 scale;
 	} cur_node;
 
+// camera node
+  const ContentFeatures *cam_f;
+
 // lighting
 	void getSmoothLightFrame();
 	LightInfo blendLight(const v3f &vertex_pos);

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -751,10 +751,10 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data, v3s16 camera_offs
 				p.layer.texture = (*p.layer.frames)[0].texture;
 			}
 
-			// - Texture hiddable
+			// - Texture hideable
 			if (p.layer.material_flags & MATERIAL_FLAG_HIDDABLE) {
-				// Add to MapBlockMesh to hiddable
-				auto &info = m_hiddable_info[{layer, i}];
+				// Add to MapBlockMesh to hideable
+				auto &info = m_hideable_info[{layer, i}];
 				info.hidden = false;
 				info.liquid_source_id = p.layer.liquid_source_id;
 				info.liquid_flowing_id = p.layer.liquid_flowing_id;
@@ -936,10 +936,10 @@ bool MapBlockMesh::animate(bool faraway, float time, int crack,
 	return true;
 }
 
-void MapBlockMesh::updateHiddable(content_t liquid_source_id, content_t liquid_flowing_id)
+void MapBlockMesh::updateHideable(content_t liquid_source_id, content_t liquid_flowing_id)
 {
 	// Texture animation
-	for (auto &it : m_hiddable_info) {
+	for (auto &it : m_hideable_info) {
 		const TileLayer &tile = it.second.tile;
 
 		scene::IMeshBuffer *buf = m_mesh[it.first.first]->getMeshBuffer(it.first.second);
@@ -947,21 +947,11 @@ void MapBlockMesh::updateHiddable(content_t liquid_source_id, content_t liquid_f
 		bool hide = (it.second.liquid_source_id == liquid_source_id) &&
 				(it.second.liquid_flowing_id == liquid_flowing_id);
 		if (it.second.hidden != hide) {
-			if (hide) {
-				buf->getMaterial().setTexture(0, m_texture_blank);
-				if (m_enable_shaders) {
-					if (tile.normal_texture)
-						buf->getMaterial().setTexture(1, m_texture_blank);
-					buf->getMaterial().setTexture(2, m_texture_blank);
-				}
-			}
-			else {
-				buf->getMaterial().setTexture(0, tile.texture);
-				if (m_enable_shaders) {
-					if (tile.normal_texture)
-						buf->getMaterial().setTexture(1, tile.normal_texture);
-					buf->getMaterial().setTexture(2, tile.flags_texture);
-				}
+			buf->getMaterial().setTexture(0, hide ? m_texture_blank : tile.texture);
+			if (m_enable_shaders) {
+				if (tile.normal_texture)
+					buf->getMaterial().setTexture(1, hide ? m_texture_blank : tile.normal_texture);
+				buf->getMaterial().setTexture(2, hide ? m_texture_blank : tile.flags_texture);
 			}
 			it.second.hidden = hide;
 		}

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -49,9 +49,11 @@ struct MeshMakeData
 	u16 side_length;
 
 	const NodeDefManager *nodedef;
+	MapNode m_cameranode;
 	bool m_use_shaders;
 
-	MeshMakeData(const NodeDefManager *ndef, u16 side_length, bool use_shaders);
+	MeshMakeData(Client *client, u16 side_length, bool use_shaders);
+	MeshMakeData(const NodeDefManager *ndef, MapNode &cameranode, u16 side_length, bool use_shaders);
 
 	/*
 		Copy block data manually (to allow optimizations by the caller)
@@ -192,6 +194,8 @@ public:
 	// Returns true if anything has been changed.
 	bool animate(bool faraway, float time, int crack, u32 daynight_ratio);
 
+	void updateHiddable(content_t liquid_source_id, content_t liquid_flowing_id);
+
 	scene::IMesh *getMesh()
 	{
 		return m_mesh[0];
@@ -242,11 +246,19 @@ private:
 		int frame_offset;
 		TileLayer tile;
 	};
+	struct HiddableInfo {
+		bool hidden;
+		content_t liquid_source_id;
+		content_t liquid_flowing_id;
+		TileLayer tile;
+	};
 
 	scene::IMesh *m_mesh[MAX_TILE_LAYERS];
 	std::vector<MinimapMapblock*> m_minimap_mapblocks;
 	ITextureSource *m_tsrc;
 	IShaderSource *m_shdrsrc;
+	video::ITexture *m_texture_blank;
+	u32 m_texture_blank_id;
 
 	f32 m_bounding_radius;
 	v3f m_bounding_sphere_center;
@@ -267,6 +279,10 @@ private:
 	// Maps mesh and mesh buffer indices to TileSpecs
 	// Keys are pairs of (mesh index, buffer index in the mesh)
 	std::map<std::pair<u8, u32>, AnimationInfo> m_animation_info;
+
+	// Hiddable info: hiddable textures
+	// Used for better rendering under liquids
+	std::map<std::pair<u8, u32>, HiddableInfo> m_hiddable_info;
 
 	// Animation info: day/night transitions
 	// Last daynight_ratio value passed to animate()

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -194,7 +194,7 @@ public:
 	// Returns true if anything has been changed.
 	bool animate(bool faraway, float time, int crack, u32 daynight_ratio);
 
-	void updateHiddable(content_t liquid_source_id, content_t liquid_flowing_id);
+	void updateHideable(content_t liquid_source_id, content_t liquid_flowing_id);
 
 	scene::IMesh *getMesh()
 	{
@@ -246,7 +246,7 @@ private:
 		int frame_offset;
 		TileLayer tile;
 	};
-	struct HiddableInfo {
+	struct HideableInfo {
 		bool hidden;
 		content_t liquid_source_id;
 		content_t liquid_flowing_id;
@@ -280,9 +280,9 @@ private:
 	// Keys are pairs of (mesh index, buffer index in the mesh)
 	std::map<std::pair<u8, u32>, AnimationInfo> m_animation_info;
 
-	// Hiddable info: hiddable textures
+	// Hideable info: hideable textures
 	// Used for better rendering under liquids
-	std::map<std::pair<u8, u32>, HiddableInfo> m_hiddable_info;
+	std::map<std::pair<u8, u32>, HideableInfo> m_hideable_info;
 
 	// Animation info: day/night transitions
 	// Last daynight_ratio value passed to animate()

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -190,7 +190,7 @@ void MeshUpdateQueue::done(v3s16 pos)
 void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 {
 	auto mesh_grid = m_client->getMeshGrid();
-	MeshMakeData *data = new MeshMakeData(m_client->ndef(), MAP_BLOCKSIZE * mesh_grid.cell_size, m_cache_enable_shaders);
+	MeshMakeData *data = new MeshMakeData(m_client, MAP_BLOCKSIZE * mesh_grid.cell_size, m_cache_enable_shaders);
 	q->data = data;
 
 	data->fillBlockDataBegin(q->p);

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <ITexture.h>
 #include <vector>
 #include <SMaterial.h>
+#include "mapnode.h"
 
 enum MaterialType{
 	TILE_MATERIAL_BASIC,
@@ -51,6 +52,7 @@ enum MaterialType{
 //#define MATERIAL_FLAG_HIGHLIGHTED 0x10
 #define MATERIAL_FLAG_TILEABLE_HORIZONTAL 0x20
 #define MATERIAL_FLAG_TILEABLE_VERTICAL 0x40
+#define MATERIAL_FLAG_HIDDABLE 0x80
 
 /*
 	This fully defines the looks of a tile.
@@ -121,6 +123,9 @@ struct TileLayer
 
 	u32 texture_id = 0;
 
+	content_t liquid_source_id;
+	content_t liquid_flowing_id;
+
 	u16 animation_frame_length_ms = 0;
 	u16 animation_frame_count = 1;
 
@@ -167,4 +172,7 @@ struct TileSpec
 	u8 emissive_light = 0;
 	//! The first is base texture, the second is overlay.
 	TileLayer layers[MAX_TILE_LAYERS];
+	//Specify liquid for hide
+	content_t liquid_source_id = CONTENT_IGNORE;
+	content_t liquid_flowing_id = CONTENT_IGNORE;
 };

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -315,7 +315,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 static scene::SMesh *createSpecialNodeMesh(Client *client, MapNode n,
 	std::vector<ItemPartColor> *colors, const ContentFeatures &f)
 {
-	MeshMakeData mesh_make_data(client->ndef(), 1, false);
+	MeshMakeData mesh_make_data(client, 1, false);
 	MeshCollector collector(v3f(0.0f * BS), v3f());
 	mesh_make_data.setSmoothLighting(false);
 	MapblockMeshGenerator gen(&mesh_make_data, &collector,

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -53,7 +53,8 @@ public:
 
 	MeshMakeData makeSingleNodeMMD(bool smooth_lighting = true, bool for_shaders = true)
 	{
-		MeshMakeData data{ndef(), 1, for_shaders};
+		MapNode cameranode(CONTENT_AIR);
+		MeshMakeData data{ndef(), cameranode, 1, for_shaders};
 		data.setSmoothLighting(smooth_lighting);
 		data.m_blockpos = {0, 0, 0};
 		for (s16 x = -1; x <= 1; x++)


### PR DESCRIPTION
- Goal of the PR
Fixes #3733.
- How does the PR work?
Liquid node sides in contact with the glass are not rendered if the camera is in the same liquid type.
- Does it resolve any reported issue?
Fix bug #3733.

## To do

This PR is a Ready for Review.

## How to test

Go to the world, find water, and place glass under water.


https://github.com/minetest/minetest/assets/17455197/7fb18bcf-25bc-44a8-9528-3579e39a196f

