### PR TITLE
Add Active Object Spatial Cache

### DIFF
--- a/irr/include/vector3d.h
+++ b/irr/include/vector3d.h
@@ -189,7 +189,7 @@ public:
 		return { X, Y, Z };
 	}
 
-	vector3d<T> min(const T min_component) const {
+	vector3d<T> component_clip_below(const T min_component) const {
 		return vector3d<T>(
 			std::min(X, min_component),
 			std::min(Y, min_component),
@@ -197,7 +197,7 @@ public:
 		);
 	}
 
-	vector3d<T> max(const T max_component) const {
+	vector3d<T> component_clip_above(const T max_component) const {
 		return vector3d<T>(
 			std::max(X, max_component),
 			std::max(Y, max_component),

--- a/irr/include/vector3d.h
+++ b/irr/include/vector3d.h
@@ -7,6 +7,7 @@
 #include "irrMath.h"
 
 #include <functional>
+#include <array>
 
 namespace irr
 {
@@ -32,6 +33,9 @@ public:
 	//! Constructor with the same value for all elements
 	explicit constexpr vector3d(T n) :
 			X(n), Y(n), Z(n) {}
+	//! Array - vector conversion
+	constexpr vector3d(const std::array<T, 3>& arr) :
+		X(arr[0]), Y(arr[1]), Z(arr[2]) {}
 
 	// operators
 
@@ -179,6 +183,26 @@ public:
 		Y = p.Y;
 		Z = p.Z;
 		return *this;
+	}
+
+	std::array<T, 3> toArray() const {
+		return { X, Y, Z };
+	}
+
+	vector3d<T> min(const T min_component) const {
+		return vector3d<T>(
+			std::min(X, min_component),
+			std::min(Y, min_component),
+			std::min(Z, min_component)
+		);
+	}
+
+	vector3d<T> max(const T max_component) const {
+		return vector3d<T>(
+			std::max(X, max_component),
+			std::max(Y, max_component),
+			std::max(Z, max_component)
+		);
 	}
 
 	//! Get length of the vector.

--- a/src/benchmark/benchmark_activeobjectmgr.cpp
+++ b/src/benchmark/benchmark_activeobjectmgr.cpp
@@ -105,7 +105,9 @@ void benchGetObjectsInArea(Catch::Benchmark::Chronometer &meter)
 TEST_CASE("ActiveObjectMgr") {
 	BENCH_INSIDE_RADIUS(200)
 	BENCH_INSIDE_RADIUS(1450)
+	BENCH_INSIDE_RADIUS(10000)
 
 	BENCH_IN_AREA(200)
 	BENCH_IN_AREA(1450)
+	BENCH_IN_AREA(10000)
 }

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -281,13 +281,15 @@ static void add_object_boxes(Environment *env,
 		}
 	};
 
-	// Calculate distance by speed, add own extent and 1.5m of tolerance
-	const f32 distance = speed_f.getLength() * dtime +
-		box_0.getExtent().getLength() + 1.5f * BS;
+	const f32 tolerance = 1.5f * BS; // TODO increase tolerance
 
 #ifndef SERVER
 	ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
 	if (c_env) {
+		// Calculate distance by speed, add own extent and 1.5m of tolerance
+		const f32 distance = speed_f.getLength() * dtime +
+			box_0.getExtent().getLength() + 1.5f * BS;
+
 		std::vector<DistanceSortedActiveObject> clientobjects;
 		c_env->getActiveObjects(pos_f, distance, clientobjects);
 
@@ -326,9 +328,14 @@ static void add_object_boxes(Environment *env,
 				return false;
 			};
 
+			// Calculate distance by speed, add own extent and tolerance
+			const v3f movement = speed_f * dtime;
+			const v3f min = pos_f + box_0.MinEdge - v3f(tolerance) + movement.min(0);
+			const v3f max = pos_f + box_0.MaxEdge + v3f(tolerance) + movement.max(0);
+
 			// nothing is put into this vector
 			std::vector<ServerActiveObject*> s_objects;
-			s_env->getObjectsInsideRadius(s_objects, pos_f, distance, include_obj_cb);
+			s_env->getObjectsInArea(s_objects, aabb3f(min, max), include_obj_cb);
 		}
 	}
 }

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -281,14 +281,14 @@ static void add_object_boxes(Environment *env,
 		}
 	};
 
-	const f32 tolerance = 1.5f * BS; // TODO increase tolerance
+	constexpr f32 tolerance = 1.5f * BS;
 
 #ifndef SERVER
 	ClientEnvironment *c_env = dynamic_cast<ClientEnvironment*>(env);
 	if (c_env) {
-		// Calculate distance by speed, add own extent and 1.5m of tolerance
+		// Calculate distance by speed, add own extent and tolerance
 		const f32 distance = speed_f.getLength() * dtime +
-			box_0.getExtent().getLength() + 1.5f * BS;
+			box_0.getExtent().getLength() + tolerance;
 
 		std::vector<DistanceSortedActiveObject> clientobjects;
 		c_env->getActiveObjects(pos_f, distance, clientobjects);
@@ -330,8 +330,8 @@ static void add_object_boxes(Environment *env,
 
 			// Calculate distance by speed, add own extent and tolerance
 			const v3f movement = speed_f * dtime;
-			const v3f min = pos_f + box_0.MinEdge - v3f(tolerance) + movement.min(0);
-			const v3f max = pos_f + box_0.MaxEdge + v3f(tolerance) + movement.max(0);
+			const v3f min = pos_f + box_0.MinEdge - v3f(tolerance) + movement.component_clip_below(0);
+			const v3f max = pos_f + box_0.MaxEdge + v3f(tolerance) + movement.component_clip_above(0);
 
 			// nothing is put into this vector
 			std::vector<ServerActiveObject*> s_objects;

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -8,6 +8,7 @@ set(server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/serveractiveobject.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serverinventorymgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serverlist.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/spatial_map.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/unit_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/rollback.cpp
 	PARENT_SCOPE)

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -34,6 +34,12 @@ ActiveObjectMgr::~ActiveObjectMgr()
 	}
 }
 
