### PR TITLE
Widen limits for the `mouse_sensitivity` setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -138,7 +138,7 @@ invert_mouse (Invert mouse) bool false
 #    Mouse sensitivity multiplier.
 #
 #    Requires: keyboard_mouse
-mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
+mouse_sensitivity (Mouse sensitivity) float 0.2 0.000000001 1000000.0
 
 #    Enable mouse wheel (scroll) for item selection in hotbar.
 #

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1446,7 +1446,7 @@ void Game::copyServerClientCache()
 {
 	// It would be possible to let the client directly read the media files
 	// from where the server knows they are. But aside from being more complicated
-	// it would also *not* fill the media cache and cause slower joining of 
+	// it would also *not* fill the media cache and cause slower joining of
 	// remote servers.
 	// (Imagine that you launch a game once locally and then connect to a server.)
 
@@ -4394,7 +4394,7 @@ void Game::readSettings()
 	m_cache_enable_joysticks             = g_settings->getBool("enable_joysticks");
 	m_cache_enable_particles             = g_settings->getBool("enable_particles");
 	m_cache_enable_fog                   = g_settings->getBool("enable_fog");
-	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity", 0.001f, 10.0f);
+	m_cache_mouse_sensitivity            = g_settings->getFloat("mouse_sensitivity", 0.000000001f, 1000000.0f);
 	m_cache_joystick_frustum_sensitivity = std::max(g_settings->getFloat("joystick_frustum_sensitivity"), 0.001f);
 	m_repeat_place_time                  = g_settings->getFloat("repeat_place_time", 0.16f, 2.0f);
 	m_repeat_dig_time                    = g_settings->getFloat("repeat_dig_time", 0.0f, 2.0f);
@@ -4409,7 +4409,6 @@ void Game::readSettings()
 		m_cache_cam_smoothing = 1 - g_settings->getFloat("camera_smoothing");
 
 	m_cache_cam_smoothing = rangelim(m_cache_cam_smoothing, 0.01f, 1.0f);
-	m_cache_mouse_sensitivity = rangelim(m_cache_mouse_sensitivity, 0.001, 100.0);
 
 	m_invert_mouse = g_settings->getBool("invert_mouse");
 	m_enable_hotbar_mouse_wheel = g_settings->getBool("enable_hotbar_mouse_wheel");


### PR DESCRIPTION
I don't think we should set unnecessarily strict limits to controls related settings, if they can't be used for cheating.

In this case, we can't know what sort of crazy pointing device the user may have.

PR that introduced the limit: #11463

## To do

This PR is a Ready for Review.

## How to test

* Set it.
* Try it.
