### PR TITLE
Rewrite pkgmgr and contentdb in C++

### DIFF
--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -241,11 +241,6 @@ function pkgmgr.get_base_folder(temppath)
 end
 
 --------------------------------------------------------------------------------
-function pkgmgr.is_valid_modname(modpath)
-	return modpath:match("[^a-z0-9_]") == nil
-end
-
---------------------------------------------------------------------------------
 --- @param render_list filterlist
 --- @param use_technical_names boolean to show technical names instead of human-readable titles
 --- @param with_icon table or nil, from virtual path to icon object

--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -101,7 +101,6 @@ local function load_texture_packs(txtpath, retval)
 end
 
 --modmanager implementation
-pkgmgr = {}
 
 --- Scans a directory recursively for mods and adds them to `listing`
 -- @param path         Absolute directory path to scan recursively
@@ -215,41 +214,6 @@ function pkgmgr.get_all()
 	end
 
 	return result
-end
-
---------------------------------------------------------------------------------
-function pkgmgr.get_folder_type(path)
-	local testfile = io.open(path .. DIR_DELIM .. "init.lua","r")
-	if testfile ~= nil then
-		testfile:close()
-		return { type = "mod", path = path }
-	end
-
-	testfile = io.open(path .. DIR_DELIM .. "modpack.conf","r")
-	if testfile ~= nil then
-		testfile:close()
-		return { type = "modpack", path = path }
-	end
-
-	testfile = io.open(path .. DIR_DELIM .. "modpack.txt","r")
-	if testfile ~= nil then
-		testfile:close()
-		return { type = "modpack", path = path }
-	end
-
-	testfile = io.open(path .. DIR_DELIM .. "game.conf","r")
-	if testfile ~= nil then
-		testfile:close()
-		return { type = "game", path = path }
-	end
-
-	testfile = io.open(path .. DIR_DELIM .. "texture_pack.conf","r")
-	if testfile ~= nil then
-		testfile:close()
-		return { type = "txp", path = path }
-	end
-
-	return nil
 end
 
 -------------------------------------------------------------------------------

--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -764,30 +764,6 @@ function pkgmgr.update_translations(list)
 end
 
 --------------------------------------------------------------------------------
--- Returns the ContentDB ID for an installed piece of content.
-function pkgmgr.get_contentdb_id(content)
-	-- core.get_games() will return "" instead of nil if there is no "author" field.
-	if content.author and content.author ~= "" and content.release > 0 then
-		if content.type == "game" then
-			return content.author:lower() .. "/" .. content.id
-		end
-		return content.author:lower() .. "/" .. content.name
-	end
-
-	-- Until Minetest 5.8.0, Minetest Game was bundled with Minetest.
-	-- Unfortunately, the bundled MTG was not versioned (missing "release"
-	-- field in game.conf).
-	-- Therefore, we consider any installation of MTG that is not versioned,
-	-- has not been cloned from Git, and is not system-wide to be updatable.
-	if content.type == "game" and content.id == "minetest" and content.release == 0 and
-			not core.is_dir(content.path .. "/.git") and core.may_modify_path(content.path) then
-		return "minetest/minetest"
-	end
-
-	return nil
-end
-
---------------------------------------------------------------------------------
 -- read initial data
 --------------------------------------------------------------------------------
 pkgmgr.update_gamelist()

--- a/src/content/CMakeLists.txt
+++ b/src/content/CMakeLists.txt
@@ -3,5 +3,6 @@ set(content_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/mod_configuration.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mods.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/subgames.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/pkgmgr.cpp
 	PARENT_SCOPE
 )

--- a/src/content/content.cpp
+++ b/src/content/content.cpp
@@ -44,6 +44,8 @@ ContentType content::getContentType(const std::string &path)
 	return ContentType::UNKNOWN;
 }
 
