### PR TITLE
Hypertext: accept em as a length unit

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2657,6 +2657,8 @@ Version History
 * Formspec version 7 (5.8.0):
   * style[]: Add focused state for buttons
   * Add field_enter_after_edit[] (experimental)
+* Formspec version 8 (5.9.0):
+  * hypertext[]: Allow `em` as a length unit
 
 Elements
 --------

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3496,6 +3496,10 @@ Some tags can enclose text, they open with `<tagname>` and close with `</tagname
 Tags can have attributes, in that case, attributes are in the opening tag in
 form of a key/value separated with equal signs. Attribute values should not be quoted.
 
+Attributes that describe lengths (font size and image dimensions) can be a regular
+number, which describes the size in pixels, or a number with the unit `em`, which
+describes the size in relation to the font size of the enclosing element.
+
 If you want to insert a literal greater-than sign or a backslash into the text,
 you must escape it by preceding it with a backslash.
 
@@ -5948,7 +5952,7 @@ Environment access
 * `minetest.add_entity(pos, name, [staticdata])`: Spawn Lua-defined entity at
   position.
     * Returns `ObjectRef`, or `nil` if failed
-    * Entities with `static_save = true` can be added also 
+    * Entities with `static_save = true` can be added also
       to unloaded and non-generated blocks.
 * `minetest.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -67,7 +67,8 @@ This is a normal text.
 
 <bigger><mono>style</mono> test</bigger>
 <style color=#FFFF00>Yellow text.</style> <style color=#FF0000>Red text.</style>
-<style size=24>Size 24.</style> <style size=16>Size 16</style>. <style size=12>Size 12.</style>
+<style size=24>Size 24.</style> <style size=16>Size 16.</style> <style size=12>Size 12.</style>
+<style size=2em>Size 2em.</style> <style size=0.5em>Size 0.5em.</style>
 <style font=normal>Normal font.</style> <style font=mono>Mono font.</style>
 
 <bigger>Tag test</bigger>
@@ -108,6 +109,8 @@ Normal:
 <img name=testformspec_item.png float=left>
 <mono>float=right</mono>:
 <img name=testformspec_item.png float=right>
+<mono>width=1em height=2em</mono>:
+<img name=testformspec_item.png width=1em height=2em>
 
 <bigger><mono>item</mono> test</bigger>
 Normal:

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -112,8 +112,8 @@ Normal:
 <img name=testformspec_item.png float=right>
 <mono>width=1em height=2em</mono>:
 <img name=testformspec_item.png width=1em height=2em>
-<mono>width=2em</mono> inside <mono>width=2em</mono>
-<style fontsize=2em><img name=testformspec_item.png width=2em></style>
+<mono>width=2em</mono> inside <mono>width=2em</mono> (should render at <mono>width=4em</mono>):
+<style size=2em><img name=testformspec_item.png width=2em></style>
 
 <bigger><mono>item</mono> test</bigger>
 Normal:

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -68,7 +68,8 @@ This is a normal text.
 <bigger><mono>style</mono> test</bigger>
 <style color=#FFFF00>Yellow text.</style> <style color=#FF0000>Red text.</style>
 <style size=24>Size 24.</style> <style size=16>Size 16.</style> <style size=12>Size 12.</style>
-<style size=2em>Size 2em.</style> <style size=0.5em>Size 0.5em.</style>
+<style size=2em>Size 2em.</style> <style size=1em>Size 1em.</style> <style size=0.5em>Size 0.5em.</style>
+<style size=3em>Size 3em. <style size=0.5em>Half of 3em.</style></style>
 <style font=normal>Normal font.</style> <style font=mono>Mono font.</style>
 
 <bigger>Tag test</bigger>
@@ -111,6 +112,8 @@ Normal:
 <img name=testformspec_item.png float=right>
 <mono>width=1em height=2em</mono>:
 <img name=testformspec_item.png width=1em height=2em>
+<mono>width=2em</mono> inside <mono>width=2em</mono>
+<style fontsize=2em><img name=testformspec_item.png width=2em></style>
 
 <bigger><mono>item</mono> test</bigger>
 Normal:

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -59,7 +59,7 @@ static bool check_length(const std::string &str)
 ParsedText::LengthValue::LengthValue(const std::string &str)
 {
 	char *unitptr = nullptr;
-	this->size = strtod(str.c_str(), &unitptr);
+	this->size = std::strtod(str.c_str(), &unitptr);
 
 	if (this->size <= 0)
 		this->size = 0;
@@ -105,7 +105,7 @@ void ParsedText::Element::setStyle(StyleList &style)
 	if (parseColorString(style["hovercolor"], color, false))
 		this->hovercolor = color;
 
-	this->font_size = atoi(style["fontsize"].c_str());
+	this->font_size = std::atoi(style["fontsize"].c_str());
 
 	FontMode font_mode = FM_Standard;
 	if (style["fontstyle"] == "mono")

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -48,27 +48,23 @@ static bool check_integer(const std::string &str)
 	return *endptr == '\0';
 }
 