+void ActiveObjectMgr::clear()
+{
+	::ActiveObjectMgr<ServerActiveObject>::clear();
+	m_spatial_map.removeAll();
+}
+
 void ActiveObjectMgr::clearIf(const std::function<bool(ServerActiveObject *, u16)> &cb)
 {
 	for (auto &it : m_active_objects.iter()) {
@@ -41,6 +47,7 @@ void ActiveObjectMgr::clearIf(const std::function<bool(ServerActiveObject *, u16
 			continue;
 		if (cb(it.second.get(), it.first)) {
 			// Remove reference from m_active_objects
+			m_spatial_map.remove(it.first, it.second->getBasePosition());
 			m_active_objects.remove(it.first);
 		}
 	}
@@ -59,6 +66,11 @@ void ActiveObjectMgr::step(
 	}
 
 	g_profiler->avg("ActiveObjectMgr: SAO count [#]", count);
+}
+
+void ActiveObjectMgr::updateObjectPosition(u16 id, const v3f &last_position, const v3f &new_position)
+{
+	m_spatial_map.updatePosition(id, last_position, new_position);
 }
 
 bool ActiveObjectMgr::registerObject(std::unique_ptr<ServerActiveObject> obj)
@@ -92,6 +104,7 @@ bool ActiveObjectMgr::registerObject(std::unique_ptr<ServerActiveObject> obj)
 	}
 
 	auto obj_id = obj->getId();
+	m_spatial_map.insert(obj_id, obj->getBasePosition());
 	m_active_objects.put(obj_id, std::move(obj));
 
 	auto new_size = m_active_objects.size();
@@ -109,6 +122,13 @@ void ActiveObjectMgr::removeObject(u16 id)
 {
 	verbosestream << "Server::ActiveObjectMgr::removeObject(): "
 			<< "id=" << id << std::endl;
+
+	auto &obj = m_active_objects.get(id);
+	if(obj) {
+		m_spatial_map.remove(id, obj->getBasePosition());
+	} else {
+		m_spatial_map.remove(id);
+	}
 
 	// this will take the object out of the map and then destruct it
 	bool ok = m_active_objects.remove(id);
@@ -133,34 +153,42 @@ void ActiveObjectMgr::getObjectsInsideRadius(const v3f &pos, float radius,
 		std::function<bool(ServerActiveObject *obj)> include_obj_cb)
 {
 	float r2 = radius * radius;
-	for (auto &activeObject : m_active_objects.iter()) {
-		ServerActiveObject *obj = activeObject.second.get();
-		if (!obj)
-			continue;
+	aabb3f bounds(pos.X-radius, pos.Y-radius, pos.Z-radius, 
+			   pos.X+radius, pos.Y+radius, pos.Z+radius);
+
+	m_spatial_map.getRelevantObjectIds(bounds, [&](u16 id) {
+		auto obj = m_active_objects.get(id).get();
+		if (!obj) { // should never be hit
+			m_spatial_map.remove(id);
+			return;
+		}
 		const v3f &objectpos = obj->getBasePosition();
 		if (objectpos.getDistanceFromSQ(pos) > r2)
-			continue;
+			return;
 
 		if (!include_obj_cb || include_obj_cb(obj))
 			result.push_back(obj);
-	}
+	});
 }
 
 void ActiveObjectMgr::getObjectsInArea(const aabb3f &box,
 		std::vector<ServerActiveObject *> &result,
 		std::function<bool(ServerActiveObject *obj)> include_obj_cb)
 {
-	for (auto &activeObject : m_active_objects.iter()) {
-		ServerActiveObject *obj = activeObject.second.get();
-		if (!obj)
-			continue;
+	m_spatial_map.getRelevantObjectIds(box,[&](u16 id) {
+		auto obj = m_active_objects.get(id).get();
+		if (!obj) { // should never be hit
+			m_spatial_map.remove(id);
+			return;
+		}
+
 		const v3f &objectpos = obj->getBasePosition();
 		if (!box.isPointInside(objectpos))
-			continue;
+			return;
 
 		if (!include_obj_cb || include_obj_cb(obj))
 			result.push_back(obj);
-	}
+	});
 }
 
 void ActiveObjectMgr::getAddedActiveObjectsAroundPos(
@@ -177,24 +205,26 @@ void ActiveObjectMgr::getAddedActiveObjectsAroundPos(
 		- discard objects that are not observed by the player.
 		- add remaining objects to added_objects
 	*/
-	for (auto &ao_it : m_active_objects.iter()) {
-		u16 id = ao_it.first;
-
-		// Get object
-		ServerActiveObject *object = ao_it.second.get();
-		if (!object)
-			continue;
-
-		if (object->isGone())
-			continue;
-
-		f32 distance_f = object->getBasePosition().getDistanceFrom(player_pos);
-		if (object->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
+	f32 offset = radius > player_radius ? radius : player_radius;
+	aabb3f bounds(player_pos.X-offset, player_pos.Y-offset, player_pos.Z-offset, 
+			   player_pos.X+offset, player_pos.Y+offset, player_pos.Z+offset);
+	m_spatial_map.getRelevantObjectIds(bounds, [&](u16 id) {
+		auto obj = m_active_objects.get(id).get();
+		if (!obj) { // should never be hit
+			m_spatial_map.remove(id);
+			return;
+		}
+		if (obj->isGone()) {
+			return;
+		}
+		
+		f32 distance_f = obj->getBasePosition().getDistanceFrom(player_pos);
+		if (obj->getType() == ACTIVEOBJECT_TYPE_PLAYER) {
 			// Discard if too far
 			if (distance_f > player_radius && player_radius != 0)
-				continue;
+				return;
 		} else if (distance_f > radius)
-			continue;
+			return;
 
 		if (!object->isEffectivelyObservedBy(player_name))
 			continue;
@@ -202,10 +232,11 @@ void ActiveObjectMgr::getAddedActiveObjectsAroundPos(
 		// Discard if already on current_objects
 		auto n = current_objects.find(id);
 		if (n != current_objects.end())
-			continue;
+			return;
+
 		// Add to added_objects
 		added_objects.push_back(id);
-	}
+	});
 }
 
 } // namespace server

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -47,8 +47,7 @@ void ActiveObjectMgr::clearIf(const std::function<bool(ServerActiveObject *, u16
 			continue;
 		if (cb(it.second.get(), it.first)) {
 			// Remove reference from m_active_objects
-			m_spatial_map.remove(it.first, it.second->getBasePosition());
-			m_active_objects.remove(it.first);
+			removeObject(it.first);
 		}
 	}
 }
@@ -95,10 +94,10 @@ bool ActiveObjectMgr::registerObject(std::unique_ptr<ServerActiveObject> obj)
 		return false;
 	}
 
-	if (objectpos_over_limit(obj->getBasePosition())) {
-		v3f p = obj->getBasePosition();
+	const v3f pos = obj->getBasePosition();
+	if (objectpos_over_limit(pos)) {
 		warningstream << "Server::ActiveObjectMgr::addActiveObjectRaw(): "
-				<< "object position (" << p.X << "," << p.Y << "," << p.Z
+				<< "object position (" << pos.X << "," << pos.Y << "," << pos.Z
 				<< ") outside maximum range" << std::endl;
 		return false;
 	}

--- a/src/server/activeobjectmgr.h
+++ b/src/server/activeobjectmgr.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <vector>
 #include "../activeobjectmgr.h"
 #include "serveractiveobject.h"
+#include "spatial_map.h"
 
 namespace server
 {
@@ -35,8 +36,10 @@ public:
 	void clearIf(const std::function<bool(ServerActiveObject *, u16)> &cb);
 	void step(float dtime,
 			const std::function<void(ServerActiveObject *)> &f) override;
+	void clear();
 	bool registerObject(std::unique_ptr<ServerActiveObject> obj) override;
 	void removeObject(u16 id) override;
+	void updateObjectPosition(u16 id, const v3f &last_position, const v3f &new_position);
 
 	void invalidateActiveObjectObserverCaches();
 
@@ -51,5 +54,7 @@ public:
 			f32 radius, f32 player_radius,
 			const std::set<u16> &current_objects,
 			std::vector<u16> &added_objects);
+protected:
+	SpatialMap m_spatial_map;
 };
 } // namespace server

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -162,7 +162,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	// Each frame, parent position is copied if the object is attached, otherwise it's calculated normally
 	// If the object gets detached this comes into effect automatically from the last known origin
 	if (auto *parent = getParent()) {
-		m_base_position = parent->getBasePosition();
+		setBasePosition(parent->getBasePosition());
 		m_velocity = v3f(0,0,0);
 		m_acceleration = v3f(0,0,0);
 	} else {
@@ -171,7 +171,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			box.MinEdge *= BS;
 			box.MaxEdge *= BS;
 			f32 pos_max_d = BS*0.25; // Distance per iteration
-			v3f p_pos = m_base_position;
+			v3f p_pos = getBasePosition();
 			v3f p_velocity = m_velocity;
 			v3f p_acceleration = m_acceleration;
 			moveresult = collisionMoveSimple(m_env, m_env->getGameDef(),
@@ -181,11 +181,11 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 			moveresult_p = &moveresult;
 
 			// Apply results
-			m_base_position = p_pos;
+			setBasePosition(p_pos);
 			m_velocity = p_velocity;
 			m_acceleration = p_acceleration;
 		} else {
-			m_base_position += (m_velocity + m_acceleration * 0.5f * dtime) * dtime;
+			setBasePosition(getBasePosition() + (m_velocity + m_acceleration * 0.5f * dtime) * dtime);
 			m_velocity += dtime * m_acceleration;
 		}
 
@@ -228,7 +228,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 		} else if(m_last_sent_position_timer > 0.2){
 			minchange = 0.05*BS;
 		}
-		float move_d = m_base_position.getDistanceFrom(m_last_sent_position);
+		float move_d = getBasePosition().getDistanceFrom(m_last_sent_position);
 		move_d += m_last_sent_move_precision;
 		float vel_d = m_velocity.getDistanceFrom(m_last_sent_velocity);
 		if (move_d > minchange || vel_d > minchange ||
@@ -252,7 +252,7 @@ std::string LuaEntitySAO::getClientInitializationData(u16 protocol_version)
 	os << serializeString16(m_init_name); // name
 	writeU8(os, 0); // is_player
 	writeU16(os, getId()); //id
-	writeV3F32(os, m_base_position);
+	writeV3F32(os, getBasePosition());
 	writeV3F32(os, m_rotation);
 	writeU16(os, m_hp);
 
@@ -381,7 +381,7 @@ void LuaEntitySAO::setPos(const v3f &pos)
 {
 	if(isAttached())
 		return;
-	m_base_position = pos;
+	setBasePosition(pos);
 	sendPosition(false, true);
 }
 
@@ -389,7 +389,7 @@ void LuaEntitySAO::moveTo(v3f pos, bool continuous)
 {
 	if(isAttached())
 		return;
-	m_base_position = pos;
+	setBasePosition(pos);
 	if(!continuous)
 		sendPosition(true, true);
 }
@@ -403,7 +403,7 @@ std::string LuaEntitySAO::getDescription()
 {
 	std::ostringstream oss;
 	oss << "LuaEntitySAO \"" << m_init_name << "\" ";
-	auto pos = floatToInt(m_base_position, BS);
+	auto pos = floatToInt(getBasePosition(), BS);
 	oss << "at " << pos;
 	return oss.str();
 }
@@ -519,10 +519,10 @@ void LuaEntitySAO::sendPosition(bool do_interpolate, bool is_movement_end)
 	// Send attachment updates instantly to the client prior updating position
 	sendOutdatedData();
 
-	m_last_sent_move_precision = m_base_position.getDistanceFrom(
+	m_last_sent_move_precision = getBasePosition().getDistanceFrom(
 			m_last_sent_position);
 	m_last_sent_position_timer = 0;
-	m_last_sent_position = m_base_position;
+	m_last_sent_position = getBasePosition();
 	m_last_sent_velocity = m_velocity;
 	//m_last_sent_acceleration = m_acceleration;
 	m_last_sent_rotation = m_rotation;
@@ -530,7 +530,7 @@ void LuaEntitySAO::sendPosition(bool do_interpolate, bool is_movement_end)
 	float update_interval = m_env->getSendRecommendedInterval();
 
 	std::string str = generateUpdatePositionCommand(
-		m_base_position,
+		getBasePosition(),
 		m_velocity,
 		m_acceleration,
 		m_rotation,
@@ -550,8 +550,8 @@ bool LuaEntitySAO::getCollisionBox(aabb3f *toset) const
 		toset->MinEdge = m_prop.collisionbox.MinEdge * BS;
 		toset->MaxEdge = m_prop.collisionbox.MaxEdge * BS;
 
-		toset->MinEdge += m_base_position;
-		toset->MaxEdge += m_base_position;
+		toset->MinEdge += getBasePosition();
+		toset->MaxEdge += getBasePosition();
 
 		return true;
 	}

--- a/src/server/luaentity_sao.h
+++ b/src/server/luaentity_sao.h
@@ -40,7 +40,7 @@ public:
 	ActiveObjectType getType() const { return ACTIVEOBJECT_TYPE_LUAENTITY; }
 	ActiveObjectType getSendType() const { return ACTIVEOBJECT_TYPE_GENERIC; }
 	virtual void addedToEnvironment(u32 dtime_s);
-	void step(float dtime, bool send_recommended);
+	void step(float dtime, bool send_recommended) override;
 	std::string getClientInitializationData(u16 protocol_version);
 
 	bool isStaticAllowed() const { return m_prop.static_save; }

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -86,11 +86,11 @@ std::string PlayerSAO::getDescription()
 void PlayerSAO::addedToEnvironment(u32 dtime_s)
 {
 	ServerActiveObject::addedToEnvironment(dtime_s);
-	ServerActiveObject::setBasePosition(m_base_position);
+	ServerActiveObject::setBasePosition(getBasePosition());
 	m_player->setPlayerSAO(this);
 	m_player->setPeerId(m_peer_id_initial);
 	m_peer_id_initial = PEER_ID_INEXISTENT; // don't try to use it again.
-	m_last_good_position = m_base_position;
+	m_last_good_position = getBasePosition();
 }
 
 // Called before removing from environment
@@ -116,7 +116,7 @@ std::string PlayerSAO::getClientInitializationData(u16 protocol_version)
 	os << serializeString16(m_player->getName()); // name
 	writeU8(os, 1); // is_player
 	writeS16(os, getId()); // id
-	writeV3F32(os, m_base_position);
+	writeV3F32(os, getBasePosition());
 	writeV3F32(os, m_rotation);
 	writeU16(os, getHP());
 
@@ -195,7 +195,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		// Sequence of damage points, starting 0.1 above feet and progressing
 		// upwards in 1 node intervals, stopping below top damage point.
 		for (float dam_height = 0.1f; dam_height < dam_top; dam_height++) {
-			v3s16 p = floatToInt(m_base_position +
+			v3s16 p = floatToInt(getBasePosition() +
 				v3f(0.0f, dam_height * BS, 0.0f), BS);
 			MapNode n = m_env->getMap().getNode(p);
 			const ContentFeatures &c = m_env->getGameDef()->ndef()->get(n);
@@ -207,7 +207,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		}
 
 		// Top damage point
-		v3s16 ptop = floatToInt(m_base_position +
+		v3s16 ptop = floatToInt(getBasePosition() +
 			v3f(0.0f, dam_top * BS, 0.0f), BS);
 		MapNode ntop = m_env->getMap().getNode(ptop);
 		const ContentFeatures &c = m_env->getGameDef()->ndef()->get(ntop);
@@ -284,7 +284,7 @@ void PlayerSAO::step(float dtime, bool send_recommended)
 		if (isAttached())
 			pos = m_last_good_position;
 		else
-			pos = m_base_position;
+			pos = getBasePosition();
 
 		std::string str = generateUpdatePositionCommand(
 			pos,
@@ -341,9 +341,9 @@ std::string PlayerSAO::generateUpdatePhysicsOverrideCommand() const
 	return os.str();
 }
 
-void PlayerSAO::setBasePosition(v3f position)
+void PlayerSAO::setBasePosition(const v3f &position)
 {
-	if (m_player && position != m_base_position)
+	if (m_player && position != getBasePosition())
 		m_player->setDirty(true);
 
 	// This needs to be ran for attachments too
@@ -396,7 +396,7 @@ void PlayerSAO::addPos(const v3f &added_pos)
 	m_env->getGameDef()->SendMovePlayerRel(getPeerID(), added_pos);
 }
 
-void PlayerSAO::moveTo(v3f pos, bool continuous)
+void PlayerSAO::moveTo(const v3f &pos, bool continuous)
 {
 	if(isAttached())
 		return;
@@ -628,7 +628,7 @@ bool PlayerSAO::checkMovementCheat()
 	if (m_is_singleplayer ||
 			isAttached() ||
 			g_settings->getBool("disable_anticheat")) {
-		m_last_good_position = m_base_position;
+		m_last_good_position = getBasePosition();
 		return false;
 	}
 
@@ -693,7 +693,7 @@ bool PlayerSAO::checkMovementCheat()
 	if (player_max_jump < 0.0001f)
 		player_max_jump = 0.0001f;
 
-	v3f diff = (m_base_position - m_last_good_position);
+	v3f diff = (getBasePosition() - m_last_good_position);
 	float d_vert = diff.Y;
 	diff.Y = 0;
 	float d_horiz = diff.getLength();
@@ -709,7 +709,7 @@ bool PlayerSAO::checkMovementCheat()
 	}
 
 	if (m_move_pool.grab(required_time)) {
-		m_last_good_position = m_base_position;
+		m_last_good_position = getBasePosition();
 	} else {
 		const float LAG_POOL_MIN = 5.0;
 		float lag_pool_max = m_env->getMaxLagEstimate() * 2.0;
@@ -731,8 +731,8 @@ bool PlayerSAO::getCollisionBox(aabb3f *toset) const
 	toset->MinEdge = m_prop.collisionbox.MinEdge * BS;
 	toset->MaxEdge = m_prop.collisionbox.MaxEdge * BS;
 
-	toset->MinEdge += m_base_position;
-	toset->MaxEdge += m_base_position;
+	toset->MinEdge += getBasePosition();
+	toset->MaxEdge += getBasePosition();
 	return true;
 }
 

--- a/src/server/player_sao.h
+++ b/src/server/player_sao.h
@@ -88,10 +88,10 @@ public:
 	std::string getClientInitializationData(u16 protocol_version) override;
 	void getStaticData(std::string *result) const override;
 	void step(float dtime, bool send_recommended) override;
-	void setBasePosition(v3f position);
+	void setBasePosition(const v3f &position);
 	void setPos(const v3f &pos) override;
 	void addPos(const v3f &added_pos) override;
-	void moveTo(v3f pos, bool continuous) override;
+	void moveTo(const v3f &pos, bool continuous) override;
 	void setPlayerYaw(const float yaw);
 	// Data should not be sent at player initialization
 	void setPlayerYawAndSend(const float yaw);
@@ -182,7 +182,7 @@ public:
 
 	void finalize(RemotePlayer *player, const std::set<std::string> &privs);
 
-	v3f getEyePosition() const { return m_base_position + getEyeOffset(); }
+	v3f getEyePosition() const { return getBasePosition() + getEyeOffset(); }
 	v3f getEyeOffset() const;
 	float getZoomFOV() const;
 

--- a/src/server/serveractiveobject.cpp
+++ b/src/server/serveractiveobject.cpp
@@ -18,6 +18,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include "serveractiveobject.h"
+#include "serverenvironment.h"
 #include "inventory.h"
 #include "inventorymanager.h"
 #include "constants.h" // BS
@@ -27,6 +28,12 @@ ServerActiveObject::ServerActiveObject(ServerEnvironment *env, v3f pos):
 	m_env(env),
 	m_base_position(pos)
 {
+}
+
+void ServerActiveObject::setBasePosition(const v3f &pos) {
+	if(getEnv())
+		getEnv()->updateObjectPosition(getId(), m_base_position, pos);
+	m_base_position = pos;
 }
 
 float ServerActiveObject::getMinimumSavedMovement()

--- a/src/server/serveractiveobject.cpp
+++ b/src/server/serveractiveobject.cpp
@@ -31,7 +31,8 @@ ServerActiveObject::ServerActiveObject(ServerEnvironment *env, v3f pos):
 }
 
 void ServerActiveObject::setBasePosition(const v3f &pos) {
-	if(getEnv())
+	bool changed = m_base_position != pos;
+	if (changed && getEnv())
 		getEnv()->updateObjectPosition(getId(), m_base_position, pos);
 	m_base_position = pos;
 }

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -78,7 +78,7 @@ public:
 		Some simple getters/setters
 	*/
 	v3f getBasePosition() const { return m_base_position; }
-	void setBasePosition(v3f pos){ m_base_position = pos; }
+	void setBasePosition(const v3f &pos);
 	ServerEnvironment* getEnv(){ return m_env; }
 
 	/*
@@ -88,9 +88,9 @@ public:
 	virtual void setPos(const v3f &pos)
 		{ setBasePosition(pos); }
 	virtual void addPos(const v3f &added_pos)
-		{ setBasePosition(m_base_position + added_pos); }
+		{ setBasePosition(getBasePosition() + added_pos); }
 	// continuous: if true, object does not stop immediately at pos
-	virtual void moveTo(v3f pos, bool continuous)
+	virtual void moveTo(const v3f &pos, bool continuous)
 		{ setBasePosition(pos); }
 	// If object has moved less than this and data has not changed,
 	// saving to disk may be omitted
@@ -260,7 +260,6 @@ protected:
 	virtual void onMarkedForRemoval() {}
 
 	ServerEnvironment *m_env;
-	v3f m_base_position;
 	std::unordered_set<u32> m_attached_particle_spawners;
 
 	/*
@@ -288,4 +287,6 @@ protected:
 		Queue of messages to be sent to the client
 	*/
 	std::queue<ActiveObjectMessage> m_messages_out;
+private:
+	v3f m_base_position; // setBasePosition updates index and MUST be called
 };

--- a/src/server/spatial_map.cpp
+++ b/src/server/spatial_map.cpp
@@ -1,0 +1,167 @@
+/*
+Minetest
+Copyright (C) 2024, ExeVirus <nodecastmt@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "spatial_map.h"
+#include <algorithm>
+
+namespace server
+{
+
+// all inserted entires go into the uncached vector
+void SpatialMap::insert(u16 id, const v3f &pos, bool postIteration)
+{
+	if(!m_iterators_stopping_insertion_and_deletion) {
+		SpatialKey key(pos);
+		if (postIteration)
+			key = SpatialKey(pos.X, pos.Y, pos.Z, true);
+		m_cached.insert({key, id});
+	} else {
+		m_pending_inserts.insert(SpatialKey(pos,id));
+	}
+}
+
+// Invalidates upon position update
+void SpatialMap::updatePosition(u16 id, const v3f &oldPos, const v3f &newPos)
+{
+	// Try to leave early if already in the same bucket:
+	auto range = m_cached.equal_range(SpatialKey(newPos));
+	for (auto it = range.first; it != range.second; ++it) {
+		if (it->second == id) {
+			return; // all good, let's get out of here
+		}
+	}
+
+	remove(id, oldPos); // remove from old cache position
+	insert(id, newPos); // reinsert
+}
+
+void SpatialMap::remove(u16 id, const v3f &pos, bool postIteration)
+{
+	if(!m_iterators_stopping_insertion_and_deletion) {
+		SpatialKey key(pos);
+		if (postIteration)
+			key = SpatialKey(pos.X, pos.Y, pos.Z, true);
+		if(m_cached.find(key) != m_cached.end()) {
+			auto range = m_cached.equal_range(key);
+			for (auto it = range.first; it != range.second; ++it) {
+				if (it->second == id) {
+					m_cached.erase(it);
+					return; // Erase and leave early
+				}
+			}
+		}
+	} else {
+		m_pending_deletes.insert(SpatialKey(pos, id));
+		return;
+	}
+	remove(id); // should never be hit
+}
+
+void SpatialMap::remove(u16 id)
+{
+	if(!m_iterators_stopping_insertion_and_deletion) {
+		for (auto it = m_cached.begin(); it != m_cached.end(); ++it) {
+			if (it->second == id) {
+				m_cached.erase(it);
+				break; // Erase and leave early
+			}
+		}
+	} else {
+		m_pending_deletes.insert(SpatialKey(v3f(), id));
+	}
+}
+
+void SpatialMap::removeAll()
+{
+	if(!m_iterators_stopping_insertion_and_deletion) {
+		m_cached.clear();
+	} else {
+		m_remove_all = true;
+	}
+}
+
+void SpatialMap::getRelevantObjectIds(const aabb3f &box, const std::function<void(u16 id)> &callback)
+{
+	if(!m_cached.empty()) {
+		// when searching, we must round to maximum extent of relevant mapblock indexes
+		auto low = [](f32 val) -> s16 {
+			s16 _val = static_cast<s16>(val / BS);
+			return (_val >> 4) - 1;
+		};
+		auto high = [](f32 val) -> s16 {
+			s16 _val = static_cast<s16>(val / BS);
+			return (_val >> 4) + 1;
+		};
+
+		v3s16 min(low(box.MinEdge.X), low(box.MinEdge.Y), low(box.MinEdge.Z)),
+			max(high(box.MaxEdge.X), high(box.MaxEdge.Y), high(box.MaxEdge.Z));
+		
+		// We should only iterate using this spatial map when there are at least 1 objects per mapblocks to check.
+		// Otherwise, might as well just iterate.
+
+		v3s16 diff = max - min;
+		uint64_t number_of_mapblocks_to_check = std::abs(diff.X) * std::abs(diff.Y) * std::abs(diff.Z);
+		if(number_of_mapblocks_to_check <= m_cached.size()) { // might be worth it
+			for (s16 x = min.X; x < max.X;x++) {
+				for (s16 y = min.Y; y < max.Y;y++) {
+					for (s16 z = min.Z; z < max.Z;z++) {
+						SpatialKey key(x,y,z, false);
+						if (m_cached.find(key) != m_cached.end()) {
+							m_iterators_stopping_insertion_and_deletion++;
+							auto range = m_cached.equal_range(key);
+							for (auto &it = range.first; it != range.second; ++it) {
+								callback(it->second);
+							}
+							m_iterators_stopping_insertion_and_deletion--;
+							handleInsertsAndDeletes();
+						}
+					}
+				}
+			}
+		} else { // let's just iterate, it'll be faster
+			m_iterators_stopping_insertion_and_deletion++;
+			for (auto it = m_cached.begin(); it != m_cached.end(); ++it) {
+				callback(it->second);
+			}
+			m_iterators_stopping_insertion_and_deletion--;
+			handleInsertsAndDeletes();
+		}
+	}
+}
+
+void SpatialMap::handleInsertsAndDeletes()
+{
+	if(!m_iterators_stopping_insertion_and_deletion) {
+		if(!m_remove_all) {
+			for (auto key : m_pending_deletes) {
+				remove(key.padding_or_optional_id, v3f(key.x, key.y, key.z), true);
+			}
+			for (auto key : m_pending_inserts) {
+				insert(key.padding_or_optional_id, v3f(key.x, key.y, key.z), true);
+			}
+		} else {
+			m_cached.clear();
+			m_remove_all = false;
+		}
+		m_pending_inserts.clear();
+		m_pending_deletes.clear();
+	}
+}
+
+} // namespace server

--- a/src/server/spatial_map.cpp
+++ b/src/server/spatial_map.cpp
@@ -26,14 +26,15 @@ namespace server
 // all inserted entires go into the uncached vector
 void SpatialMap::insert(u16 id, const v3f &pos, bool postIteration)
 {
-	if(!m_iterators_stopping_insertion_and_deletion) {
-		SpatialKey key(pos);
-		if (postIteration)
-			key = SpatialKey(pos.X, pos.Y, pos.Z, true);
-		m_cached.insert({key, id});
-	} else {
-		m_pending_inserts.insert(SpatialKey(pos,id));
+	if (m_iterators_stopping_insertion_and_deletion) {
+		m_pending_inserts.insert(SpatialKey(pos, id));
+		return;
 	}
+
+	SpatialKey key(pos);
+	if (postIteration)
+		key = SpatialKey(pos.X, pos.Y, pos.Z, true);
+	m_cached.insert({key, id});
 }
 
 // Invalidates upon position update
@@ -53,115 +54,119 @@ void SpatialMap::updatePosition(u16 id, const v3f &oldPos, const v3f &newPos)
 
 void SpatialMap::remove(u16 id, const v3f &pos, bool postIteration)
 {
-	if(!m_iterators_stopping_insertion_and_deletion) {
-		SpatialKey key(pos);
-		if (postIteration)
-			key = SpatialKey(pos.X, pos.Y, pos.Z, true);
-		if(m_cached.find(key) != m_cached.end()) {
-			auto range = m_cached.equal_range(key);
-			for (auto it = range.first; it != range.second; ++it) {
-				if (it->second == id) {
-					m_cached.erase(it);
-					return; // Erase and leave early
-				}
-			}
-		}
-	} else {
+	if (m_iterators_stopping_insertion_and_deletion) {
 		m_pending_deletes.insert(SpatialKey(pos, id));
 		return;
 	}
+
+	SpatialKey key(pos);
+	if (postIteration)
+		key = SpatialKey(pos.X, pos.Y, pos.Z, true);
+	if(m_cached.find(key) != m_cached.end()) {
+		auto range = m_cached.equal_range(key);
+		for (auto it = range.first; it != range.second; ++it) {
+			if (it->second == id) {
+				m_cached.erase(it);
+				return; // Erase and leave early
+			}
+		}
+	}
+
 	remove(id); // should never be hit
 }
 
 void SpatialMap::remove(u16 id)
 {
-	if(!m_iterators_stopping_insertion_and_deletion) {
-		for (auto it = m_cached.begin(); it != m_cached.end(); ++it) {
-			if (it->second == id) {
-				m_cached.erase(it);
-				break; // Erase and leave early
-			}
-		}
-	} else {
+	if(m_iterators_stopping_insertion_and_deletion) {
 		m_pending_deletes.insert(SpatialKey(v3f(), id));
+		return;
+	}
+
+	for (auto it = m_cached.begin(); it != m_cached.end(); ++it) {
+		if (it->second == id) {
+			m_cached.erase(it);
+			return; // Erase and leave early
+		}
 	}
 }
 
 void SpatialMap::removeAll()
 {
-	if(!m_iterators_stopping_insertion_and_deletion) {
-		m_cached.clear();
-	} else {
+	if(m_iterators_stopping_insertion_and_deletion) {
 		m_remove_all = true;
+	} else {
+		m_cached.clear();
 	}
 }
 
 void SpatialMap::getRelevantObjectIds(const aabb3f &box, const std::function<void(u16 id)> &callback)
 {
-	if(!m_cached.empty()) {
-		// when searching, we must round to maximum extent of relevant mapblock indexes
-		auto low = [](f32 val) -> s16 {
-			s16 _val = static_cast<s16>(val / BS);
-			return (_val >> 4) - 1;
-		};
-		auto high = [](f32 val) -> s16 {
-			s16 _val = static_cast<s16>(val / BS);
-			return (_val >> 4) + 1;
-		};
+	if (m_cached.empty()) return;
 
-		v3s16 min(low(box.MinEdge.X), low(box.MinEdge.Y), low(box.MinEdge.Z)),
-			max(high(box.MaxEdge.X), high(box.MaxEdge.Y), high(box.MaxEdge.Z));
+	// When searching, we must round to maximum extent of relevant mapblock indexes.
+	// Since we're using floats, always assume +-1
+	auto low = [](f32 val) -> s16 {
+		s16 _val = static_cast<s16>(val / BS);
+		return (_val >> 4) - 1;
+	};
+	auto high = [](f32 val) -> s16 {
+		s16 _val = static_cast<s16>(val / BS);
+		return (_val >> 4) + 1;
+	};
+
+	v3s16 min(low(box.MinEdge.X), low(box.MinEdge.Y), low(box.MinEdge.Z)),
+		max(high(box.MaxEdge.X), high(box.MaxEdge.Y), high(box.MaxEdge.Z));
 		
-		// We should only iterate using this spatial map when there are at least 1 objects per mapblocks to check.
-		// Otherwise, might as well just iterate.
+	// We should only iterate using this spatial map when there are at least 1 objects per mapblocks to check.
+	// Otherwise, might as well just iterate.
 
-		v3s16 diff = max - min;
-		uint64_t number_of_mapblocks_to_check = std::abs(diff.X) * std::abs(diff.Y) * std::abs(diff.Z);
-		if(number_of_mapblocks_to_check <= m_cached.size()) { // might be worth it
-			for (s16 x = min.X; x < max.X;x++) {
-				for (s16 y = min.Y; y < max.Y;y++) {
-					for (s16 z = min.Z; z < max.Z;z++) {
-						SpatialKey key(x,y,z, false);
-						if (m_cached.find(key) != m_cached.end()) {
-							m_iterators_stopping_insertion_and_deletion++;
-							auto range = m_cached.equal_range(key);
-							for (auto &it = range.first; it != range.second; ++it) {
-								callback(it->second);
-							}
-							m_iterators_stopping_insertion_and_deletion--;
-							handleInsertsAndDeletes();
+	v3s16 diff = max - min;
+	uint64_t number_of_mapblocks_to_check = std::abs(diff.X) * std::abs(diff.Y) * std::abs(diff.Z);
+	if(number_of_mapblocks_to_check <= m_cached.size()) { // might be worth it
+		for (s16 x = min.X; x < max.X;x++) {
+			for (s16 y = min.Y; y < max.Y;y++) {
+				for (s16 z = min.Z; z < max.Z;z++) {
+					SpatialKey key(x,y,z, false);
+					if (m_cached.find(key) != m_cached.end()) {
+						m_iterators_stopping_insertion_and_deletion++;
+						auto range = m_cached.equal_range(key);
+						for (auto &it = range.first; it != range.second; ++it) {
+							callback(it->second);
 						}
+						m_iterators_stopping_insertion_and_deletion--;
+						handleInsertsAndDeletes();
 					}
 				}
 			}
-		} else { // let's just iterate, it'll be faster
-			m_iterators_stopping_insertion_and_deletion++;
-			for (auto it = m_cached.begin(); it != m_cached.end(); ++it) {
-				callback(it->second);
-			}
-			m_iterators_stopping_insertion_and_deletion--;
-			handleInsertsAndDeletes();
 		}
+	} else { // let's just iterate, it'll be faster
+		m_iterators_stopping_insertion_and_deletion++;
+		for (auto it = m_cached.begin(); it != m_cached.end(); ++it) {
+			callback(it->second);
+		}
+		m_iterators_stopping_insertion_and_deletion--;
+		handleInsertsAndDeletes();
 	}
 }
 
 void SpatialMap::handleInsertsAndDeletes()
 {
-	if(!m_iterators_stopping_insertion_and_deletion) {
-		if(!m_remove_all) {
-			for (auto key : m_pending_deletes) {
-				remove(key.padding_or_optional_id, v3f(key.x, key.y, key.z), true);
-			}
-			for (auto key : m_pending_inserts) {
-				insert(key.padding_or_optional_id, v3f(key.x, key.y, key.z), true);
-			}
-		} else {
-			m_cached.clear();
-			m_remove_all = false;
+	if (m_iterators_stopping_insertion_and_deletion)
+		return;
+	
+	if(!m_remove_all) {
+		for (auto key : m_pending_deletes) {
+			remove(key.padding_or_optional_id, v3f(key.x, key.y, key.z), true);
 		}
-		m_pending_inserts.clear();
-		m_pending_deletes.clear();
+		for (auto key : m_pending_inserts) {
+			insert(key.padding_or_optional_id, v3f(key.x, key.y, key.z), true);
+		}
+	} else {
+		m_cached.clear();
+		m_remove_all = false;
 	}
+	m_pending_inserts.clear();
+	m_pending_deletes.clear();
 }
 
 } // namespace server

--- a/src/server/spatial_map.h
+++ b/src/server/spatial_map.h
@@ -1,0 +1,83 @@
+/*
+Minetest
+Copyright (C) 2024, ExeVirus <nodecastmt@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include <functional>
+#include <vector>
+#include <unordered_set>
+#include "irrlichttypes_bloated.h"
+#include "constants.h"
+
+namespace server
+{
+class SpatialMap
+{
+public:
+	void insert(u16 id, const v3f &pos, bool postIteration = false);
+	void remove(u16 id, const v3f &pos, bool postIteration = false);
+	void remove(u16 id);
+	void removeAll();
+	void updatePosition(u16 id, const v3f &oldPos, const v3f &newPos);
+	void getRelevantObjectIds(const aabb3f &box, const std::function<void(u16 id)> &callback);
+	void handleInsertsAndDeletes();
+
+protected:
+	struct SpatialKey {
+		u16 padding_or_optional_id{0};
+		s16 x;
+		s16 y;
+		s16 z;
+
+		SpatialKey(s16 _x, s16 _y, s16 _z, bool _shrink = true) {
+			if(_shrink) {
+				x = _x >> 4;
+				y = _y >> 4;
+				z = _z >> 4;
+			} else {
+				x = _x;
+				y = _y;
+				z = _z;
+			}
+		}
+		SpatialKey(const v3f &_pos) : SpatialKey(_pos.X / BS, _pos.Y / BS, _pos.Z / BS){}
+		// The following use case is for storing pending insertions and deletions while iterating
+		// using the extra 16 bit padding makes keeping track of them super efficient for hashing.
+		SpatialKey(const v3f &_pos, const u16 id) : SpatialKey(_pos.X / BS, _pos.Y / BS, _pos.Z / BS, false){
+			padding_or_optional_id = id;
+		}
+
+		bool operator==(const SpatialKey &other) const {
+			return (x == other.x && y == other.y && z == other.z);
+		}
+	};
+
+	struct SpatialKeyHash {
+		auto operator()(const SpatialKey &key) const -> size_t {
+			return std::hash<size_t>()(*reinterpret_cast<const size_t*>(&key));
+		}
+	};
+
+	std::unordered_multimap<SpatialKey, u16, SpatialKeyHash> m_cached;
+	std::unordered_set<SpatialKey, SpatialKeyHash> m_pending_inserts;
+	std::unordered_set<SpatialKey, SpatialKeyHash> m_pending_deletes;
+	bool m_remove_all{false};
+	u64 m_iterators_stopping_insertion_and_deletion{0};
+};
+} // namespace server

--- a/src/server/spatial_map.h
+++ b/src/server/spatial_map.h
@@ -65,6 +65,8 @@ protected:
 		}
 	};
 
+	static_assert(sizeof(SpatialKey) == sizeof(u64), "SpatialKey must align with 8 bytes, i.e. uint64_t");
+
 	struct SpatialKeyHash {
 		auto operator()(const SpatialKey& key) const -> u64 {
 			return std::hash<u64>()(*reinterpret_cast<const u64*>(&key));

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -1886,10 +1886,12 @@ void ServerEnvironment::getSelectedActiveObjects(
 		return false;
 	};
 
+	aabb3f search_area(shootline_on_map.start - 5 * BS, shootline_on_map.end + 5 * BS);
+	search_area.repair();
+
 	// Use "logic in callback" pattern to avoid useless vector filling
 	std::vector<ServerActiveObject*> tmp;
-	getObjectsInsideRadius(tmp, shootline_on_map.getMiddle(),
-		0.5 * shootline_on_map.getLength() + 5 * BS, process);
+	getObjectsInArea(tmp, search_area, process);
 }
 
 /*

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -350,6 +350,11 @@ public:
 		return m_ao_manager.getObjectsInArea(box, objects, include_obj_cb);
 	}
 
+	void updateObjectPosition(u16 id, const v3f &last_position, const v3f &new_position)
+	{
+		m_ao_manager.updateObjectPosition(id, last_position, new_position);
+	}
+
 	// Clear objects, loading and going through every MapBlock
 	void clearObjects(ClearObjectsMode mode);
 


### PR DESCRIPTION
This PR adds a simple cache to server active objects (SAOs) based on position. This PR was made to solve the problem outlined in #14613, hoping to improve by orders of magnitude our ability to handle more entities in Minetest, and to make more performant ways to get objects in a given area/radius. 

This directly addresses [section 2.4](https://github.com/minetest/minetest/blob/master/doc/direction.md#24-object-and-entity-improvements) of the current roadmap for minetest. It specifically calls out the old version of the issue this task tries to address.

The implementation is best described as a single-layer of buckets implemented using unordered_multimap, which is a fancy term for "It's sorts entities into buckets the same size as mapblocks (16x16x16)". When you ask for entities in a given area/radius, this map allows you to filter out the vast majority of irrelevant entities. 

## Performance: 

- 2-5x faster inArea and inRadius lookups, for most games/servers
- inArea is now slightly more performant than inRadius checks, depending on entity dispersal
- If all your 1000 entities are in a single mapblock (16x16x16): this map doesn't help you.

#### Areas where the cache is integrated in this PR:
- getObjectsInRadius
- getObjectsInArea
- getAddedActiveObjects
- getSelectedActiveObjects
- collisions

### Builtin Benchmarking

![image](https://github.com/minetest/minetest/assets/44562154/5ec5a0ee-b6cc-4518-8f87-424fcf7692bb)

## To do: Done

- [x] Create performant, simple position based data structure 
- [x] Add benchmarks to verify exactly what the tradeoffs are of this versus current master
- [x] Perform side-by-side benchmarking metrics
- [x] Create initial PR to get code cleaned up for merge
- [x] Integrate new cache with server::ActiveObjectManager
- [x] Ensure cache is updated on every entity move, insertion, and deletion.
- [x] Integrate cache capabilities throughout Minetest, such as helping with per-client SAO updates, etc.
- [x] Make code to match Minetest style guidelines, and integrate into the proper C++ files in the engine
- [x] Run with a full test server to verify nothing is broken (beyond unit tests already performed)  

## How to test

#### benchmarking:
1. Enable benchmarking in your c++ cmake settings
2. Build
3. run minetest.exe --run-benchmarks
4. checkout master, and bring over this branch's benchmark_activeobjectmgr.cpp for A to B comparison
5. recompile
6. run minetest.exe --run-benchmarks

## Stability/Correctness

####  Stable and Validated
I have done extensive testing using a pseudorandom test function that tests insertion and removal of SAO's during iteration through SAOs, as well as testing inRadius and inArea checks and moving all found entities, and veriified that master and this branch have identical results for all steps after 20x200 iterations of 1000 entities. That function for your review is [here](https://github.com/ExeVirus/minetest/blob/a78f7b8c6ed37c92ef47fb78965120e8eb7ea410/src/benchmark/benchmark_activeobjectmgr.cpp#L102) Note that I am *not* advocating its inclusion; it's only useful for this one core change and not much thereafter. 

#### Slight Difference compared to master

Using this new spatial map, when we iterate over entities during an inArea or inRadius search, it is now possible for some (not all) entities that are added *during iteration* to be found *within the current search iteration*. Future work may want to take this some steps further to guarantee all added objects are checked for the current search iteration, and that may be a solution to #14614. That is future work, however. 


