### PR TITLE
Try to preserve metatable information in core.serialize

### DIFF
--- a/builtin/common/metatable.lua
+++ b/builtin/common/metatable.lua
@@ -31,3 +31,9 @@ function core.register_async_metatable(...)
 end
 
 core.register_portable_metatable("__builtin:vector", vector.metatable)
+
+if ItemStack then
+	local item = ItemStack()
+	local itemstack_mt = getmetatable(item)
+	core.register_portable_metatable("__itemstack", itemstack_mt, item.to_table, ItemStack)
+end

--- a/builtin/common/metatable.lua
+++ b/builtin/common/metatable.lua
@@ -1,14 +1,28 @@
 -- Registered metatables, used by the C++ packer
+local serializable_metatables = {}
 local known_metatables = {}
-function core.register_portable_metatable(name, mt)
+
+local function dummy_serializer(x)
+	return x
+end
+
+function core.register_portable_metatable(name, mt, serializer, deserializer)
+	serializer = serializer or dummy_serializer
+	deserializer = deserializer or function(x) return setmetatable(x, mt) end
 	assert(type(name) == "string", ("attempt to use %s value as metatable name"):format(type(name)))
 	assert(type(mt) == "table", ("attempt to register a %s value as metatable"):format(type(mt)))
+	assert(type(serializer), ("attempt to use a %s value as serializer"):format(type(serializer)))
+	assert(type(deserializer), ("attempt to use a %s value as serialier"):format(type(deserializer)))
 	assert(known_metatables[name] == nil or known_metatables[name] == mt,
 			("attempt to override metatable %s"):format(name))
 	known_metatables[name] = mt
 	known_metatables[mt] = name
+	serializable_metatables[mt] = serializer
+	serializable_metatables[name] = deserializer
 end
+
 core.known_metatables = known_metatables
