### PR TITLE
Log player dropping / picking up items

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -377,8 +377,10 @@ function core.item_drop(itemstack, dropper, pos)
 			obj:set_velocity(dir)
 			obj:get_luaentity().dropped_by = dropper:get_player_name()
 
-			core.log("action", dropper:get_player_name() .. " dropped " ..
-				item:to_string() .. " at " .. core.pos_to_string(p, 1))
+			core.log("action", string.format("%s dropped %s %i at %s",
+				dropper_is_player and dropper:get_player_name() or "A mod",
+				item:get_name(), item:get_count(),
+				core.pos_to_string(p, 1)))
 		end
 		return itemstack
 	end

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -376,6 +376,9 @@ function core.item_drop(itemstack, dropper, pos)
 			dir.z = dir.z * 2.9
 			obj:set_velocity(dir)
 			obj:get_luaentity().dropped_by = dropper:get_player_name()
+
+			core.log("action", dropper:get_player_name() .. " dropped " ..
+				item:to_string() .. " at " .. core.pos_to_string(p, 1))
 		end
 		return itemstack
 	end


### PR DESCRIPTION
This PR aims to log players interacting with dropped items.

## To do

This PR is a Work in Progress.

- [x] Log dropping items
- [ ] Log picking up items

I am having trouble deciding where to put the pickup logs. Should I put them in `on_punch` of `__builtin:item`?

## How to test

Drop an item. The action should be logged.