+
+
 std::string content::contentTypeToString(ContentType &t)
 {
 	switch (t)

--- a/src/content/content.cpp
+++ b/src/content/content.cpp
@@ -24,13 +24,16 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "filesys.h"
 #include "settings.h"
 
-ContentType getContentType(const std::string &path)
-{
-	if (fs::IsFile(path + DIR_DELIM "modpack.txt") || fs::IsFile(path + DIR_DELIM "modpack.conf"))
-		return ContentType::MODPACK;
+using namespace content;
 
+ContentType content::getContentType(const std::string &path)
+{
 	if (fs::IsFile(path + DIR_DELIM "init.lua"))
 		return ContentType::MOD;
+		
+	if (fs::IsFile(path + DIR_DELIM "modpack.txt") ||
+		fs::IsFile(path + DIR_DELIM "modpack.conf"))
+		return ContentType::MODPACK;
 
 	if (fs::IsFile(path + DIR_DELIM "game.conf"))
 		return ContentType::GAME;
@@ -41,7 +44,26 @@ ContentType getContentType(const std::string &path)
 	return ContentType::UNKNOWN;
 }
 
-void parseContentInfo(ContentSpec &spec)
+std::string content::contentTypeToString(ContentType &t)
+{
+	switch (t)
+	{
+	case ContentType::MOD:
+		return "mod";
+	case ContentType::MODPACK:
+		return "modpack";
+	case ContentType::GAME:
+		return "game";
+	case ContentType::TXP:
+		return "txp";
+	case ContentType::UNKNOWN:
+		return "unknown";
+	default:
+		return nullptr;
+	}
+}
+
+void content::parseContentInfo(ContentSpec &spec)
 {
 	std::string conf_path;
 

--- a/src/content/content.cpp
+++ b/src/content/content.cpp
@@ -46,7 +46,7 @@ ContentType content::getContentType(const std::string &path)
 
 
 
-std::string content::contentTypeToString(ContentType &t)
+std::string content::content_type_to_string(ContentType &t)
 {
 	switch (t)
 	{

--- a/src/content/content.h
+++ b/src/content/content.h
@@ -22,8 +22,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "convert_json.h"
 #include "irrlichttypes.h"
 
-
-
 namespace content {
 
 enum class ContentType

--- a/src/content/content.h
+++ b/src/content/content.h
@@ -34,15 +34,16 @@ enum class ContentType
 };
 
 
-
 struct ContentSpec
 {
+	// TODO Maybe use ContentType here
 	std::string type;
 	std::string author;
 	u32 release = 0;
 
 	/// Technical name / Id
 	std::string name;
+	std::string id;
 
 	/// Human-readable title
 	std::string title;
@@ -53,7 +54,7 @@ struct ContentSpec
 	std::string textdomain;
 };
 
-std::string contentTypeToString(ContentType &t);
+std::string content_type_to_string(ContentType &t);
 
 
 ContentType getContentType(const std::string &path);

--- a/src/content/pkgmgr.cpp
+++ b/src/content/pkgmgr.cpp
@@ -18,7 +18,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <regex>
-#include "../filesys.h"
+#include "content.h"
+#include "filesys.h"
+// TODO move the non-lua related method elsewhere?
+#include "script/lua_api/l_mainmenu.h"
+#include "../util/string.h"
 #include "pkgmgr.h"
 
 using namespace content;
@@ -27,4 +31,34 @@ bool content::PkgMgr::isValidModname(const std::string& str)
 {
 	std::smatch m;
 	return ! std::regex_match(str, m, std::regex{"[^a-z0-9_]"});
+}
+
+std::string content::PkgMgr::getContentdbId(const ContentSpec& content)
+{
+	if (content.author != "" and content.release > 0)
+	{
+		if (content.type == "game")
+			return lowercase(content.author) + DIR_DELIM + content.id;
+		
+		return lowercase(content.author) + DIR_DELIM + content.name;
+	}
+	
+	/* Until Minetest 5.8.0, Minetest Game was bundled with Minetest.
+	 * Unfortunately, the bundled MTG was not versioned (missing "release"
+	 * field in game.conf).
+	 * Therefore, we consider any installation of MTG that is not versioned,
+	 * has not been cloned from Git, and is not system-wide to be updatable.
+	 */
+	if (content.type == "game" &&
+	    content.id == "minetest" && 
+	    content.release == 0 &&
+		! fs::IsDir(content.path + DIR_DELIM + ".git") &&
+		ModApiMainMenu::mayModifyPath(
+	       fs::RemoveRelativePathComponents(content.path)))
+	{
+		return "minetest/minetest";
+	}
+	
+	return {};
+		
 }

--- a/src/content/pkgmgr.cpp
+++ b/src/content/pkgmgr.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2018 rubenwardy <rw@rubenwardy.com>
+Copyright (C) 2024 Hyland B. (swagtoy) <me@swag.toys>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -17,48 +17,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#pragma once
-#include "config.h"
-#include "convert_json.h"
-#include "irrlichttypes.h"
+#include "../filesys.h"
+#include "pkgmgr.h"
 
-
-
-namespace content {
-
-enum class ContentType
-{
-	UNKNOWN,
-	MOD,
-	MODPACK,
-	GAME,
-	TXP
-};
-
-
-
-struct ContentSpec
-{
-	std::string type;
-	std::string author;
-	u32 release = 0;
-
-	/// Technical name / Id
-	std::string name;
-
-	/// Human-readable title
-	std::string title;
-
-	/// Short description
-	std::string desc;
-	std::string path;
-	std::string textdomain;
-};
-
-std::string contentTypeToString(ContentType &t);
-
-
-ContentType getContentType(const std::string &path);
-void parseContentInfo(ContentSpec &spec);
-
-} // namespace content
+using namespace content;

--- a/src/content/pkgmgr.cpp
+++ b/src/content/pkgmgr.cpp
@@ -17,7 +17,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
+#include <regex>
 #include "../filesys.h"
 #include "pkgmgr.h"
 
 using namespace content;
+
+bool content::PkgMgr::isValidModname(const std::string& str)
+{
+	std::smatch m;
+	return ! std::regex_match(str, m, std::regex{"[^a-z0-9_]"});
+}

--- a/src/content/pkgmgr.h
+++ b/src/content/pkgmgr.h
@@ -30,6 +30,8 @@ class PkgMgr
 public:
 	PkgMgr() = default;
 	~PkgMgr() = default;
+	
+	static bool isValidModname(const std::string& str);
 };
 
 }

--- a/src/content/pkgmgr.h
+++ b/src/content/pkgmgr.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2018 rubenwardy <rw@rubenwardy.com>
+Copyright (C) 2024 Hyland B. (swagtoy) <me@swag.toys>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -18,47 +18,18 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #pragma once
-#include "config.h"
-#include "convert_json.h"
-#include "irrlichttypes.h"
 
-
+#include <string>
+#include "content.h"
+#include "../httpfetch.h"
 
 namespace content {
 
-enum class ContentType
+class PkgMgr
 {
-	UNKNOWN,
-	MOD,
-	MODPACK,
-	GAME,
-	TXP
+public:
+	PkgMgr() = default;
+	~PkgMgr() = default;
 };
 
-
-
-struct ContentSpec
-{
-	std::string type;
-	std::string author;
-	u32 release = 0;
-
-	/// Technical name / Id
-	std::string name;
-
-	/// Human-readable title
-	std::string title;
-
-	/// Short description
-	std::string desc;
-	std::string path;
-	std::string textdomain;
-};
-
-std::string contentTypeToString(ContentType &t);
-
-
-ContentType getContentType(const std::string &path);
-void parseContentInfo(ContentSpec &spec);
-
-} // namespace content
+}

--- a/src/content/pkgmgr.h
+++ b/src/content/pkgmgr.h
@@ -24,7 +24,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "../httpfetch.h"
 
 namespace content {
-
+ 
 class PkgMgr
 {
 public:
@@ -32,6 +32,7 @@ public:
 	~PkgMgr() = default;
 	
 	static bool isValidModname(const std::string& str);
+	static std::string getContentdbId(const ContentSpec& content);
 };
 
 }

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -234,6 +234,8 @@ std::string findLocaleFileInMods(const std::string &path, const std::string &fil
 Translations *GUIEngine::getContentTranslations(const std::string &path,
 		const std::string &domain, const std::string &lang_code)
 {
+	using namespace content;
+
 	if (domain.empty() || lang_code.empty())
 		return nullptr;
 

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -34,5 +34,6 @@ set(client_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_mainmenu_sound.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_minimap.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_particles_local.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_pkgmgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_storage.cpp
 	PARENT_SCOPE)

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -833,6 +833,7 @@ int ModApiMainMenu::l_get_mainmenu_path(lua_State *L)
 }
 
 /******************************************************************************/
+// TODO Move to fs? Used in content/pkgmgr
 bool ModApiMainMenu::mayModifyPath(std::string path)
 {
 	path = fs::RemoveRelativePathComponents(path);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -352,6 +352,8 @@ int ModApiMainMenu::l_get_games(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_get_content_info(lua_State *L)
 {
+	using namespace content;
+	
 	std::string path = luaL_checkstring(L, 1);
 
 	ContentSpec spec;

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -52,14 +52,6 @@ private:
 	 */
 	static int getBoolData(lua_State *L, const std::string &name ,bool& valid);
 
-	/**
-	 * Checks if a path may be modified. Paths in the temp directory or the user
-	 * games, mods, textures, or worlds directories may be modified.
-	 * @param path path to check
-	 * @return true if the path may be modified
-	 */
-	static bool mayModifyPath(std::string path);
-
 	//api calls
 
 	static int l_start(lua_State *L);
@@ -170,6 +162,13 @@ private:
 	static int l_do_async_callback(lua_State *L);
 
 public:
+	/**
+	 * Checks if a path may be modified. Paths in the temp directory or the user
+	 * games, mods, textures, or worlds directories may be modified.
+	 * @param path path to check
+	 * @return true if the path may be modified
+	 */
+	static bool mayModifyPath(std::string path);
 
 	/**
 	 * initialize this API module

--- a/src/script/lua_api/l_pkgmgr.cpp
+++ b/src/script/lua_api/l_pkgmgr.cpp
@@ -31,7 +31,6 @@ using namespace content;
 
 int ModApiPkgMgr::l_get_folder_type(lua_State* L)
 {
-	
 	const std::string path = luaL_checkstring(L, 1);
 	
 	ContentType type = getContentType(path);
@@ -41,7 +40,7 @@ int ModApiPkgMgr::l_get_folder_type(lua_State* L)
 	if (type != ContentType::UNKNOWN)
 	{
 		lua_newtable(L);
-		setstringfield(L, -1, "type", contentTypeToString(type).c_str());
+		setstringfield(L, -1, "type", content_type_to_string(type).c_str());
 		setstringfield(L, -1, "path", path.c_str());
 	}
 	else
@@ -55,6 +54,27 @@ int ModApiPkgMgr::l_is_valid_modname(lua_State *L)
 	return 1;
 }
 
+int ModApiPkgMgr::l_get_contentdb_id(lua_State *L)
+{
+	luaL_checktype(L, 1, LUA_TTABLE);
+	
+	ContentSpec spec;
+	spec.type = getstringfield_default(L, 1, "type", "");
+	spec.author = getstringfield_default(L, 1, "author", "");
+	spec.release = getintfield_default(L, 1, "release", 0);
+	spec.id = getstringfield_default(L, 1, "id", "");
+	spec.name = getstringfield_default(L, 1, "name", "");
+	
+	std::string res = PkgMgr::getContentdbId(spec);
+	
+	if (!res.empty())
+		lua_pushstring(L, res.c_str());
+	else
+		lua_pushnil(L);
+		
+	return 1;
+}
+
 void ModApiPkgMgr::Initialize(lua_State* L)
 {
 	lua_getglobal(L, "pkgmgr");
@@ -62,6 +82,7 @@ void ModApiPkgMgr::Initialize(lua_State* L)
 	
 	API_FCT(get_folder_type);
 	API_FCT(is_valid_modname);
+	API_FCT(get_contentdb_id);
 }
 
 

--- a/src/script/lua_api/l_pkgmgr.cpp
+++ b/src/script/lua_api/l_pkgmgr.cpp
@@ -1,0 +1,63 @@
+/*
+Minetest
+Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
+Copyright (C) 2017 nerzhul, Loic Blot <loic.blot@unix-experience.fr>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "../../content/pkgmgr.h"
+#include "cpp_api/s_base.h"
+#include "common/c_content.h"
+#include "common/c_converter.h"
+#include "cpp_api/s_base.h"
+#include "gettext.h"
+#include "l_internal.h"
+#include "l_pkgmgr.h"
+
+int ModApiPkgMgr::l_get_folder_type(lua_State* L)
+{
+	using namespace content;
+	
+	const std::string path = luaL_checkstring(L, 1);
+	
+	ContentType type = getContentType(path);
+	
+	/* The original pkgmgr.lua returned nil, but UNKNOWN was unused, so we
+	 *  just ignore that entirely */
+	if (type != ContentType::UNKNOWN)
+	{
+		lua_newtable(L);
+		setstringfield(L, -1, "type", contentTypeToString(type).c_str());
+		setstringfield(L, -1, "path", path.c_str());
+	}
+	else
+		lua_pushnil(L);
+	return 1;
+}
+
+void ModApiPkgMgr::Initialize(lua_State* L)
+{
+	lua_getglobal(L, "pkgmgr");
+	int top = lua_gettop(L);
+	
+	API_FCT(get_folder_type);
+}
+
+
+void ModApiPkgMgr::InitializeAsync(lua_State *L, int top)
+{
+	
+}

--- a/src/script/lua_api/l_pkgmgr.cpp
+++ b/src/script/lua_api/l_pkgmgr.cpp
@@ -27,9 +27,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "l_internal.h"
 #include "l_pkgmgr.h"
 
+using namespace content;
+
 int ModApiPkgMgr::l_get_folder_type(lua_State* L)
 {
-	using namespace content;
 	
 	const std::string path = luaL_checkstring(L, 1);
 	
@@ -48,12 +49,19 @@ int ModApiPkgMgr::l_get_folder_type(lua_State* L)
 	return 1;
 }
 
+int ModApiPkgMgr::l_is_valid_modname(lua_State *L)
+{
+	lua_pushboolean(L, PkgMgr::isValidModname(luaL_checkstring(L, 1)));
+	return 1;
+}
+
 void ModApiPkgMgr::Initialize(lua_State* L)
 {
 	lua_getglobal(L, "pkgmgr");
 	int top = lua_gettop(L);
 	
 	API_FCT(get_folder_type);
+	API_FCT(is_valid_modname);
 }
 
 

--- a/src/script/lua_api/l_pkgmgr.h
+++ b/src/script/lua_api/l_pkgmgr.h
@@ -25,6 +25,7 @@ class ModApiPkgMgr : public ModApiBase
 {
 private:
 	static int l_get_folder_type(lua_State *L);
+	static int l_is_valid_modname(lua_State *L);
 public:
 	static void Initialize(lua_State *L);
 	static void InitializeAsync(lua_State *L, int top);

--- a/src/script/lua_api/l_pkgmgr.h
+++ b/src/script/lua_api/l_pkgmgr.h
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2018 rubenwardy <rw@rubenwardy.com>
+Copyright (C) 2024 Hyland B. (swagtoy) <me@swag.toys>
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -18,47 +18,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #pragma once
-#include "config.h"
-#include "convert_json.h"
-#include "irrlichttypes.h"
 
+#include "l_base.h"
 
-
-namespace content {
-
-enum class ContentType
+class ModApiPkgMgr : public ModApiBase
 {
-	UNKNOWN,
-	MOD,
-	MODPACK,
-	GAME,
-	TXP
+private:
+	static int l_get_folder_type(lua_State *L);
+public:
+	static void Initialize(lua_State *L);
+	static void InitializeAsync(lua_State *L, int top);
 };
-
-
-
-struct ContentSpec
-{
-	std::string type;
-	std::string author;
-	u32 release = 0;
-
-	/// Technical name / Id
-	std::string name;
-
-	/// Human-readable title
-	std::string title;
-
-	/// Short description
-	std::string desc;
-	std::string path;
-	std::string textdomain;
-};
-
-std::string contentTypeToString(ContentType &t);
-
-
-ContentType getContentType(const std::string &path);
-void parseContentInfo(ContentSpec &spec);
-
-} // namespace content

--- a/src/script/lua_api/l_pkgmgr.h
+++ b/src/script/lua_api/l_pkgmgr.h
@@ -24,8 +24,14 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 class ModApiPkgMgr : public ModApiBase
 {
 private:
+	// pkgmgr.get_folder_type(path: str)
 	static int l_get_folder_type(lua_State *L);
+	
+	// pkgmgr.is_valid_modname(modname: str)
 	static int l_is_valid_modname(lua_State *L);
+	
+	// pkgmgr.get_contentdb_id(content: str)
+	static int l_get_contentdb_id(lua_State *L);
 public:
 	static void Initialize(lua_State *L);
 	static void InitializeAsync(lua_State *L, int top);

--- a/src/script/scripting_mainmenu.cpp
+++ b/src/script/scripting_mainmenu.cpp
@@ -26,6 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "lua_api/l_mainmenu_sound.h"
 #include "lua_api/l_util.h"
 #include "lua_api/l_settings.h"
+#include "lua_api/l_pkgmgr.h"
+#include "lua_api/l_internal.h"
 #include "log.h"
 
 extern "C" {
@@ -43,6 +45,9 @@ MainMenuScripting::MainMenuScripting(GUIEngine* guiengine):
 
 	lua_getglobal(L, "core");
 	int top = lua_gettop(L);
+	
+	lua_newtable(L);
+	lua_setglobal(L, "pkgmgr");
 
 	lua_newtable(L);
 	lua_setglobal(L, "gamedata");
@@ -67,11 +72,13 @@ void MainMenuScripting::initializeModApi(lua_State *L, int top)
 	ModApiUtil::Initialize(L, top);
 	ModApiMainMenuSound::Initialize(L, top);
 	ModApiHttp::Initialize(L, top);
+	ModApiPkgMgr::Initialize(L);
 
 	asyncEngine.registerStateInitializer(registerLuaClasses);
 	asyncEngine.registerStateInitializer(ModApiMainMenu::InitializeAsync);
 	asyncEngine.registerStateInitializer(ModApiUtil::InitializeAsync);
 	asyncEngine.registerStateInitializer(ModApiHttp::InitializeAsync);
+	asyncEngine.registerStateInitializer(ModApiPkgMgr::InitializeAsync);
 
 	// Initialize async environment
 	//TODO possibly make number of async threads configurable


### PR DESCRIPTION
Rewrites pkgmgr and contentdb functions in C++, as well as tests. Will close #12295.

The intention of this PR is the start of adding a CLI and TUI interface for mod management, updating, configuration, which I plan to do later in a separate PR. Of course, that will close in the future #7358 (along with an additional ncurses TUI) and some other features. 

It was discussed in #minetest-dev if it was worth just loading a Lua runtime on the CLI. However, since tests weren't written yet, this rewrite shouldn't be hard, and an issue was already requesting it, I figured I would tackle it. It will also add a convenient C++ API for these functions without a Lua dependency.

## To do

- [ ] Rewrite all of pkgmgr.lua
- [ ] Map appropriate C++ functions to Lua
- [ ] Create tests as requested from #12295

ATM I got the base done here and one simple function ported to wrap my head around the minetest-lua codebase. This is a draft, please do not merge.

## How to test

Coming soon in theaters June 2024