+core.serializable_metatables = serializable_metatables
 
 function core.register_async_metatable(...)
 	core.log("deprecated", "core.register_async_metatable is deprecated. " ..

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -8,14 +8,6 @@ local next, rawget, pairs, pcall, error, type, setfenv, loadstring
 local table_concat, string_dump, string_format, string_match, math_huge
 	= table.concat, string.dump, string.format, string.match, math.huge
 
-local itemstack_mt
-if ItemStack then
-	itemstack_mt = getmetatable(ItemStack())
-end
-local function is_itemstack(x)
-	return itemstack_mt and getmetatable(x) == itemstack_mt
-end
-
 local function pack_args(...)
 	return {n = select("#", ...), ...}
 end
@@ -82,10 +74,6 @@ local function dump_func(func)
 	return string_format("loadstring(%q)", string_dump(func))
 end
 
-local function dump_itemstack(item)
-	return string_format("ItemStack(%q)", item:to_string())
-end
-
 -- Serializes Lua nil, booleans, numbers, strings, tables and even functions
 -- Tables are referenced by reference, strings are referenced by value. Supports circular tables.
 local function serialize(value, write)
@@ -118,12 +106,10 @@ local function serialize(value, write)
 				write(dump_func(object))
 			elseif type_ == "string" then
 				write(quote(object))
-			elseif is_itemstack(object) then
-				write(dump_itemstack(object))
 			end
 			write(";")
 			references[object] = reference
-			if type_ ~= "string" and not is_itemstack(object) then
+			if type_ ~= "string" then
 				to_fill[object] = reference
 			end
 			refnum = refnum + 1
@@ -188,9 +174,6 @@ local function serialize(value, write)
 		end
 		if type_ == "function" then
 			return write(dump_func(value))
-		end
-		if is_itemstack(value) then
-			return write(dump_itemstack(value))
 		end
 		if type_ == "table" then
 			write("{")

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -31,24 +31,26 @@ local function prepare_objects(value)
 		if type_ == "boolean" or type_ == "number" then
 			return
 		end
+		local count = counts[val]
 		if not recount then
-			local count = counts[val]
 			counts[val] = (count or 0) + 1
 		end
-		local mt = (not recount) and (type_ == "table" or type_ == "userdata") and getmetatable(val)
+		local mt = (not count) and (type_ == "table" or type_ == "userdata") and getmetatable(val)
 		if mt and core.known_metatables[mt] then
 			type_lookup[val] = core.known_metatables[mt]
 			count_values(val, true)
 		elseif type_ == "table" then
-			for k, v in pairs(val) do
-				count_values(k)
-				count_values(v)
+			if recount or not count then
+				for k, v in pairs(val) do
+					count_values(k)
+					count_values(v)
+				end
 			end
-		elseif type_ ~= "string" then
+		elseif type_ ~= "string" and type_ ~= "function" then
 			error("unsupported type: " .. type_)
 		end
 	end
-	count_values(value, false)
+	count_values(value)
 	return counts, type_lookup
 end
 

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -109,7 +109,7 @@ local function serialize(value, write)
 			end
 			write(";")
 			references[object] = reference
-			if type_ ~= "string" then
+			if type_ == "table" then
 				to_fill[object] = reference
 			end
 			refnum = refnum + 1
@@ -269,7 +269,6 @@ function core.deserialize(str, safe)
 	local env = {
 		inf = math_huge,
 		nan = 0/0,
-		ItemStack = ItemStack or function(str) return str end,
 		core = {
 			known_metatables = core.known_metatables,
 			serializable_metatables = core.serializable_metatables,

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -26,29 +26,29 @@ local function prepare_objects(value)
 		-- Early return for nil; tables can't contain nil
 		return counts, type_lookup
 	end
-	local function count_values(val)
+	local function count_values(val, recount)
 		local type_ = type(val)
 		if type_ == "boolean" or type_ == "number" then
 			return
 		end
-		local count = counts[val]
-		counts[val] = (count or 0) + 1
-		local mt = getmetatable(val)
-		if type_ == "table" then
-			if not count then
-				for k, v in pairs(val) do
-					count_values(k)
-					count_values(v)
-				end
-				if mt then
-					type_lookup[val] = core.known_metatables[mt]
-				end
+		if not recount then
+			local count = counts[val]
+			counts[val] = (count or 0) + 1
+		end
+		local mt = (not recount) and (type_ == "table" or type_ == "userdata") and getmetatable(val)
+		if mt and core.known_metatables[mt] then
+			type_lookup[val] = core.known_metatables[mt]
+			count_values(val, true)
+		elseif type_ == "table" then
+			for k, v in pairs(val) do
+				count_values(k)
+				count_values(v)
 			end
-		elseif type_ ~= "string" and type_ ~= "function" and not is_itemstack(val) then
+		elseif type_ ~= "string" then
 			error("unsupported type: " .. type_)
 		end
 	end
-	count_values(value, {})
+	count_values(value, false)
 	return counts, type_lookup
 end
 

--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -50,7 +50,7 @@ local function pair(x, y)
 	return setmetatable({x, y}, pair_mt)
 end
 -- Use our own serialization functions to avoid incorrectly passing test related to references.
-core.register_metatable("pair", pair_mt)
+core.register_portable_metatable("pair", pair_mt)
 assert.equals(pair(1, 2), pair(1, 2))
 assert.not_equals(pair(1, 2), pair(3, 4))
 
@@ -165,7 +165,7 @@ describe("serialize", function()
 				return x[1] == y[1]
 			end,
 		}
-		core.register_metatable("test_recursive_typed", mt)
+		core.register_portable_metatable("test_recursive_typed", mt)
 		local t = setmetatable({1}, mt)
 		t[2] = t
 		assert_strictly_preserves(t)

--- a/builtin/common/tests/serialize_spec.lua
+++ b/builtin/common/tests/serialize_spec.lua
@@ -4,6 +4,7 @@ _G.setfenv = require 'busted.compatibility'.setfenv
 
 dofile("builtin/common/serialize.lua")
 dofile("builtin/common/vector.lua")
+dofile("builtin/common/metatable.lua")
 
 -- Supports circular tables; does not support table keys
 -- Correctly checks whether a mapping of references ("same") exists
@@ -40,9 +41,30 @@ local t1, t2 = {x, x, y, y}, {x, y, x, y}
 assert.same(t1, t2) -- will succeed because it only checks whether the depths match
 assert(not pcall(assert_same, t1, t2)) -- will correctly fail because it checks whether the refs match
 
+local pair_mt = {
+	__eq = function(x, y)
+		return x[1] == y[1] and x[2] == y[2]
+	end,
+}
+local function pair(x, y)
+	return setmetatable({x, y}, pair_mt)
+end
+-- Use our own serialization functions to avoid incorrectly passing test related to references.
+core.register_metatable("pair", pair_mt)
+assert.equals(pair(1, 2), pair(1, 2))
+assert.not_equals(pair(1, 2), pair(3, 4))
+
 describe("serialize", function()
 	local function assert_preserves(value)
 		local preserved_value = core.deserialize(core.serialize(value))
+		assert_same(value, preserved_value)
+	end
+	local function assert_strictly_preserves(value)
+		local preserved_value = core.deserialize(core.serialize(value))
+		assert.equals(value, preserved_value)
+	end
+	local function assert_compatibly_preserves(value)
+		local preserved_value = loadstring(core.serialize(value))()
 		assert_same(value, preserved_value)
 	end
 	it("works", function()
@@ -51,6 +73,10 @@ describe("serialize", function()
 
 	it("handles characters", function()
 		assert_preserves({escape_chars="\n\r\t\v\\\"\'", non_european="θשׁ٩∂"})
+	end)
+
+	it("handles nil", function()
+		assert_strictly_preserves(nil)
 	end)
 
 	it("handles NaN & infinities", function()
@@ -113,12 +139,52 @@ describe("serialize", function()
 	it("vectors work", function()
 		local v = vector.new(1, 2, 3)
 		assert_preserves({v})
-		assert_preserves(v)
+		assert_compatibly_preserves({v})
+		assert_strictly_preserves(v)
+		assert_compatibly_preserves(v)
+		assert(core.deserialize(core.serialize(v)):check())
 
 		-- abuse
 		v = vector.new(1, 2, 3)
 		v.a = "bla"
 		assert_preserves(v)
+	end)
+
+	it("correctly handles typed objects with multiple references", function()
+		local x, y = pair(1, 2), pair(1, 2)
+		local t = core.deserialize(core.serialize{x, x, y})
+		assert.equals(x, t[1])
+		assert.equals(x, t[3])
+		assert(rawequal(t[1], t[2]))
+		assert(not rawequal(t[1], t[3]))
+	end)
+
+	it("correctly handles recursive typed objects with the identity function as serializer", function()
+		local mt = {
+			__eq = function(x, y)
+				return x[1] == y[1]
+			end,
+		}
+		core.register_metatable("test_recursive_typed", mt)
+		local t = setmetatable({1}, mt)
+		t[2] = t
+		assert_strictly_preserves(t)
+	end)
+
+	it("correctly handles binary trees", function()
+		local child = {pair(1, 1)}
+		local layers = 4
+		for i = 2, layers do
+			child[i] = pair(child[i-1], child[i-1])
+		end
+		local tree = child[layers]
+		assert_strictly_preserves(tree)
+		local node = core.deserialize(core.serialize(tree))
+		for i = 2, layers do
+			assert(rawequal(node[1], node[2]))
+			node = node[1]
+		end
+		assert_compatibly_preserves(tree)
 	end)
 
 	it("handles keywords as keys", function()

--- a/builtin/common/vector.lua
+++ b/builtin/common/vector.lua
@@ -12,6 +12,10 @@ vector = {}
 local metatable = {}
 vector.metatable = metatable
 
+if core and core.register_serializable then
+	core.register_serializable("__builtin:vector", metatable)
+end
+
 local xyz = {"x", "y", "z"}
 
 -- only called when rawget(v, key) returns nil

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7653,12 +7653,18 @@ Misc.
 * `core.global_exists(name)`
     * Checks if a global variable has been set, without triggering a warning.
 
-* `core.register_portable_metatable(name, mt)`:
+* `core.register_portable_metatable(name, mt, serializer, deserializer)`:
     * Register a metatable that should be preserved when Lua data is transferred
       between environments (via IPC, `handle_async`, or `core.serialize`).
     * `name` is a string that identifies the metatable. It is recommended to
       follow the `modname:name` convention for this identifier.
     * `mt` is the metatable to register.
+    * `serializer` is a function used by `core.serialize` to serialize data with
+      the given metatable. It may return multiple values, but the return values should not
+      contain the input datum unless `serializer` is the identity function. The default
+      value for `serializer` is the identity function.
+    * `deserializer` is a function used by `core.deserialize` to deserialize data from
+      values returned by `serializer`. The default value is a wrapper around `setmetatable`.
     * Note that the same metatable can be registered under multiple names,
       but multiple metatables must not be registered under the same name.
     * You must register the metatable in both the main environment

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7655,7 +7655,7 @@ Misc.
 
 * `core.register_portable_metatable(name, mt)`:
     * Register a metatable that should be preserved when Lua data is transferred
-      between environments (via IPC or `handle_async`).
+      between environments (via IPC, `handle_async`, or `core.serialize`).
     * `name` is a string that identifies the metatable. It is recommended to
       follow the `modname:name` convention for this identifier.
     * `mt` is the metatable to register.

--- a/games/devtest/mods/unittests/itemstack_equals.lua
+++ b/games/devtest/mods/unittests/itemstack_equals.lua
@@ -72,3 +72,10 @@ local function test_itemstack_equals_metadata()
 end
 
 unittests.register("test_itemstack_equals_metadata", test_itemstack_equals_metadata)
+
+local function test_itemstack_serialization_preservation()
+	local i = ItemStack("basenodes:stone 20 1000")
+	assert(i:equals(core.deserialize(core.serialize(i))))
+end
+
+unittests.register("test_itemstack_serialization_preservation", test_itemstack_serialization_preservation)


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  This PR attempts to preserve metatable information in the data serialized by `minetest.serialize`.
- How does the PR work?
  This PR works by keeping a record of metatables that are assigned to a name. This name is then kept along with the serialized data which can later be used to construct the wanted type during the deserialization process.
  Note that there are certain limitations that apply when an object contains a recognized metatable. These limitations will be documented as part of this PR.
- Does it resolve any reported issue?
  Fixes #14357.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  No, but it may be considered a bugfix depending on whether the issue linked above is considered as a bug.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  See linked issue.

## To do

This PR is Ready for Review.

- Compatibility: serialized data that do not use this feature remain compatible with older versions of `core.deserialize`; compatibility is otherwise not guaranteed.
- [x] Documentation
- [x] Support custom (de)serializers
- Support for MT's builtin types:
  - [x] vector
  - [x] ItemStack (*)
- [ ] Support for recursive objects and reference counting.
- [ ] Unittests

## How to test

* Make sure that there is a test case for each entry in the To-Do.
* Make sure that the To-Do covers every case.
* Test the new `core.serialize` on various data structures and make sure they work.

(*) The testcase for ItemStacks is put into the devtest as it appears to be implemented as `userdata`.