-static ParsedText::LengthValue parse_length(const std::string &str)
-{
-	char *unitptr = nullptr;
-	double size = strtod(str.c_str(), &unitptr);
-	ParsedText::LengthValue length;
-
-	if (size <= 0)
-		size = 0;
-	length.size = size;
-	length.unit = unitptr;
-
-	return length;
-}
-
 static bool check_length(const std::string &str)
 {
-	return parse_length(str).isValid();
+	return ParsedText::LengthValue(str).isValid();
 }
 
 // -----------------------------------------------------------------------------
 // LengthValue - A data structure representing a (possibly relative) length
+
+ParsedText::LengthValue::LengthValue(const std::string &str)
+{
+	char *unitptr = nullptr;
+	this->size = strtod(str.c_str(), &unitptr);
+
+	if (this->size <= 0)
+		this->size = 0;
+	this->unit = unitptr;
+}
 
 bool ParsedText::LengthValue::isValid()
 {
@@ -557,13 +553,13 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 		}
 
 		if (attrs.count("width")) {
-			int width = parse_length(attrs["width"]).getAbsoluteValue(m_element->font_size);
+			int width = LengthValue(attrs["width"]).getAbsoluteValue(m_element->font_size);
 			if (width > 0)
 				m_element->dim.Width = width;
 		}
 
 		if (attrs.count("height")) {
-			int height = parse_length(attrs["height"]).getAbsoluteValue(m_element->font_size);
+			int height = LengthValue(attrs["height"]).getAbsoluteValue(m_element->font_size);
 			if (height > 0)
 				m_element->dim.Height = height;
 		}
@@ -645,7 +641,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 		for (const auto &prop : (*tag)->style) {
 			if (prop.first == "fontsize") {
 				// resolve font size
-				font_size = parse_length(prop.second).getAbsoluteValue(font_size);
+				font_size = LengthValue(prop.second).getAbsoluteValue(font_size);
 			} else {
 				m_style[prop.first] = prop.second;
 			}

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -80,6 +80,7 @@ public:
 	{
 		double size;
 		std::string unit;
+		LengthValue(const std::string &str);
 		bool isValid();
 		bool isAbsolute();
 		double getAbsoluteValue();

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -98,6 +98,7 @@ public:
 		ValignType valign;
 
 		gui::IGUIFont *font;
+		unsigned int font_size;
 
 		irr::video::SColor color;
 		irr::video::SColor hovercolor;

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -76,6 +76,16 @@ public:
 	typedef std::unordered_map<std::string, std::string> StyleList;
 	typedef std::unordered_map<std::string, std::string> AttrsList;
 
+	struct LengthValue
+	{
+		double size;
+		std::string unit;
+		bool isValid();
+		bool isAbsolute();
+		double getAbsoluteValue();
+		double getAbsoluteValue(const double &em_size);
+	};
+
 	struct Tag
 	{
 		std::string name;

--- a/src/network/networkprotocol.h
+++ b/src/network/networkprotocol.h
@@ -246,7 +246,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
                             // base64-encoded SHA-1 (27+\0).
 
 // See also formspec [Version History] in doc/lua_api.md
-#define FORMSPEC_API_VERSION 7
+#define FORMSPEC_API_VERSION 8
 
 #define TEXTURENAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-"
 


### PR DESCRIPTION
This PR allows the use of `em` as a length unit in places where lengths are involved. 

- Goal of the PR
  Allow the use of `em` as a unit when specifying lengths.
- How does the PR work?
  Lengths are handled by a separate function on the client, which also reads the unit and uses this information to calculate the actual size.
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  2.3. UI Improvement.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  Among other things, this PR allows specifying the size of an image to be a constant factor of the font size, which is useful for e.g. icons.

## To do

This PR is Ready for Review.

- [x] Using `em`s as image size works.
- [x] Using `em`s as font size works.
- [x] `em`s scale text multiplicatively based on enclosing tags.
- [x] `em`s scale images multiplicatively based on enclosing tags.
- [x] Add documentation
- (What other length units should be added?)

## How to test
Check the "Hypertext" section of the test formspec.