### PR TITLE
SDL: Use scancodes for keybindings

### DIFF
--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -347,7 +347,7 @@ public:
 		return video::isDriverSupported(driver);
 	}
 
-	//! Get the scancode of the corresponding keycode.
+	//! Get the corresponding scancode for the keycode.
 	/**
 	\param key The keycode to convert.
 	\return The implementation-dependent scancode for the key (represented by the u32 component) or, if a scancode is not
@@ -359,7 +359,7 @@ public:
 		return (u32)std::get<wchar_t>(key);
 	}
 
-	//! Get the keycode of the corresponding scancode.
+	//! Get the corresponding keycode for the scancode.
 	/**
 	\param scancode The implementation-dependent scancode for the key.
 	\return The corresponding keycode.

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -347,8 +347,12 @@ public:
 		return video::isDriverSupported(driver);
 	}
 
-#if defined(_IRR_COMPILE_WITH_SDL_DEVICE_) || USE_SDL2
 	//! Get the scancode of the corresponding keycode.
+	/**
+	\param key The keycode to convert.
+	\return The implementation-dependent scancode for the key (represented by the u32 component) or, if a scancode is not
+	available, the corresponding Irrlicht keycode (represented by the EKEY_CODE component).
+	*/
 	virtual std::variant<u32, EKEY_CODE> getScancodeFromKey(const Keycode &key) const {
 		if (auto pv = std::get_if<EKEY_CODE>(&key))
 			return *pv;
@@ -356,10 +360,13 @@ public:
 	}
 
 	//! Get the keycode of the corresponding scancode.
+	/**
+	\param scancode The implementation-dependent scancode for the key.
+	\return The corresponding keycode.
+	*/
 	virtual Keycode getKeyFromScancode(const u32 scancode) const {
 		return Keycode(KEY_UNKNOWN, (wchar_t)scancode);
 	}
-#endif
 };
 
 } // end namespace irr

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -352,7 +352,11 @@ public:
 	//! Get the scancode of the corresponding keycode.
 	virtual u32 getScancodeFromKey(const KeyCode &key) const
 	{
-		return key.index() == 0 ? std::get<EKEY_CODE>(key) : KEY_KEY_CODES_COUNT + std::get<wchar_t>(key);
+		if (const auto *keycode = std::get_if<EKEY_CODE>(&key))
+			// treat KEY_UNKNOWN and KEY_KEY_CODES_COUNT as the same and return 0.
+			return KeyCode::isValid(*keycode) ? *keycode : 0;
+		const auto keychar = std::get<wchar_t>(key);
+		return keychar == 0 ? 0 : KEY_KEY_CODES_COUNT + keychar;
 	}
 
 	//! Get the keycode of the corresponding scancode.

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -350,19 +350,19 @@ public:
 	// not implement this.
 
 	//! Get the scancode of the corresponding keycode.
-	virtual u32 getScancodeFromKey(const KeyCode &key) const
+	virtual u32 getScancodeFromKey(const Keycode &key) const
 	{
 		if (const auto *keycode = std::get_if<EKEY_CODE>(&key))
 			// treat KEY_UNKNOWN and KEY_KEY_CODES_COUNT as the same and return 0.
-			return KeyCode::isValid(*keycode) ? *keycode : 0;
+			return Keycode::isValid(*keycode) ? *keycode : 0;
 		const auto keychar = std::get<wchar_t>(key);
 		return keychar == 0 ? 0 : KEY_KEY_CODES_COUNT + keychar;
 	}
 
 	//! Get the keycode of the corresponding scancode.
-	virtual KeyCode getKeyFromScancode(const u32 scancode) const
+	virtual Keycode getKeyFromScancode(const u32 scancode) const
 	{
-		KeyCode key;
+		Keycode key;
 		if (scancode < KEY_KEY_CODES_COUNT)
 			key.emplace<EKEY_CODE>((EKEY_CODE)scancode);
 		else

--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -345,6 +345,26 @@ public:
 	{
 		return video::isDriverSupported(driver);
 	}
+
+	// This is a trivial (near-identity) mapping for converting between scancodes and keycodes for devices that do
+	// not implement this.
+
+	//! Get the scancode of the corresponding keycode.
+	virtual u32 getScancodeFromKey(const KeyCode &key) const
+	{
+		return key.index() == 0 ? std::get<EKEY_CODE>(key) : KEY_KEY_CODES_COUNT + std::get<wchar_t>(key);
+	}
+
+	//! Get the keycode of the corresponding scancode.
+	virtual KeyCode getKeyFromScancode(const u32 scancode) const
+	{
+		KeyCode key;
+		if (scancode < KEY_KEY_CODES_COUNT)
+			key.emplace<EKEY_CODE>((EKEY_CODE)scancode);
+		else
+			key.emplace<wchar_t>(scancode - KEY_KEY_CODES_COUNT);
+		return key;
+	}
 };
 
 } // end namespace irr

--- a/irr/include/Keycodes.h
+++ b/irr/include/Keycodes.h
@@ -3,6 +3,7 @@
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
 #pragma once
+#include <variant>
 
 namespace irr
 {
@@ -180,6 +181,31 @@ enum EKEY_CODE
 	KEY_NONE = 0xFF,              // usually no key mapping, but some laptops use it for fn key
 
 	KEY_KEY_CODES_COUNT = 0x100 // this is not a key, but the amount of keycodes there are.
+};
+
+class KeyCode : public std::variant<EKEY_CODE, wchar_t> {
+	using super = std::variant<EKEY_CODE, wchar_t>;
+public:
+	KeyCode() : KeyCode(KEY_KEY_CODES_COUNT, L'\0') {}
+
+	KeyCode(EKEY_CODE code, wchar_t ch)
+	{
+		emplace(code, ch);
+	}
+
+	using super::emplace;
+	void emplace(EKEY_CODE code, wchar_t ch)
+	{
+		if (isValid(code))
+			emplace<EKEY_CODE>(code);
+		else
+			emplace<wchar_t>(ch);
+	}
+
+	static bool isValid(EKEY_CODE code)
+	{
+		return code > 0 && code < KEY_KEY_CODES_COUNT;
+	}
 };
 
 } // end namespace irr

--- a/irr/include/Keycodes.h
+++ b/irr/include/Keycodes.h
@@ -183,6 +183,7 @@ enum EKEY_CODE
 	KEY_KEY_CODES_COUNT = 0x100 // this is not a key, but the amount of keycodes there are.
 };
 
+// A Keycode is either a character produced by the key or one of Irrlicht's codes (EKEY_CODE)
 class Keycode : public std::variant<EKEY_CODE, wchar_t> {
 	using super = std::variant<EKEY_CODE, wchar_t>;
 public:

--- a/irr/include/Keycodes.h
+++ b/irr/include/Keycodes.h
@@ -183,12 +183,12 @@ enum EKEY_CODE
 	KEY_KEY_CODES_COUNT = 0x100 // this is not a key, but the amount of keycodes there are.
 };
 
-class KeyCode : public std::variant<EKEY_CODE, wchar_t> {
+class Keycode : public std::variant<EKEY_CODE, wchar_t> {
 	using super = std::variant<EKEY_CODE, wchar_t>;
 public:
-	KeyCode() : KeyCode(KEY_KEY_CODES_COUNT, L'\0') {}
+	Keycode() : Keycode(KEY_KEY_CODES_COUNT, L'\0') {}
 
-	KeyCode(EKEY_CODE code, wchar_t ch)
+	Keycode(EKEY_CODE code, wchar_t ch)
 	{
 		emplace(code, ch);
 	}

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -869,6 +869,12 @@ bool CIrrDeviceSDL::run()
 			auto keysym = SDL_event.key.keysym.sym;
 			auto scancode = SDL_event.key.keysym.scancode;
 
+			// Treat AC_BACK as the Escape key
+			if (scancode == SDL_SCANCODE_AC_BACK) {
+				scancode = SDL_SCANCODE_ESCAPE;
+				keysym = SDLK_ESCAPE;
+			}
+
 			const auto &entry = KeyMap.find(keysym);
 			auto key = entry == KeyMap.end() ? KEY_UNKNOWN : entry->second;
 

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -869,19 +869,6 @@ bool CIrrDeviceSDL::run()
 			auto keysym = SDL_event.key.keysym.sym;
 			auto scancode = SDL_event.key.keysym.scancode;
 
-			// Treat AC_BACK as the Escape key
-			if (scancode == SDL_SCANCODE_AC_BACK || scancode == SDL_SCANCODE_ESCAPE)
-			{
-				if (SDL_event.type == SDL_KEYDOWN)
-					escapeKeys.insert(scancode);
-				else
-					escapeKeys.erase(scancode);
-				if (SDL_event.type == SDL_KEYUP && !escapeKeys.empty())
-					break; // avoid sending KEYUP twice if AC_BACK and ESCAPE are both released
-				scancode = SDL_SCANCODE_ESCAPE;
-				keysym = SDLK_ESCAPE;
-			}
-
 			const auto &entry = KeyMap.find(keysym);
 			auto key = entry == KeyMap.end() ? KEY_UNKNOWN : entry->second;
 

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -220,7 +220,7 @@ int CIrrDeviceSDL::findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtK
 	}
 }
 
-u32 CIrrDeviceSDL::getScancodeFromKey(const KeyCode &key) const
+u32 CIrrDeviceSDL::getScancodeFromKey(const Keycode &key) const
 {
 	u32 keynum = 0;
 	if (const auto *keycode = std::get_if<EKEY_CODE>(&key)) {
@@ -236,13 +236,13 @@ u32 CIrrDeviceSDL::getScancodeFromKey(const KeyCode &key) const
 	return SDL_GetScancodeFromKey(keynum);
 }
 
-KeyCode CIrrDeviceSDL::getKeyFromScancode(const u32 scancode) const
+Keycode CIrrDeviceSDL::getKeyFromScancode(const u32 scancode) const
 {
 	auto keycode = SDL_GetKeyFromScancode((SDL_Scancode)scancode);
 	const auto &keyentry = KeyMap.find(keycode);
 	auto irrcode = keyentry != KeyMap.end() ? keyentry->second : KEY_UNKNOWN;
 	auto keychar = findCharToPassToIrrlicht(keycode, irrcode, false);
-	return KeyCode(irrcode, keychar);
+	return Keycode(irrcode, keychar);
 }
 
 void CIrrDeviceSDL::resetReceiveTextInputEvents()
@@ -866,7 +866,7 @@ bool CIrrDeviceSDL::run()
 			const auto &entry = KeyMap.find(keysym);
 			auto key = entry == KeyMap.end() ? KEY_UNKNOWN : entry->second;
 
-			if (!KeyCode::isValid(key))
+			if (!Keycode::isValid(key))
 				os::Printer::log("keycode not mapped", core::stringc(keysym), ELL_DEBUG);
 
 			// Make sure to only input special characters if something is in focus, as SDL_TEXTINPUT handles normal unicode already

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -223,10 +223,9 @@ int CIrrDeviceSDL::findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtK
 u32 CIrrDeviceSDL::getScancodeFromKey(const KeyCode &key) const
 {
 	u32 keynum = 0;
-	if (key.index() == 0) {
-		auto keycode = std::get<EKEY_CODE>(key);
+	if (const auto *keycode = std::get_if<EKEY_CODE>(&key)) {
 		for (const auto &entry: KeyMap) {
-			if (entry.second == keycode) {
+			if (entry.second == *keycode) {
 				keynum = entry.first;
 				break;
 			}

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -822,18 +822,12 @@ bool CIrrDeviceSDL::run()
 
 		case SDL_KEYDOWN:
 		case SDL_KEYUP: {
-			SKeyMap mp;
-			mp.SDLKey = SDL_event.key.keysym.sym;
-			s32 idx = KeyMap.binary_search(mp);
+			auto keysym = SDL_event.key.keysym.sym;
+			const auto &entry = KeyMap.find(keysym);
+			auto key = entry == KeyMap.end() ? KEY_UNKNOWN : entry->second;
 
-			EKEY_CODE key;
-			if (idx == -1)
-				key = (EKEY_CODE)0;
-			else
-				key = (EKEY_CODE)KeyMap[idx].Win32Key;
-
-			if (key == (EKEY_CODE)0)
-				os::Printer::log("keycode not mapped", core::stringc(mp.SDLKey), ELL_DEBUG);
+			if (!KeyCode::isValid(key))
+				os::Printer::log("keycode not mapped", core::stringc(keysym), ELL_DEBUG);
 
 			// Make sure to only input special characters if something is in focus, as SDL_TEXTINPUT handles normal unicode already
 			if (SDL_IsTextInputActive() && !keyIsKnownSpecial(key) && (SDL_event.key.keysym.mod & KMOD_CTRL) == 0)
@@ -844,7 +838,7 @@ bool CIrrDeviceSDL::run()
 			irrevent.KeyInput.PressedDown = (SDL_event.type == SDL_KEYDOWN);
 			irrevent.KeyInput.Shift = (SDL_event.key.keysym.mod & KMOD_SHIFT) != 0;
 			irrevent.KeyInput.Control = (SDL_event.key.keysym.mod & KMOD_CTRL) != 0;
-			irrevent.KeyInput.Char = findCharToPassToIrrlicht(mp.SDLKey, key,
+			irrevent.KeyInput.Char = findCharToPassToIrrlicht(keysym, key,
 					(SDL_event.key.keysym.mod & KMOD_NUM) != 0);
 			postEventFromUser(irrevent);
 		} break;
@@ -1319,142 +1313,138 @@ void CIrrDeviceSDL::createKeyMap()
 	// the lookuptable, but I'll leave it like that until
 	// I find a better version.
 
-	KeyMap.reallocate(105);
-
 	// buttons missing
 
 	// Android back button = ESC
-	KeyMap.push_back(SKeyMap(SDLK_AC_BACK, KEY_ESCAPE));
+	KeyMap.emplace(SDLK_AC_BACK, KEY_ESCAPE);
 
-	KeyMap.push_back(SKeyMap(SDLK_BACKSPACE, KEY_BACK));
-	KeyMap.push_back(SKeyMap(SDLK_TAB, KEY_TAB));
-	KeyMap.push_back(SKeyMap(SDLK_CLEAR, KEY_CLEAR));
-	KeyMap.push_back(SKeyMap(SDLK_RETURN, KEY_RETURN));
+	KeyMap.emplace(SDLK_BACKSPACE, KEY_BACK);
+	KeyMap.emplace(SDLK_TAB, KEY_TAB);
+	KeyMap.emplace(SDLK_CLEAR, KEY_CLEAR);
+	KeyMap.emplace(SDLK_RETURN, KEY_RETURN);
 
 	// combined modifiers missing
 
-	KeyMap.push_back(SKeyMap(SDLK_PAUSE, KEY_PAUSE));
-	KeyMap.push_back(SKeyMap(SDLK_CAPSLOCK, KEY_CAPITAL));
+	KeyMap.emplace(SDLK_PAUSE, KEY_PAUSE);
+	KeyMap.emplace(SDLK_CAPSLOCK, KEY_CAPITAL);
 
 	// asian letter keys missing
 
-	KeyMap.push_back(SKeyMap(SDLK_ESCAPE, KEY_ESCAPE));
+	KeyMap.emplace(SDLK_ESCAPE, KEY_ESCAPE);
 
 	// asian letter keys missing
 
-	KeyMap.push_back(SKeyMap(SDLK_SPACE, KEY_SPACE));
-	KeyMap.push_back(SKeyMap(SDLK_PAGEUP, KEY_PRIOR));
-	KeyMap.push_back(SKeyMap(SDLK_PAGEDOWN, KEY_NEXT));
-	KeyMap.push_back(SKeyMap(SDLK_END, KEY_END));
-	KeyMap.push_back(SKeyMap(SDLK_HOME, KEY_HOME));
-	KeyMap.push_back(SKeyMap(SDLK_LEFT, KEY_LEFT));
-	KeyMap.push_back(SKeyMap(SDLK_UP, KEY_UP));
-	KeyMap.push_back(SKeyMap(SDLK_RIGHT, KEY_RIGHT));
-	KeyMap.push_back(SKeyMap(SDLK_DOWN, KEY_DOWN));
+	KeyMap.emplace(SDLK_SPACE, KEY_SPACE);
+	KeyMap.emplace(SDLK_PAGEUP, KEY_PRIOR);
+	KeyMap.emplace(SDLK_PAGEDOWN, KEY_NEXT);
+	KeyMap.emplace(SDLK_END, KEY_END);
+	KeyMap.emplace(SDLK_HOME, KEY_HOME);
+	KeyMap.emplace(SDLK_LEFT, KEY_LEFT);
+	KeyMap.emplace(SDLK_UP, KEY_UP);
+	KeyMap.emplace(SDLK_RIGHT, KEY_RIGHT);
+	KeyMap.emplace(SDLK_DOWN, KEY_DOWN);
 
 	// select missing
-	KeyMap.push_back(SKeyMap(SDLK_PRINTSCREEN, KEY_PRINT));
+	KeyMap.emplace(SDLK_PRINTSCREEN, KEY_PRINT);
 	// execute missing
-	KeyMap.push_back(SKeyMap(SDLK_PRINTSCREEN, KEY_SNAPSHOT));
+	KeyMap.emplace(SDLK_PRINTSCREEN, KEY_SNAPSHOT);
 
-	KeyMap.push_back(SKeyMap(SDLK_INSERT, KEY_INSERT));
-	KeyMap.push_back(SKeyMap(SDLK_DELETE, KEY_DELETE));
-	KeyMap.push_back(SKeyMap(SDLK_HELP, KEY_HELP));
+	KeyMap.emplace(SDLK_INSERT, KEY_INSERT);
+	KeyMap.emplace(SDLK_DELETE, KEY_DELETE);
+	KeyMap.emplace(SDLK_HELP, KEY_HELP);
 
-	KeyMap.push_back(SKeyMap(SDLK_0, KEY_KEY_0));
-	KeyMap.push_back(SKeyMap(SDLK_1, KEY_KEY_1));
-	KeyMap.push_back(SKeyMap(SDLK_2, KEY_KEY_2));
-	KeyMap.push_back(SKeyMap(SDLK_3, KEY_KEY_3));
-	KeyMap.push_back(SKeyMap(SDLK_4, KEY_KEY_4));
-	KeyMap.push_back(SKeyMap(SDLK_5, KEY_KEY_5));
-	KeyMap.push_back(SKeyMap(SDLK_6, KEY_KEY_6));
-	KeyMap.push_back(SKeyMap(SDLK_7, KEY_KEY_7));
-	KeyMap.push_back(SKeyMap(SDLK_8, KEY_KEY_8));
-	KeyMap.push_back(SKeyMap(SDLK_9, KEY_KEY_9));
+	KeyMap.emplace(SDLK_0, KEY_KEY_0);
+	KeyMap.emplace(SDLK_1, KEY_KEY_1);
+	KeyMap.emplace(SDLK_2, KEY_KEY_2);
+	KeyMap.emplace(SDLK_3, KEY_KEY_3);
+	KeyMap.emplace(SDLK_4, KEY_KEY_4);
+	KeyMap.emplace(SDLK_5, KEY_KEY_5);
+	KeyMap.emplace(SDLK_6, KEY_KEY_6);
+	KeyMap.emplace(SDLK_7, KEY_KEY_7);
+	KeyMap.emplace(SDLK_8, KEY_KEY_8);
+	KeyMap.emplace(SDLK_9, KEY_KEY_9);
 
-	KeyMap.push_back(SKeyMap(SDLK_a, KEY_KEY_A));
-	KeyMap.push_back(SKeyMap(SDLK_b, KEY_KEY_B));
-	KeyMap.push_back(SKeyMap(SDLK_c, KEY_KEY_C));
-	KeyMap.push_back(SKeyMap(SDLK_d, KEY_KEY_D));
-	KeyMap.push_back(SKeyMap(SDLK_e, KEY_KEY_E));
-	KeyMap.push_back(SKeyMap(SDLK_f, KEY_KEY_F));
-	KeyMap.push_back(SKeyMap(SDLK_g, KEY_KEY_G));
-	KeyMap.push_back(SKeyMap(SDLK_h, KEY_KEY_H));
-	KeyMap.push_back(SKeyMap(SDLK_i, KEY_KEY_I));
-	KeyMap.push_back(SKeyMap(SDLK_j, KEY_KEY_J));
-	KeyMap.push_back(SKeyMap(SDLK_k, KEY_KEY_K));
-	KeyMap.push_back(SKeyMap(SDLK_l, KEY_KEY_L));
-	KeyMap.push_back(SKeyMap(SDLK_m, KEY_KEY_M));
-	KeyMap.push_back(SKeyMap(SDLK_n, KEY_KEY_N));
-	KeyMap.push_back(SKeyMap(SDLK_o, KEY_KEY_O));
-	KeyMap.push_back(SKeyMap(SDLK_p, KEY_KEY_P));
-	KeyMap.push_back(SKeyMap(SDLK_q, KEY_KEY_Q));
-	KeyMap.push_back(SKeyMap(SDLK_r, KEY_KEY_R));
-	KeyMap.push_back(SKeyMap(SDLK_s, KEY_KEY_S));
-	KeyMap.push_back(SKeyMap(SDLK_t, KEY_KEY_T));
-	KeyMap.push_back(SKeyMap(SDLK_u, KEY_KEY_U));
-	KeyMap.push_back(SKeyMap(SDLK_v, KEY_KEY_V));
-	KeyMap.push_back(SKeyMap(SDLK_w, KEY_KEY_W));
-	KeyMap.push_back(SKeyMap(SDLK_x, KEY_KEY_X));
-	KeyMap.push_back(SKeyMap(SDLK_y, KEY_KEY_Y));
-	KeyMap.push_back(SKeyMap(SDLK_z, KEY_KEY_Z));
+	KeyMap.emplace(SDLK_a, KEY_KEY_A);
+	KeyMap.emplace(SDLK_b, KEY_KEY_B);
+	KeyMap.emplace(SDLK_c, KEY_KEY_C);
+	KeyMap.emplace(SDLK_d, KEY_KEY_D);
+	KeyMap.emplace(SDLK_e, KEY_KEY_E);
+	KeyMap.emplace(SDLK_f, KEY_KEY_F);
+	KeyMap.emplace(SDLK_g, KEY_KEY_G);
+	KeyMap.emplace(SDLK_h, KEY_KEY_H);
+	KeyMap.emplace(SDLK_i, KEY_KEY_I);
+	KeyMap.emplace(SDLK_j, KEY_KEY_J);
+	KeyMap.emplace(SDLK_k, KEY_KEY_K);
+	KeyMap.emplace(SDLK_l, KEY_KEY_L);
+	KeyMap.emplace(SDLK_m, KEY_KEY_M);
+	KeyMap.emplace(SDLK_n, KEY_KEY_N);
+	KeyMap.emplace(SDLK_o, KEY_KEY_O);
+	KeyMap.emplace(SDLK_p, KEY_KEY_P);
+	KeyMap.emplace(SDLK_q, KEY_KEY_Q);
+	KeyMap.emplace(SDLK_r, KEY_KEY_R);
+	KeyMap.emplace(SDLK_s, KEY_KEY_S);
+	KeyMap.emplace(SDLK_t, KEY_KEY_T);
+	KeyMap.emplace(SDLK_u, KEY_KEY_U);
+	KeyMap.emplace(SDLK_v, KEY_KEY_V);
+	KeyMap.emplace(SDLK_w, KEY_KEY_W);
+	KeyMap.emplace(SDLK_x, KEY_KEY_X);
+	KeyMap.emplace(SDLK_y, KEY_KEY_Y);
+	KeyMap.emplace(SDLK_z, KEY_KEY_Z);
 
-	KeyMap.push_back(SKeyMap(SDLK_LGUI, KEY_LWIN));
-	KeyMap.push_back(SKeyMap(SDLK_RGUI, KEY_RWIN));
+	KeyMap.emplace(SDLK_LGUI, KEY_LWIN);
+	KeyMap.emplace(SDLK_RGUI, KEY_RWIN);
 	// apps missing
-	KeyMap.push_back(SKeyMap(SDLK_POWER, KEY_SLEEP)); //??
+	KeyMap.emplace(SDLK_POWER, KEY_SLEEP); //??
 
-	KeyMap.push_back(SKeyMap(SDLK_KP_0, KEY_NUMPAD0));
-	KeyMap.push_back(SKeyMap(SDLK_KP_1, KEY_NUMPAD1));
-	KeyMap.push_back(SKeyMap(SDLK_KP_2, KEY_NUMPAD2));
-	KeyMap.push_back(SKeyMap(SDLK_KP_3, KEY_NUMPAD3));
-	KeyMap.push_back(SKeyMap(SDLK_KP_4, KEY_NUMPAD4));
-	KeyMap.push_back(SKeyMap(SDLK_KP_5, KEY_NUMPAD5));
-	KeyMap.push_back(SKeyMap(SDLK_KP_6, KEY_NUMPAD6));
-	KeyMap.push_back(SKeyMap(SDLK_KP_7, KEY_NUMPAD7));
-	KeyMap.push_back(SKeyMap(SDLK_KP_8, KEY_NUMPAD8));
-	KeyMap.push_back(SKeyMap(SDLK_KP_9, KEY_NUMPAD9));
-	KeyMap.push_back(SKeyMap(SDLK_KP_MULTIPLY, KEY_MULTIPLY));
-	KeyMap.push_back(SKeyMap(SDLK_KP_PLUS, KEY_ADD));
-	KeyMap.push_back(SKeyMap(SDLK_KP_ENTER, KEY_RETURN));
-	KeyMap.push_back(SKeyMap(SDLK_KP_MINUS, KEY_SUBTRACT));
-	KeyMap.push_back(SKeyMap(SDLK_KP_PERIOD, KEY_DECIMAL));
-	KeyMap.push_back(SKeyMap(SDLK_KP_DIVIDE, KEY_DIVIDE));
+	KeyMap.emplace(SDLK_KP_0, KEY_NUMPAD0);
+	KeyMap.emplace(SDLK_KP_1, KEY_NUMPAD1);
+	KeyMap.emplace(SDLK_KP_2, KEY_NUMPAD2);
+	KeyMap.emplace(SDLK_KP_3, KEY_NUMPAD3);
+	KeyMap.emplace(SDLK_KP_4, KEY_NUMPAD4);
+	KeyMap.emplace(SDLK_KP_5, KEY_NUMPAD5);
+	KeyMap.emplace(SDLK_KP_6, KEY_NUMPAD6);
+	KeyMap.emplace(SDLK_KP_7, KEY_NUMPAD7);
+	KeyMap.emplace(SDLK_KP_8, KEY_NUMPAD8);
+	KeyMap.emplace(SDLK_KP_9, KEY_NUMPAD9);
+	KeyMap.emplace(SDLK_KP_MULTIPLY, KEY_MULTIPLY);
+	KeyMap.emplace(SDLK_KP_PLUS, KEY_ADD);
+	KeyMap.emplace(SDLK_KP_ENTER, KEY_RETURN);
+	KeyMap.emplace(SDLK_KP_MINUS, KEY_SUBTRACT);
+	KeyMap.emplace(SDLK_KP_PERIOD, KEY_DECIMAL);
+	KeyMap.emplace(SDLK_KP_DIVIDE, KEY_DIVIDE);
 
-	KeyMap.push_back(SKeyMap(SDLK_F1, KEY_F1));
-	KeyMap.push_back(SKeyMap(SDLK_F2, KEY_F2));
-	KeyMap.push_back(SKeyMap(SDLK_F3, KEY_F3));
-	KeyMap.push_back(SKeyMap(SDLK_F4, KEY_F4));
-	KeyMap.push_back(SKeyMap(SDLK_F5, KEY_F5));
-	KeyMap.push_back(SKeyMap(SDLK_F6, KEY_F6));
-	KeyMap.push_back(SKeyMap(SDLK_F7, KEY_F7));
-	KeyMap.push_back(SKeyMap(SDLK_F8, KEY_F8));
-	KeyMap.push_back(SKeyMap(SDLK_F9, KEY_F9));
-	KeyMap.push_back(SKeyMap(SDLK_F10, KEY_F10));
-	KeyMap.push_back(SKeyMap(SDLK_F11, KEY_F11));
-	KeyMap.push_back(SKeyMap(SDLK_F12, KEY_F12));
-	KeyMap.push_back(SKeyMap(SDLK_F13, KEY_F13));
-	KeyMap.push_back(SKeyMap(SDLK_F14, KEY_F14));
-	KeyMap.push_back(SKeyMap(SDLK_F15, KEY_F15));
+	KeyMap.emplace(SDLK_F1, KEY_F1);
+	KeyMap.emplace(SDLK_F2, KEY_F2);
+	KeyMap.emplace(SDLK_F3, KEY_F3);
+	KeyMap.emplace(SDLK_F4, KEY_F4);
+	KeyMap.emplace(SDLK_F5, KEY_F5);
+	KeyMap.emplace(SDLK_F6, KEY_F6);
+	KeyMap.emplace(SDLK_F7, KEY_F7);
+	KeyMap.emplace(SDLK_F8, KEY_F8);
+	KeyMap.emplace(SDLK_F9, KEY_F9);
+	KeyMap.emplace(SDLK_F10, KEY_F10);
+	KeyMap.emplace(SDLK_F11, KEY_F11);
+	KeyMap.emplace(SDLK_F12, KEY_F12);
+	KeyMap.emplace(SDLK_F13, KEY_F13);
+	KeyMap.emplace(SDLK_F14, KEY_F14);
+	KeyMap.emplace(SDLK_F15, KEY_F15);
 	// no higher F-keys
 
-	KeyMap.push_back(SKeyMap(SDLK_NUMLOCKCLEAR, KEY_NUMLOCK));
-	KeyMap.push_back(SKeyMap(SDLK_SCROLLLOCK, KEY_SCROLL));
-	KeyMap.push_back(SKeyMap(SDLK_LSHIFT, KEY_LSHIFT));
-	KeyMap.push_back(SKeyMap(SDLK_RSHIFT, KEY_RSHIFT));
-	KeyMap.push_back(SKeyMap(SDLK_LCTRL, KEY_LCONTROL));
-	KeyMap.push_back(SKeyMap(SDLK_RCTRL, KEY_RCONTROL));
-	KeyMap.push_back(SKeyMap(SDLK_LALT, KEY_LMENU));
-	KeyMap.push_back(SKeyMap(SDLK_RALT, KEY_RMENU));
+	KeyMap.emplace(SDLK_NUMLOCKCLEAR, KEY_NUMLOCK);
+	KeyMap.emplace(SDLK_SCROLLLOCK, KEY_SCROLL);
+	KeyMap.emplace(SDLK_LSHIFT, KEY_LSHIFT);
+	KeyMap.emplace(SDLK_RSHIFT, KEY_RSHIFT);
+	KeyMap.emplace(SDLK_LCTRL, KEY_LCONTROL);
+	KeyMap.emplace(SDLK_RCTRL, KEY_RCONTROL);
+	KeyMap.emplace(SDLK_LALT, KEY_LMENU);
+	KeyMap.emplace(SDLK_RALT, KEY_RMENU);
 
-	KeyMap.push_back(SKeyMap(SDLK_PLUS, KEY_PLUS));
-	KeyMap.push_back(SKeyMap(SDLK_COMMA, KEY_COMMA));
-	KeyMap.push_back(SKeyMap(SDLK_MINUS, KEY_MINUS));
-	KeyMap.push_back(SKeyMap(SDLK_PERIOD, KEY_PERIOD));
+	KeyMap.emplace(SDLK_PLUS, KEY_PLUS);
+	KeyMap.emplace(SDLK_COMMA, KEY_COMMA);
+	KeyMap.emplace(SDLK_MINUS, KEY_MINUS);
+	KeyMap.emplace(SDLK_PERIOD, KEY_PERIOD);
 
 	// some special keys missing
-
-	KeyMap.sort();
 }
 
 void CIrrDeviceSDL::CCursorControl::initCursors()

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -242,7 +242,8 @@ KeyCode CIrrDeviceSDL::getKeyFromScancode(const u32 scancode) const
 	auto keycode = SDL_GetKeyFromScancode((SDL_Scancode)scancode);
 	const auto &keyentry = KeyMap.find(keycode);
 	auto irrcode = keyentry != KeyMap.end() ? keyentry->second : KEY_UNKNOWN;
-	return KeyCode(irrcode, keycode);
+	auto keychar = findCharToPassToIrrlicht(keycode, irrcode, false);
+	return KeyCode(irrcode, keychar);
 }
 
 void CIrrDeviceSDL::resetReceiveTextInputEvents()

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -25,7 +25,6 @@
 
 #include <memory>
 #include <unordered_map>
-#include <set>
 
 namespace irr
 {
@@ -333,8 +332,6 @@ private:
 
 	s32 CurrentTouchCount;
 	bool IsInBackground;
-
-	std::set<SDL_Scancode> escapeKeys;
 };
 
 } // end namespace irr

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -25,7 +25,7 @@
 
 #include <memory>
 #include <unordered_map>
-#include <unordered_set>
+#include <set>
 
 namespace irr
 {
@@ -332,7 +332,7 @@ private:
 	s32 CurrentTouchCount;
 	bool IsInBackground;
 
-	std::unordered_set<SDL_Scancode> escapeKeys;
+	std::set<SDL_Scancode> escapeKeys;
 };
 
 } // end namespace irr

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -291,8 +291,8 @@ private:
 	// Return the Char that should be sent to Irrlicht for the given key (either the one passed in or 0).
 	static int findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtKey, bool numlock);
 
-	virtual u32 getScancodeFromKey(const KeyCode &key) const override;
-	virtual KeyCode getKeyFromScancode(const u32 scancode) const override;
+	virtual u32 getScancodeFromKey(const Keycode &key) const override;
+	virtual Keycode getKeyFromScancode(const u32 scancode) const override;
 
 	// Check if a text box is in focus. Enable or disable SDL_TEXTINPUT events only if in focus.
 	void resetReceiveTextInputEvents();

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -291,8 +291,8 @@ private:
 	// Return the Char that should be sent to Irrlicht for the given key (either the one passed in or 0).
 	static int findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtKey, bool numlock);
 
-	virtual u32 getScancodeFromKey(const Keycode &key) const override;
-	virtual Keycode getKeyFromScancode(const u32 scancode) const override;
+	std::variant<u32, EKEY_CODE> getScancodeFromKey(const Keycode &key) const override;
+	Keycode getKeyFromScancode(const u32 scancode) const override;
 
 	// Check if a text box is in focus. Enable or disable SDL_TEXTINPUT events only if in focus.
 	void resetReceiveTextInputEvents();

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -24,6 +24,8 @@
 #include <SDL_syswm.h>
 
 #include <memory>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace irr
 {
@@ -289,6 +291,9 @@ private:
 	// Return the Char that should be sent to Irrlicht for the given key (either the one passed in or 0).
 	static int findCharToPassToIrrlicht(uint32_t sdlKey, EKEY_CODE irrlichtKey, bool numlock);
 
+	virtual u32 getScancodeFromKey(const KeyCode &key) const override;
+	virtual KeyCode getKeyFromScancode(const u32 scancode) const override;
+
 	// Check if a text box is in focus. Enable or disable SDL_TEXTINPUT events only if in focus.
 	void resetReceiveTextInputEvents();
 
@@ -326,6 +331,8 @@ private:
 
 	s32 CurrentTouchCount;
 	bool IsInBackground;
+
+	std::unordered_set<SDL_Scancode> escapeKeys;
 };
 
 } // end namespace irr

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -322,24 +322,7 @@ private:
 
 	core::rect<s32> lastElemPos;
 
-	struct SKeyMap
-	{
-		SKeyMap() {}
-		SKeyMap(s32 x11, s32 win32) :
-				SDLKey(x11), Win32Key(win32)
-		{
-		}
-
-		s32 SDLKey;
-		s32 Win32Key;
-
-		bool operator<(const SKeyMap &o) const
-		{
-			return SDLKey < o.SDLKey;
-		}
-	};
-
-	core::array<SKeyMap> KeyMap;
+	std::unordered_map<SDL_Keycode, EKEY_CODE> KeyMap;
 
 	s32 CurrentTouchCount;
 	bool IsInBackground;

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -327,6 +327,8 @@ private:
 
 	core::rect<s32> lastElemPos;
 
+	// TODO: This is only used for scancode/keycode conversion with EKEY_CODE (among other things, for Luanti
+	// to display keys to users). Drop this along with EKEY_CODE.
 	std::unordered_map<SDL_Keycode, EKEY_CODE> KeyMap;
 
 	s32 CurrentTouchCount;

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -143,7 +143,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	// Remember whether each key is down or up
 	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		const KeyPress keyCode(event.KeyInput);
-		if (keysListenedFor[keyCode]) {
+		if (keyCode && keysListenedFor[keyCode]) {
 			if (event.KeyInput.PressedDown) {
 				if (!IsKeyDown(keyCode))
 					keyWasPressed.set(keyCode);

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -143,7 +143,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	// Remember whether each key is down or up
 	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		const KeyPress keyCode(event.KeyInput);
-		if (keyCode && keysListenedFor[keyCode]) {
+		if (keyCode && keysListenedFor[keyCode]) { // ignore key input that is invalid or irrelevant for the game.
 			if (event.KeyInput.PressedDown) {
 				if (!IsKeyDown(keyCode))
 					keyWasPressed.set(keyCode);

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -241,7 +241,7 @@ static const table_key &lookup_keychar(wchar_t Char)
 	std::ostringstream os;
 	os << "<Char " << hex_encode((char*) &Char, sizeof(wchar_t)) << ">";
 	auto newsym = wide_to_utf8(std::wstring_view(&Char, 1));
-	table_key new_key = {newsym, irr::KEY_KEY_CODES_COUNT, Char, newsym};
+	table_key new_key {newsym, irr::KEY_KEY_CODES_COUNT, Char, newsym};
 	return table.emplace_back(std::move(new_key));
 }
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -275,7 +275,9 @@ static const table_key &lookup_keykey(irr::EKEY_CODE key)
 static const table_key &lookup_scancode(const u32 scancode)
 {
 	auto key = RenderingEngine::get_raw_device()->getKeyFromScancode(scancode);
-	return key.index() == 0 ? lookup_keykey(std::get<irr::EKEY_CODE>(key)) : lookup_keychar(std::get<wchar_t>(key));
+	return std::holds_alternative<EKEY_CODE>(key) ?
+		lookup_keykey(std::get<irr::EKEY_CODE>(key)) :
+		lookup_keychar(std::get<wchar_t>(key));
 }
 
 KeyPress::KeyPress(std::string_view name)

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -238,8 +238,6 @@ static const table_key &lookup_keychar(wchar_t Char)
 			return table_key;
 	}
 
-	std::ostringstream os;
-	os << "<Char " << hex_encode((char*) &Char, sizeof(wchar_t)) << ">";
 	auto newsym = wide_to_utf8(std::wstring_view(&Char, 1));
 	table_key new_key {newsym, irr::KEY_KEY_CODES_COUNT, Char, newsym};
 	return table.emplace_back(std::move(new_key));
@@ -271,8 +269,6 @@ static const table_key &lookup_keykey(irr::EKEY_CODE key)
 			return table_key;
 	}
 
-	std::ostringstream os;
-	os << "<Keycode " << (int) key << ">";
 	return invalid_key;
 }
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -275,11 +275,7 @@ static const table_key &lookup_keyname(std::string_view name)
 
 static const table_key &lookup_scancode(const u32 scancode)
 {
-	auto device = RenderingEngine::get_raw_device();
-	if (!device)
-		return invalid_key;
-
-	auto key = device->getKeyFromScancode(scancode);
+	auto key = RenderingEngine::get_raw_device()->getKeyFromScancode(scancode);
 	return std::holds_alternative<EKEY_CODE>(key) ?
 		lookup_keykey(std::get<irr::EKEY_CODE>(key)) :
 		lookup_keychar(std::get<wchar_t>(key));
@@ -294,12 +290,7 @@ static const table_key &lookup_scancode(const std::variant<u32, irr::EKEY_CODE> 
 
 void KeyPress::loadFromKey(irr::EKEY_CODE keycode, wchar_t keychar)
 {
-	if (auto device = RenderingEngine::get_raw_device())
-		scancode = device->getScancodeFromKey(Keycode(keycode, keychar));
-	else if (Keycode::isValid(keycode))
-		scancode = keycode;
-	else
-		scancode = (u32) keychar;
+	scancode = RenderingEngine::get_raw_device()->getScancodeFromKey(Keycode(keycode, keychar));
 }
 
 KeyPress::KeyPress(const std::string &name)

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -276,11 +276,8 @@ static const table_key &lookup_keyname(std::string_view name)
 static const table_key &lookup_scancode(const u32 scancode)
 {
 	auto device = RenderingEngine::get_raw_device();
-	if (!device) {
-		warningstream << "IrrlichtDevice not available during scancode lookup." <<
-				" The resulting value is invalid." << std::endl;
+	if (!device)
 		return invalid_key;
-	}
 
 	auto key = device->getKeyFromScancode(scancode);
 	return std::holds_alternative<EKEY_CODE>(key) ?
@@ -297,16 +294,12 @@ static const table_key &lookup_scancode(const std::variant<u32, irr::EKEY_CODE> 
 
 void KeyPress::loadFromKey(irr::EKEY_CODE keycode, wchar_t keychar)
 {
-	if (auto device = RenderingEngine::get_raw_device()) {
+	if (auto device = RenderingEngine::get_raw_device())
 		scancode = device->getScancodeFromKey(Keycode(keycode, keychar));
-	} else {
-		warningstream << "IrrlichtDevice not available when creating KeyPress." <<
-				" The resulting value may be incorrect or unusable." << std::endl;
-		if (Keycode::isValid(keycode))
-			scancode = keycode;
-		else
-			scancode = (u32) keychar;
-	}
+	else if (Keycode::isValid(keycode))
+		scancode = keycode;
+	else
+		scancode = (u32) keychar;
 }
 
 KeyPress::KeyPress(const std::string &name)

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 
 struct table_key {
-	std::string Name;
+	std::string Name; // An EKEY_CODE 'symbol' name as a string
 	irr::EKEY_CODE Key;
 	wchar_t Char; // L'\0' means no character assigned
 	std::string LangName; // empty string means it doesn't have a human description
@@ -315,10 +315,10 @@ KeyPress::KeyPress(const irr::SEvent::SKeyInput &in)
 
 std::string KeyPress::formatScancode() const
 {
-#if USE_SDL2
-	if (auto pv = std::get_if<u32>(&scancode))
-		return *pv == 0 ? "" : "<" + std::to_string(*pv) + ">";
-#endif
+	if (USE_SDL2) {
+		if (auto pv = std::get_if<u32>(&scancode))
+			return *pv == 0 ? "" : "<" + std::to_string(*pv) + ">";
+	}
 	return "";
 }
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -10,6 +10,7 @@
 #include "util/hex.h"
 #include "util/string.h"
 #include "util/basic_macros.h"
+#include <unordered_map>
 #include <vector>
 
 struct table_key {
@@ -365,7 +366,7 @@ bool KeyPress::loadFromScancode(const std::string &name)
 	}
 }
 
-std::unordered_map<std::string, KeyPress> KeyPress::specialKeyCache;
+std::unordered_map<std::string, KeyPress> specialKeyCache;
 const KeyPress &KeyPress::getSpecialKey(const std::string &name)
 {
 	auto &key = specialKeyCache[name];

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -388,8 +388,12 @@ const KeyPress &getKeySetting(const std::string &settingname)
 	if (n != g_key_setting_cache.end())
 		return n->second;
 
+	auto keysym = g_settings->get(settingname);
 	auto &ref = g_key_setting_cache[settingname];
-	ref = KeyPress(g_settings->get(settingname));
+	ref = KeyPress(keysym);
+	if (!keysym.empty() && !ref) {
+		warningstream << "Invalid key '" << keysym << "' for '" << settingname << "'." << std::endl;
+	}
 	return ref;
 }
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -303,14 +303,14 @@ KeyPress::KeyPress(const std::string &name)
 
 KeyPress::KeyPress(const irr::SEvent::SKeyInput &in)
 {
-#if USE_SDL2
-	if (in.SystemKeyCode)
-		scancode.emplace<u32>(in.SystemKeyCode);
-	else
-		scancode.emplace<irr::EKEY_CODE>(in.Key);
-#else
-	loadFromKey(in.Key, in.Char);
-#endif
+	if (USE_SDL2) {
+		if (in.SystemKeyCode)
+			scancode.emplace<u32>(in.SystemKeyCode);
+		else
+			scancode.emplace<irr::EKEY_CODE>(in.Key);
+	} else {
+		loadFromKey(in.Key, in.Char);
+	}
 }
 
 std::string KeyPress::formatScancode() const
@@ -351,18 +351,18 @@ wchar_t KeyPress::getKeychar() const
 
 bool KeyPress::loadFromScancode(const std::string &name)
 {
-#if USE_SDL2
-	if (name.size() < 2 || name[0] != '<' || name.back() != '>')
+	if (USE_SDL2) {
+		if (name.size() < 2 || name[0] != '<' || name.back() != '>')
+			return false;
+		char *p;
+		const auto code = strtoul(name.c_str()+1, &p, 10);
+		if (p != name.c_str() + name.size() - 1)
+			return false;
+		scancode.emplace<u32>(code);
+		return true;
+	} else {
 		return false;
-	char *p;
-	const auto code = strtoul(name.c_str()+1, &p, 10);
-	if (p != name.c_str() + name.size() - 1)
-		return false;
-	scancode.emplace<u32>(code);
-	return true;
-#else
-	return false;
-#endif
+	}
 }
 
 std::unordered_map<std::string, KeyPress> KeyPress::specialKeyCache;

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -318,7 +318,7 @@ std::string KeyPress::formatScancode() const
 {
 	if (USE_SDL2) {
 		if (auto pv = std::get_if<u32>(&scancode))
-			return *pv == 0 ? "" : "<" + std::to_string(*pv) + ">";
+			return *pv == 0 ? "" : "SYSTEM_SCANCODE_" + std::to_string(*pv);
 	}
 	return "";
 }
@@ -353,11 +353,11 @@ wchar_t KeyPress::getKeychar() const
 bool KeyPress::loadFromScancode(const std::string &name)
 {
 	if (USE_SDL2) {
-		if (name.size() < 2 || name[0] != '<' || name.back() != '>')
+		if (!str_starts_with(name, "SYSTEM_SCANCODE_"))
 			return false;
 		char *p;
-		const auto code = strtoul(name.c_str()+1, &p, 10);
-		if (p != name.c_str() + name.size() - 1)
+		const auto code = strtoul(name.c_str()+16, &p, 10);
+		if (p != name.c_str() + name.size())
 			return false;
 		scancode.emplace<u32>(code);
 		return true;

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -6,15 +6,17 @@
 #include "settings.h"
 #include "log.h"
 #include "debug.h"
+#include "renderingengine.h"
 #include "util/hex.h"
 #include "util/string.h"
 #include "util/basic_macros.h"
+#include <vector>
 
 struct table_key {
-	const char *Name;
+	std::string Name;
 	irr::EKEY_CODE Key;
 	wchar_t Char; // L'\0' means no character assigned
-	const char *LangName; // NULL means it doesn't have a human description
+	std::string LangName; // NULL means it doesn't have a human description
 };
 
 #define DEFINEKEY1(x, lang) /* Irrlicht key without character */ \
@@ -30,7 +32,7 @@ struct table_key {
 
 #define N_(text) text
 
-static const struct table_key table[] = {
+static std::vector<table_key> table = {
 	// Keys that can be reliably mapped between Char and Key
 	DEFINEKEY3(0)
 	DEFINEKEY3(1)
@@ -126,7 +128,7 @@ static const struct table_key table[] = {
 	DEFINEKEY1(KEY_ADD, N_("Numpad +"))
 	DEFINEKEY1(KEY_SEPARATOR, N_("Numpad ."))
 	DEFINEKEY1(KEY_SUBTRACT, N_("Numpad -"))
-	DEFINEKEY1(KEY_DECIMAL, NULL)
+	DEFINEKEY1(KEY_DECIMAL, N_("Numpad ."))
 	DEFINEKEY1(KEY_DIVIDE, N_("Numpad /"))
 	DEFINEKEY4(1)
 	DEFINEKEY4(2)
@@ -221,33 +223,16 @@ static const struct table_key table[] = {
 	DEFINEKEY5("_")
 };
 
+static const table_key invalid_key = {"", irr::KEY_UNKNOWN, L'\0', ""};
+
 #undef N_
 
 
-static const table_key &lookup_keyname(const char *name)
-{
-	for (const auto &table_key : table) {
-		if (strcmp(table_key.Name, name) == 0)
-			return table_key;
-	}
-
-	throw UnknownKeycode(name);
-}
-
-static const table_key &lookup_keykey(irr::EKEY_CODE key)
-{
-	for (const auto &table_key : table) {
-		if (table_key.Key == key)
-			return table_key;
-	}
-
-	std::ostringstream os;
-	os << "<Keycode " << (int) key << ">";
-	throw UnknownKeycode(os.str().c_str());
-}
-
 static const table_key &lookup_keychar(wchar_t Char)
 {
+	if (Char == L'\0')
+		return invalid_key;
+
 	for (const auto &table_key : table) {
 		if (table_key.Char == Char)
 			return table_key;
@@ -255,88 +240,73 @@ static const table_key &lookup_keychar(wchar_t Char)
 
 	std::ostringstream os;
 	os << "<Char " << hex_encode((char*) &Char, sizeof(wchar_t)) << ">";
-	throw UnknownKeycode(os.str().c_str());
+	auto newsym = wide_to_utf8(std::wstring_view(&Char, 1));
+	table_key new_key = {newsym, irr::KEY_KEY_CODES_COUNT, Char, newsym};
+	return table.emplace_back(std::move(new_key));
 }
 
-KeyPress::KeyPress(const char *name)
+static const table_key &lookup_keyname(const std::string_view &name)
 {
-	if (strlen(name) == 0) {
-		Key = irr::KEY_KEY_CODES_COUNT;
-		Char = L'\0';
-		m_name = "";
-		return;
+	if (name.empty())
+		return invalid_key;
+
+	for (const auto &table_key : table) {
+		if (table_key.Name == name)
+			return table_key;
 	}
 
-	if (strlen(name) <= 4) {
-		// Lookup by resulting character
-		int chars_read = mbtowc(&Char, name, 1);
-		FATAL_ERROR_IF(chars_read != 1, "Unexpected multibyte character");
-		try {
-			auto &k = lookup_keychar(Char);
-			m_name = k.Name;
-			Key = k.Key;
-			return;
-		} catch (UnknownKeycode &e) {};
-	} else {
-		// Lookup by name
-		m_name = name;
-		try {
-			auto &k = lookup_keyname(name);
-			Key = k.Key;
-			Char = k.Char;
-			return;
-		} catch (UnknownKeycode &e) {};
+	auto wname = utf8_to_wide(name);
+	if (wname.empty())
+		return invalid_key;
+	return lookup_keychar(wname[0]);
+}
+
+static const table_key &lookup_keykey(irr::EKEY_CODE key)
+{
+	if (!KeyCode::isValid(key))
+		return invalid_key;
+
+	for (const auto &table_key : table) {
+		if (table_key.Key == key)
+			return table_key;
 	}
 
-	// It's not a known key, complain and try to do something
-	Key = irr::KEY_KEY_CODES_COUNT;
-	int chars_read = mbtowc(&Char, name, 1);
-	FATAL_ERROR_IF(chars_read != 1, "Unexpected multibyte character");
-	m_name = "";
-	warningstream << "KeyPress: Unknown key '" << name
-		<< "', falling back to first char." << std::endl;
+	std::ostringstream os;
+	os << "<Keycode " << (int) key << ">";
+	return invalid_key;
 }
 
-KeyPress::KeyPress(const irr::SEvent::SKeyInput &in, bool prefer_character)
+static const table_key &lookup_scancode(const u32 scancode)
 {
-	if (prefer_character)
-		Key = irr::KEY_KEY_CODES_COUNT;
-	else
-		Key = in.Key;
-	Char = in.Char;
-
-	try {
-		if (valid_kcode(Key))
-			m_name = lookup_keykey(Key).Name;
-		else
-			m_name = lookup_keychar(Char).Name;
-	} catch (UnknownKeycode &e) {
-		m_name.clear();
-	};
+	auto key = RenderingEngine::get_raw_device()->getKeyFromScancode(scancode);
+	return key.index() == 0 ? lookup_keykey(std::get<irr::EKEY_CODE>(key)) : lookup_keychar(std::get<wchar_t>(key));
 }
 
-const char *KeyPress::sym() const
+KeyPress::KeyPress(const std::string_view &name)
 {
-	return m_name.c_str();
+	const auto &key = lookup_keyname(name);
+	KeyCode keycode(key.Key, key.Char);
+	scancode = RenderingEngine::get_raw_device()->getScancodeFromKey(keycode);
 }
 
-const char *KeyPress::name() const
+std::string KeyPress::sym() const
 {
-	if (m_name.empty())
-		return "";
-	const char *ret;
-	if (valid_kcode(Key))
-		ret = lookup_keykey(Key).LangName;
-	else
-		ret = lookup_keychar(Char).LangName;
-	return ret ? ret : "<Unnamed key>";
+	return lookup_scancode(scancode).Name;
 }
 
-const KeyPress EscapeKey("KEY_ESCAPE");
+std::string KeyPress::name() const
+{
+	return lookup_scancode(scancode).LangName;
+}
 
-const KeyPress LMBKey("KEY_LBUTTON");
-const KeyPress MMBKey("KEY_MBUTTON");
-const KeyPress RMBKey("KEY_RBUTTON");
+std::unordered_map<std::string, KeyPress> KeyPress::specialKeyCache;
+const KeyPress &KeyPress::getSpecialKey(const std::string &name)
+{
+	auto &key = specialKeyCache[name];
+	if (!key)
+		key = KeyPress(name);
+	return key;
+}
 
 /*
 	Key config
@@ -352,7 +322,7 @@ const KeyPress &getKeySetting(const char *settingname)
 		return n->second;
 
 	auto &ref = g_key_setting_cache[settingname];
-	ref = g_settings->get(settingname).c_str();
+	ref = std::string_view(g_settings->get(settingname));
 	return ref;
 }
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -284,6 +284,8 @@ static const table_key &lookup_scancode(const u32 scancode)
 
 KeyPress::KeyPress(const std::string_view &name)
 {
+	if (loadFromScancode(name))
+		return;
 	const auto &key = lookup_keyname(name);
 	KeyCode keycode(key.Key, key.Char);
 	scancode = RenderingEngine::get_raw_device()->getScancodeFromKey(keycode);
@@ -291,12 +293,28 @@ KeyPress::KeyPress(const std::string_view &name)
 
 std::string KeyPress::sym() const
 {
-	return lookup_scancode(scancode).Name;
+	const auto &name = lookup_scancode(scancode).Name;
+	if (!name.empty() || scancode == 0)
+		return name;
+	return formatScancode();
 }
 
 std::string KeyPress::name() const
 {
-	return lookup_scancode(scancode).LangName;
+	const auto &name = lookup_scancode(scancode).LangName;
+	auto table_key = lookup_scancode(scancode);
+	if (!name.empty() || scancode == 0)
+		return name;
+	return formatScancode();
+}
+
+bool KeyPress::loadFromScancode(const std::string_view &name)
+{
+	if (name.size() < 2 || name[0] != '<')
+		return false;
+	char *p;
+	scancode = strtoul(name.data()+1, &p, 10);
+	return p > name.data()+1;
 }
 
 std::unordered_map<std::string, KeyPress> KeyPress::specialKeyCache;

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -309,7 +309,7 @@ void KeyPress::loadFromKey(irr::EKEY_CODE keycode, wchar_t keychar)
 	}
 }
 
-KeyPress::KeyPress(std::string_view name)
+KeyPress::KeyPress(const std::string &name)
 {
 	if (loadFromScancode(name))
 		return;
@@ -365,14 +365,14 @@ wchar_t KeyPress::getKeychar() const
 	return lookup_scancode(scancode).Char;
 }
 
-bool KeyPress::loadFromScancode(std::string_view name)
+bool KeyPress::loadFromScancode(const std::string &name)
 {
 #if USE_SDL2
 	if (name.size() < 2 || name[0] != '<' || name.back() != '>')
 		return false;
 	char *p;
-	const auto code = strtoul(name.data()+1, &p, 10);
-	if (p != name.data() + name.size() - 1)
+	const auto code = strtoul(name.c_str()+1, &p, 10);
+	if (p != name.c_str() + name.size() - 1)
 		return false;
 	scancode.emplace<u32>(code);
 	return true;

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -318,11 +318,14 @@ wchar_t KeyPress::getKeychar() const
 
 bool KeyPress::loadFromScancode(std::string_view name)
 {
-	if (name.size() < 2 || name[0] != '<')
+	if (name.size() < 2 || name[0] != '<' || name.back() != '>')
 		return false;
 	char *p;
-	scancode = strtoul(name.data()+1, &p, 10);
-	return p > name.data()+1;
+	const auto code = strtoul(name.data()+1, &p, 10);
+	if (p != name.data() + name.size() - 1)
+		return false;
+	scancode = code;
+	return true;
 }
 
 std::unordered_map<std::string, KeyPress> KeyPress::specialKeyCache;

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -261,7 +261,7 @@ static const table_key &lookup_keyname(std::string_view name)
 
 static const table_key &lookup_keykey(irr::EKEY_CODE key)
 {
-	if (!KeyCode::isValid(key))
+	if (!Keycode::isValid(key))
 		return invalid_key;
 
 	for (const auto &table_key : table) {
@@ -285,7 +285,7 @@ KeyPress::KeyPress(std::string_view name)
 	if (loadFromScancode(name))
 		return;
 	const auto &key = lookup_keyname(name);
-	KeyCode keycode(key.Key, key.Char);
+	Keycode keycode(key.Key, key.Char);
 	scancode = RenderingEngine::get_raw_device()->getScancodeFromKey(keycode);
 }
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -276,8 +276,11 @@ static const table_key &lookup_keyname(std::string_view name)
 static const table_key &lookup_scancode(const u32 scancode)
 {
 	auto device = RenderingEngine::get_raw_device();
-	if (!device)
+	if (!device) {
+		warningstream << "IrrlichtDevice not available during scancode lookup." <<
+				" The resulting value is invalid." << std::endl;
 		return invalid_key;
+	}
 
 	auto key = device->getKeyFromScancode(scancode);
 	return std::holds_alternative<EKEY_CODE>(key) ?
@@ -294,12 +297,16 @@ static const table_key &lookup_scancode(const std::variant<u32, irr::EKEY_CODE> 
 
 void KeyPress::loadFromKey(irr::EKEY_CODE keycode, wchar_t keychar)
 {
-	if (auto device = RenderingEngine::get_raw_device())
+	if (auto device = RenderingEngine::get_raw_device()) {
 		scancode = device->getScancodeFromKey(Keycode(keycode, keychar));
-	else if (Keycode::isValid(keycode))
-		scancode = keycode;
-	else
-		scancode = (u32) keychar;
+	} else {
+		warningstream << "IrrlichtDevice not available when creating KeyPress." <<
+				" The resulting value may be incorrect or unusable." << std::endl;
+		if (Keycode::isValid(keycode))
+			scancode = keycode;
+		else
+			scancode = (u32) keychar;
+	}
 }
 
 KeyPress::KeyPress(std::string_view name)

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -385,7 +385,7 @@ const KeyPress &getKeySetting(const std::string &settingname)
 		return n->second;
 
 	auto &ref = g_key_setting_cache[settingname];
-	ref = std::string_view(g_settings->get(settingname));
+	ref = KeyPress(g_settings->get(settingname));
 	return ref;
 }
 

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -16,7 +16,7 @@ struct table_key {
 	std::string Name;
 	irr::EKEY_CODE Key;
 	wchar_t Char; // L'\0' means no character assigned
-	std::string LangName; // NULL means it doesn't have a human description
+	std::string LangName; // empty string means it doesn't have a human description
 };
 
 #define DEFINEKEY1(x, lang) /* Irrlicht key without character */ \
@@ -238,6 +238,7 @@ static const table_key &lookup_keychar(wchar_t Char)
 			return table_key;
 	}
 
+	// Create a new entry in the lookup table if one is not available.
 	auto newsym = wide_to_utf8(std::wstring_view(&Char, 1));
 	table_key new_key {newsym, irr::KEY_KEY_CODES_COUNT, Char, newsym};
 	return table.emplace_back(std::move(new_key));
@@ -272,7 +273,6 @@ static const table_key &lookup_keyname(std::string_view name)
 	return lookup_keychar(wname[0]);
 }
 
-#if USE_SDL2
 static const table_key &lookup_scancode(const u32 scancode)
 {
 	auto key = RenderingEngine::get_raw_device()->getKeyFromScancode(scancode);
@@ -287,89 +287,68 @@ static const table_key &lookup_scancode(const std::variant<u32, irr::EKEY_CODE> 
 		lookup_keykey(std::get<irr::EKEY_CODE>(scancode)) :
 		lookup_scancode(std::get<u32>(scancode));
 }
-#endif
 
 KeyPress::KeyPress(std::string_view name)
 {
-#if USE_SDL2
 	if (loadFromScancode(name))
 		return;
 	const auto &key = lookup_keyname(name);
 	Keycode keycode(key.Key, key.Char);
 	scancode = RenderingEngine::get_raw_device()->getScancodeFromKey(keycode);
-#else
-	const auto &key = lookup_keyname(name);
-	Key = key.Key;
-	Char = key.Char;
-#endif
 }
 
 KeyPress::KeyPress(const irr::SEvent::SKeyInput &in)
-#if USE_SDL2
 {
+#if USE_SDL2
 	if (in.SystemKeyCode)
 		scancode.emplace<u32>(in.SystemKeyCode);
 	else
 		scancode.emplace<irr::EKEY_CODE>(in.Key);
-}
 #else
-	: Key(in.Key), Char(in.Char ? in.Char : lookup_keykey(in.Key).Char) {}
+	Keycode keycode(in.Key, in.Char);
+	scancode = RenderingEngine::get_raw_device()->getScancodeFromKey(keycode);
 #endif
+}
 
-#if USE_SDL2
 std::string KeyPress::formatScancode() const
 {
+#if USE_SDL2
 	if (auto pv = std::get_if<u32>(&scancode))
 		return *pv == 0 ? "" : "<" + std::to_string(*pv) + ">";
-	return lookup_keykey(std::get<irr::EKEY_CODE>(scancode)).Name;
-}
 #endif
+	return "";
+}
 
 std::string KeyPress::sym() const
 {
-#if USE_SDL2
-	return formatScancode();
-#else
-	if (Keycode::isValid(Key))
-		if (const auto &sym = lookup_keykey(Key).Name; !sym.empty())
-			return sym;
-	return lookup_keychar(Char).Name;
-#endif
+	std::string name = lookup_scancode(scancode).Name;
+	if (USE_SDL2 || name.empty())
+		if (auto newname = formatScancode(); !newname.empty())
+			return newname;
+	return name;
 }
 
 std::string KeyPress::name() const
 {
-#if USE_SDL2
 	const auto &name = lookup_scancode(scancode).LangName;
 	if (!name.empty())
 		return name;
 	return formatScancode();
-#else
-	return (Keycode::isValid(Key) ? lookup_keykey(Key) : lookup_keychar(Char)).LangName;
-#endif
 }
 
 irr::EKEY_CODE KeyPress::getKeycode() const
 {
-#if USE_SDL2
 	return lookup_scancode(scancode).Key;
-#else
-	return Key;
-#endif
 }
 
 wchar_t KeyPress::getKeychar() const
 {
-#if USE_SDL2
 	return lookup_scancode(scancode).Char;
-#else
-	return Char;
-#endif
 }
 
-#if USE_SDL2
 bool KeyPress::loadFromScancode(std::string_view name)
 {
+#if USE_SDL2
 	if (name.size() < 2 || name[0] != '<' || name.back() != '>')
 		return false;
 	char *p;
@@ -378,8 +357,10 @@ bool KeyPress::loadFromScancode(std::string_view name)
 		return false;
 	scancode.emplace<u32>(code);
 	return true;
-}
+#else
+	return false;
 #endif
+}
 
 std::unordered_map<std::string, KeyPress> KeyPress::specialKeyCache;
 const KeyPress &KeyPress::getSpecialKey(const std::string &name)

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -245,7 +245,7 @@ static const table_key &lookup_keychar(wchar_t Char)
 	return table.emplace_back(std::move(new_key));
 }
 
-static const table_key &lookup_keyname(const std::string_view &name)
+static const table_key &lookup_keyname(std::string_view name)
 {
 	if (name.empty())
 		return invalid_key;
@@ -282,7 +282,7 @@ static const table_key &lookup_scancode(const u32 scancode)
 	return key.index() == 0 ? lookup_keykey(std::get<irr::EKEY_CODE>(key)) : lookup_keychar(std::get<wchar_t>(key));
 }
 
-KeyPress::KeyPress(const std::string_view &name)
+KeyPress::KeyPress(std::string_view name)
 {
 	if (loadFromScancode(name))
 		return;
@@ -318,7 +318,7 @@ wchar_t KeyPress::getKeychar() const
 	return lookup_scancode(scancode).Char;
 }
 
-bool KeyPress::loadFromScancode(const std::string_view &name)
+bool KeyPress::loadFromScancode(std::string_view name)
 {
 	if (name.size() < 2 || name[0] != '<')
 		return false;

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -308,6 +308,16 @@ std::string KeyPress::name() const
 	return formatScancode();
 }
 
+irr::EKEY_CODE KeyPress::getKeycode() const
+{
+	return lookup_scancode(scancode).Key;
+}
+
+wchar_t KeyPress::getKeychar() const
+{
+	return lookup_scancode(scancode).Char;
+}
+
 bool KeyPress::loadFromScancode(const std::string_view &name)
 {
 	if (name.size() < 2 || name[0] != '<')
@@ -333,7 +343,7 @@ const KeyPress &KeyPress::getSpecialKey(const std::string &name)
 // A simple cache for quicker lookup
 static std::unordered_map<std::string, KeyPress> g_key_setting_cache;
 
-const KeyPress &getKeySetting(const char *settingname)
+const KeyPress &getKeySetting(const std::string &settingname)
 {
 	auto n = g_key_setting_cache.find(settingname);
 	if (n != g_key_setting_cache.end())
@@ -347,9 +357,4 @@ const KeyPress &getKeySetting(const char *settingname)
 void clearKeyCache()
 {
 	g_key_setting_cache.clear();
-}
-
-irr::EKEY_CODE keyname_to_keycode(const char *name)
-{
-	return lookup_keyname(name).Key;
 }

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -35,6 +35,13 @@ public:
 	static const KeyPress &getSpecialKey(const std::string &name);
 
 private:
+	bool loadFromScancode(const std::string_view &name);
+
+	inline std::string formatScancode() const
+	{
+		return "<" + std::to_string(scancode) + ">";
+	}
+
 	u32 scancode = 0;
 
 	static std::unordered_map<std::string, KeyPress> specialKeyCache;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -16,7 +16,7 @@ class KeyPress
 public:
 	KeyPress() {};
 
-	KeyPress(const std::string_view &name);
+	KeyPress(std::string_view name);
 
 	KeyPress(const irr::SEvent::SKeyInput &in) :
 		scancode(in.SystemKeyCode) {};
@@ -46,7 +46,7 @@ public:
 	static const KeyPress &getSpecialKey(const std::string &name);
 
 private:
-	bool loadFromScancode(const std::string_view &name);
+	bool loadFromScancode(std::string_view name);
 
 	inline std::string formatScancode() const
 	{

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -8,7 +8,6 @@
 #include <Keycodes.h>
 #include <IEventReceiver.h>
 #include <string>
-#include <unordered_map>
 #include <variant>
 
 /* A key press, consisting of a scancode or a keycode */
@@ -64,8 +63,6 @@ private:
 	std::string formatScancode() const;
 
 	std::variant<u32, irr::EKEY_CODE> scancode = irr::KEY_UNKNOWN;
-
-	static std::unordered_map<std::string, KeyPress> specialKeyCache;
 };
 
 // Global defines for convenience

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -4,57 +4,49 @@
 
 #pragma once
 
-#include "exceptions.h"
 #include "irrlichttypes.h"
 #include <Keycodes.h>
 #include <IEventReceiver.h>
 #include <string>
+#include <unordered_map>
 
-class UnknownKeycode : public BaseException
-{
-public:
-	UnknownKeycode(const char *s) :
-		BaseException(s) {};
-};
-
-/* A key press, consisting of either an Irrlicht keycode
-   or an actual char */
-
+/* A key press, consisting of a scancode or a keycode */
 class KeyPress
 {
 public:
-	KeyPress() = default;
+	KeyPress() {};
 
-	KeyPress(const char *name);
+	KeyPress(const std::string_view &name);
 
-	KeyPress(const irr::SEvent::SKeyInput &in, bool prefer_character = false);
+	KeyPress(const irr::SEvent::SKeyInput &in) :
+		scancode(in.SystemKeyCode) {};
 
-	bool operator==(const KeyPress &o) const
-	{
-		return (Char > 0 && Char == o.Char) || (valid_kcode(Key) && Key == o.Key);
+	std::string sym() const;
+	std::string name() const;
+
+	bool operator==(const KeyPress &o) const {
+		return scancode == o.scancode;
 	}
 
-	const char *sym() const;
-	const char *name() const;
-
-protected:
-	static bool valid_kcode(irr::EKEY_CODE k)
-	{
-		return k > 0 && k < irr::KEY_KEY_CODES_COUNT;
+	operator bool() const {
+		return scancode != 0;
 	}
 
-	irr::EKEY_CODE Key = irr::KEY_KEY_CODES_COUNT;
-	wchar_t Char = L'\0';
-	std::string m_name = "";
+	static const KeyPress &getSpecialKey(const std::string &name);
+
+private:
+	u32 scancode = 0;
+
+	static std::unordered_map<std::string, KeyPress> specialKeyCache;
 };
 
 // Global defines for convenience
-
-extern const KeyPress EscapeKey;
-
-extern const KeyPress LMBKey;
-extern const KeyPress MMBKey; // Middle Mouse Button
-extern const KeyPress RMBKey;
+// This implementation defers creation of the objects to make sure that the
+// IrrlichtDevice is initialized.
+#define EscapeKey KeyPress::getSpecialKey("KEY_ESCAPE")
+#define LMBKey KeyPress::getSpecialKey("KEY_LBUTTON")
+#define MMBKey KeyPress::getSpecialKey("KEY_MBUTTON") // Middle Mouse Button
+#define RMBKey KeyPress::getSpecialKey("KEY_RBUTTON")
 
 // Key configuration getter
 const KeyPress &getKeySetting(const char *settingname);

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "irrlichttypes.h"
-#include "cmake_config.h" // USE_SDL2
 #include <Keycodes.h>
 #include <IEventReceiver.h>
 #include <string>

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -17,7 +17,7 @@ class KeyPress
 public:
 	KeyPress() = default;
 
-	KeyPress(std::string_view name);
+	KeyPress(const std::string &name);
 
 	KeyPress(const irr::SEvent::SKeyInput &in);
 
@@ -59,7 +59,7 @@ public:
 	static const KeyPress &getSpecialKey(const std::string &name);
 
 private:
-	bool loadFromScancode(std::string_view name);
+	bool loadFromScancode(const std::string &name);
 	void loadFromKey(irr::EKEY_CODE keycode, wchar_t keychar);
 	std::string formatScancode() const;
 

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -38,14 +38,6 @@ public:
 		return 0;
 	}
 
-	irr::SEvent toKeyEvent(bool pressedDown = false) const
-	{
-		irr::SEvent event;
-		event.EventType = EET_KEY_INPUT_EVENT;
-		event.KeyInput = {getKeychar(), getKeycode(), getScancode(), pressedDown, false, false};
-		return event;
-	}
-
 	bool operator==(const KeyPress &o) const
 	{
 #if USE_SDL2

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -28,48 +28,32 @@ public:
 	irr::EKEY_CODE getKeycode() const;
 	wchar_t getKeychar() const;
 
-	//TODO: drop this once we fully switch to SDL
 	u32 getScancode() const
 	{
-#if USE_SDL2
 		if (auto pv = std::get_if<u32>(&scancode))
 			return *pv;
-#endif
 		return 0;
 	}
 
 	bool operator==(const KeyPress &o) const
 	{
-#if USE_SDL2
 		return scancode == o.scancode;
-#else
-		return (Char > 0 && Char == o.Char) || (Keycode::isValid(Key) && Key == o.Key);
-#endif
 	}
 
 	operator bool() const
 	{
-#if USE_SDL2
 		return std::holds_alternative<irr::EKEY_CODE>(scancode) ?
 			Keycode::isValid(std::get<irr::EKEY_CODE>(scancode)) :
 			std::get<u32>(scancode) != 0;
-#else
-		return Char > 0 || Keycode::isValid(Key);
-#endif
 	}
 
 	static const KeyPress &getSpecialKey(const std::string &name);
 
 private:
-#if USE_SDL2
 	bool loadFromScancode(std::string_view name);
 	std::string formatScancode() const;
 
 	std::variant<u32, irr::EKEY_CODE> scancode = irr::KEY_UNKNOWN;
-#else
-	irr::EKEY_CODE Key = irr::KEY_KEY_CODES_COUNT;
-	wchar_t Char = L'\0';
-#endif
 
 	static std::unordered_map<std::string, KeyPress> specialKeyCache;
 };

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -35,9 +35,11 @@ public:
 		return 0;
 	}
 
-	bool operator==(const KeyPress &o) const
-	{
+	bool operator==(const KeyPress &o) const {
 		return scancode == o.scancode;
+	}
+	bool operator!=(const KeyPress &o) const {
+		return !(*this == o);
 	}
 
 	operator bool() const

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -24,6 +24,17 @@ public:
 	std::string sym() const;
 	std::string name() const;
 
+	irr::EKEY_CODE getKeycode() const;
+	wchar_t getKeychar() const;
+
+	irr::SEvent toKeyEvent(bool pressedDown = false) const
+	{
+		irr::SEvent event;
+		event.EventType = EET_KEY_INPUT_EVENT;
+		event.KeyInput = {getKeychar(), getKeycode(), scancode, pressedDown, false, false};
+		return event;
+	}
+
 	bool operator==(const KeyPress &o) const {
 		return scancode == o.scancode;
 	}
@@ -56,9 +67,7 @@ private:
 #define RMBKey KeyPress::getSpecialKey("KEY_RBUTTON")
 
 // Key configuration getter
-const KeyPress &getKeySetting(const char *settingname);
+const KeyPress &getKeySetting(const std::string &settingname);
 
 // Clear fast lookup cache
 void clearKeyCache();
-
-irr::EKEY_CODE keyname_to_keycode(const char *name);

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -53,6 +53,7 @@ public:
 
 private:
 	bool loadFromScancode(std::string_view name);
+	void loadFromKey(irr::EKEY_CODE keycode, wchar_t keychar);
 	std::string formatScancode() const;
 
 	std::variant<u32, irr::EKEY_CODE> scancode = irr::KEY_UNKNOWN;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -21,12 +21,19 @@ public:
 
 	KeyPress(const irr::SEvent::SKeyInput &in);
 
+	// Get a string representation that is suitable for use in minetest.conf
 	std::string sym() const;
+
+	// Get a human-readable string representation
 	std::string name() const;
 
+	// Get the corresponding keycode or KEY_UNKNOWN if one is not available
 	irr::EKEY_CODE getKeycode() const;
+
+	// Get the corresponding keychar or '\0' if one is not available
 	wchar_t getKeychar() const;
 
+	// Get the scancode or 0 is one is not available
 	u32 getScancode() const
 	{
 		if (auto pv = std::get_if<u32>(&scancode))
@@ -41,6 +48,7 @@ public:
 		return !(*this == o);
 	}
 
+	// Check whether the keypress is valid
 	operator bool() const
 	{
 		return std::holds_alternative<irr::EKEY_CODE>(scancode) ?

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -134,69 +134,69 @@ void set_default_settings()
 #else
 #define USEKEY2(name, _, value) settings->setDefault(name, value)
 #endif
-	USEKEY2("keymap_forward", "<26>", "KEY_KEY_W");
+	USEKEY2("keymap_forward", "SYSTEM_SCANCODE_26", "KEY_KEY_W");
 	settings->setDefault("keymap_autoforward", "");
-	USEKEY2("keymap_backward", "<22>", "KEY_KEY_S");
-	USEKEY2("keymap_left", "<4>", "KEY_KEY_A");
-	USEKEY2("keymap_right", "<7>", "KEY_KEY_D");
-	USEKEY2("keymap_jump", "<44>", "KEY_SPACE");
+	USEKEY2("keymap_backward", "SYSTEM_SCANCODE_22", "KEY_KEY_S");
+	USEKEY2("keymap_left", "SYSTEM_SCANCODE_4", "KEY_KEY_A");
+	USEKEY2("keymap_right", "SYSTEM_SCANCODE_7", "KEY_KEY_D");
+	USEKEY2("keymap_jump", "SYSTEM_SCANCODE_44", "KEY_SPACE");
 #if !USE_SDL2 && defined(__MACH__) && defined(__APPLE__)
 	// Altered settings for CIrrDeviceOSX
 	settings->setDefault("keymap_sneak", "KEY_SHIFT");
 #else
-	USEKEY2("keymap_sneak", "<225>", "KEY_LSHIFT");
+	USEKEY2("keymap_sneak", "SYSTEM_SCANCODE_225", "KEY_LSHIFT");
 #endif
 	settings->setDefault("keymap_dig", "KEY_LBUTTON");
 	settings->setDefault("keymap_place", "KEY_RBUTTON");
-	USEKEY2("keymap_drop", "<20>", "KEY_KEY_Q");
-	USEKEY2("keymap_zoom", "<29>", "KEY_KEY_Z");
-	USEKEY2("keymap_inventory", "<12>", "KEY_KEY_I");
-	USEKEY2("keymap_aux1", "<8>", "KEY_KEY_E");
-	USEKEY2("keymap_chat", "<23>", "KEY_KEY_T");
-	USEKEY2("keymap_cmd", "<56>", "/");
-	USEKEY2("keymap_cmd_local", "<55>", ".");
-	USEKEY2("keymap_minimap", "<25>", "KEY_KEY_V");
-	USEKEY2("keymap_console", "<67>", "KEY_F10");
+	USEKEY2("keymap_drop", "SYSTEM_SCANCODE_20", "KEY_KEY_Q");
+	USEKEY2("keymap_zoom", "SYSTEM_SCANCODE_29", "KEY_KEY_Z");
+	USEKEY2("keymap_inventory", "SYSTEM_SCANCODE_12", "KEY_KEY_I");
+	USEKEY2("keymap_aux1", "SYSTEM_SCANCODE_8", "KEY_KEY_E");
+	USEKEY2("keymap_chat", "SYSTEM_SCANCODE_23", "KEY_KEY_T");
+	USEKEY2("keymap_cmd", "SYSTEM_SCANCODE_56", "/");
+	USEKEY2("keymap_cmd_local", "SYSTEM_SCANCODE_55", ".");
+	USEKEY2("keymap_minimap", "SYSTEM_SCANCODE_25", "KEY_KEY_V");
+	USEKEY2("keymap_console", "SYSTEM_SCANCODE_67", "KEY_F10");
 
 	// see <https://github.com/luanti-org/luanti/issues/12792>
-	USEKEY2("keymap_rangeselect", has_touch ? "<21>" : "", has_touch ? "KEY_KEY_R" : "");
+	USEKEY2("keymap_rangeselect", has_touch ? "SYSTEM_SCANCODE_21" : "", has_touch ? "KEY_KEY_R" : "");
 
-	USEKEY2("keymap_freemove", "<14>", "KEY_KEY_K");
+	USEKEY2("keymap_freemove", "SYSTEM_SCANCODE_14", "KEY_KEY_K");
 	settings->setDefault("keymap_pitchmove", "");
-	USEKEY2("keymap_fastmove", "<13>", "KEY_KEY_J");
-	USEKEY2("keymap_noclip", "<11>", "KEY_KEY_H");
-	USEKEY2("keymap_hotbar_next", "<17>", "KEY_KEY_N");
-	USEKEY2("keymap_hotbar_previous", "<5>", "KEY_KEY_B");
-	USEKEY2("keymap_mute", "<16>", "KEY_KEY_M");
+	USEKEY2("keymap_fastmove", "SYSTEM_SCANCODE_13", "KEY_KEY_J");
+	USEKEY2("keymap_noclip", "SYSTEM_SCANCODE_11", "KEY_KEY_H");
+	USEKEY2("keymap_hotbar_next", "SYSTEM_SCANCODE_17", "KEY_KEY_N");
+	USEKEY2("keymap_hotbar_previous", "SYSTEM_SCANCODE_5", "KEY_KEY_B");
+	USEKEY2("keymap_mute", "SYSTEM_SCANCODE_16", "KEY_KEY_M");
 	settings->setDefault("keymap_increase_volume", "");
 	settings->setDefault("keymap_decrease_volume", "");
 	settings->setDefault("keymap_cinematic", "");
 	settings->setDefault("keymap_toggle_block_bounds", "");
-	USEKEY2("keymap_toggle_hud", "<58>", "KEY_F1");
-	USEKEY2("keymap_toggle_chat", "<59>", "KEY_F2");
-	USEKEY2("keymap_toggle_fog", "<60>", "KEY_F3");
+	USEKEY2("keymap_toggle_hud", "SYSTEM_SCANCODE_58", "KEY_F1");
+	USEKEY2("keymap_toggle_chat", "SYSTEM_SCANCODE_59", "KEY_F2");
+	USEKEY2("keymap_toggle_fog", "SYSTEM_SCANCODE_60", "KEY_F3");
 #ifndef NDEBUG
-	USEKEY2("keymap_toggle_update_camera", "<61>", "KEY_F4");
+	USEKEY2("keymap_toggle_update_camera", "SYSTEM_SCANCODE_61", "KEY_F4");
 #else
 	settings->setDefault("keymap_toggle_update_camera", "");
 #endif
-	USEKEY2("keymap_toggle_debug", "<62>", "KEY_F5");
-	USEKEY2("keymap_toggle_profiler", "<63>", "KEY_F6");
-	USEKEY2("keymap_camera_mode", "<6>", "KEY_KEY_C");
-	USEKEY2("keymap_screenshot", "<69>", "KEY_F12");
-	USEKEY2("keymap_fullscreen", "<68>", "KEY_F11");
-	USEKEY2("keymap_increase_viewing_range_min", "<46>", "+");
-	USEKEY2("keymap_decrease_viewing_range_min", "<45>", "-");
-	USEKEY2("keymap_slot1", "<30>", "KEY_KEY_1");
-	USEKEY2("keymap_slot2", "<31>", "KEY_KEY_2");
-	USEKEY2("keymap_slot3", "<32>", "KEY_KEY_3");
-	USEKEY2("keymap_slot4", "<33>", "KEY_KEY_4");
-	USEKEY2("keymap_slot5", "<34>", "KEY_KEY_5");
-	USEKEY2("keymap_slot6", "<35>", "KEY_KEY_6");
-	USEKEY2("keymap_slot7", "<36>", "KEY_KEY_7");
-	USEKEY2("keymap_slot8", "<37>", "KEY_KEY_8");
-	USEKEY2("keymap_slot9", "<38>", "KEY_KEY_9");
-	USEKEY2("keymap_slot10", "<39>", "KEY_KEY_0");
+	USEKEY2("keymap_toggle_debug", "SYSTEM_SCANCODE_62", "KEY_F5");
+	USEKEY2("keymap_toggle_profiler", "SYSTEM_SCANCODE_63", "KEY_F6");
+	USEKEY2("keymap_camera_mode", "SYSTEM_SCANCODE_6", "KEY_KEY_C");
+	USEKEY2("keymap_screenshot", "SYSTEM_SCANCODE_69", "KEY_F12");
+	USEKEY2("keymap_fullscreen", "SYSTEM_SCANCODE_68", "KEY_F11");
+	USEKEY2("keymap_increase_viewing_range_min", "SYSTEM_SCANCODE_46", "+");
+	USEKEY2("keymap_decrease_viewing_range_min", "SYSTEM_SCANCODE_45", "-");
+	USEKEY2("keymap_slot1", "SYSTEM_SCANCODE_30", "KEY_KEY_1");
+	USEKEY2("keymap_slot2", "SYSTEM_SCANCODE_31", "KEY_KEY_2");
+	USEKEY2("keymap_slot3", "SYSTEM_SCANCODE_32", "KEY_KEY_3");
+	USEKEY2("keymap_slot4", "SYSTEM_SCANCODE_33", "KEY_KEY_4");
+	USEKEY2("keymap_slot5", "SYSTEM_SCANCODE_34", "KEY_KEY_5");
+	USEKEY2("keymap_slot6", "SYSTEM_SCANCODE_35", "KEY_KEY_6");
+	USEKEY2("keymap_slot7", "SYSTEM_SCANCODE_36", "KEY_KEY_7");
+	USEKEY2("keymap_slot8", "SYSTEM_SCANCODE_37", "KEY_KEY_8");
+	USEKEY2("keymap_slot9", "SYSTEM_SCANCODE_38", "KEY_KEY_9");
+	USEKEY2("keymap_slot10", "SYSTEM_SCANCODE_39", "KEY_KEY_0");
 	settings->setDefault("keymap_slot11", "");
 	settings->setDefault("keymap_slot12", "");
 	settings->setDefault("keymap_slot13", "");
@@ -222,10 +222,10 @@ void set_default_settings()
 
 #ifndef NDEBUG
 	// Default keybinds for quicktune in debug builds
-	USEKEY2("keymap_quicktune_prev", "<74>", "KEY_HOME");
-	USEKEY2("keymap_quicktune_next", "<77>", "KEY_END");
-	USEKEY2("keymap_quicktune_dec", "<81>", "KEY_NEXT");
-	USEKEY2("keymap_quicktune_inc", "<82>", "KEY_PRIOR");
+	USEKEY2("keymap_quicktune_prev", "SYSTEM_SCANCODE_74", "KEY_HOME");
+	USEKEY2("keymap_quicktune_next", "SYSTEM_SCANCODE_77", "KEY_END");
+	USEKEY2("keymap_quicktune_dec", "SYSTEM_SCANCODE_81", "KEY_NEXT");
+	USEKEY2("keymap_quicktune_inc", "SYSTEM_SCANCODE_82", "KEY_PRIOR");
 #else
 	settings->setDefault("keymap_quicktune_prev", "");
 	settings->setDefault("keymap_quicktune_next", "");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -82,6 +82,7 @@ void set_default_settings()
 
 	// Client
 	settings->setDefault("address", "");
+	settings->setDefault("remote_port", "30000");
 #if defined(__unix__) && !defined(__APPLE__) && !defined (__ANDROID__)
 	// On Linux+X11 (not Linux+Wayland or Linux+XWayland), I've encountered a bug
 	// where fake mouse events were generated from touch events if in relative
@@ -128,65 +129,74 @@ void set_default_settings()
 	settings->setDefault("chat_weblink_color", "#8888FF");
 
 	// Keymap
-	settings->setDefault("remote_port", "30000");
-	settings->setDefault("keymap_forward", "KEY_KEY_W");
+#if USE_SDL2
+#define USEKEY2(name, value, _) settings->setDefault(name, value)
+#else
+#define USEKEY2(name, _, value) settings->setDefault(name, value)
+#endif
+	USEKEY2("keymap_forward", "<26>", "KEY_KEY_W");
 	settings->setDefault("keymap_autoforward", "");
-	settings->setDefault("keymap_backward", "KEY_KEY_S");
-	settings->setDefault("keymap_left", "KEY_KEY_A");
-	settings->setDefault("keymap_right", "KEY_KEY_D");
-	settings->setDefault("keymap_jump", "KEY_SPACE");
-	settings->setDefault("keymap_sneak", "KEY_LSHIFT");
+	USEKEY2("keymap_backward", "<22>", "KEY_KEY_S");
+	USEKEY2("keymap_left", "<4>", "KEY_KEY_A");
+	USEKEY2("keymap_right", "<7>", "KEY_KEY_D");
+	USEKEY2("keymap_jump", "<44>", "KEY_SPACE");
+#if !USE_SDL2 && defined(__MACH__) && defined(__APPLE__)
+	// Altered settings for CIrrDeviceOSX
+	settings->setDefault("keymap_sneak", "KEY_SHIFT");
+#else
+	USEKEY2("keymap_sneak", "<225>", "KEY_LSHIFT");
+#endif
 	settings->setDefault("keymap_dig", "KEY_LBUTTON");
 	settings->setDefault("keymap_place", "KEY_RBUTTON");
-	settings->setDefault("keymap_drop", "KEY_KEY_Q");
-	settings->setDefault("keymap_zoom", "KEY_KEY_Z");
-	settings->setDefault("keymap_inventory", "KEY_KEY_I");
-	settings->setDefault("keymap_aux1", "KEY_KEY_E");
-	settings->setDefault("keymap_chat", "KEY_KEY_T");
-	settings->setDefault("keymap_cmd", "/");
-	settings->setDefault("keymap_cmd_local", ".");
-	settings->setDefault("keymap_minimap", "KEY_KEY_V");
-	settings->setDefault("keymap_console", "KEY_F10");
+	USEKEY2("keymap_drop", "<20>", "KEY_KEY_Q");
+	USEKEY2("keymap_zoom", "<29>", "KEY_KEY_Z");
+	USEKEY2("keymap_inventory", "<12>", "KEY_KEY_I");
+	USEKEY2("keymap_aux1", "<8>", "KEY_KEY_E");
+	USEKEY2("keymap_chat", "<23>", "KEY_KEY_T");
+	USEKEY2("keymap_cmd", "<56>", "/");
+	USEKEY2("keymap_cmd_local", "<55>", ".");
+	USEKEY2("keymap_minimap", "<25>", "KEY_KEY_V");
+	USEKEY2("keymap_console", "<67>", "KEY_F10");
 
-	// see <https://github.com/luanti-org/luanti/issues/12792>
-	settings->setDefault("keymap_rangeselect", has_touch ? "KEY_KEY_R" : "");
+	// See https://github.com/minetest/minetest/issues/12792
+	USEKEY2("keymap_rangeselect", has_touch ? "<21>" : "", has_touch ? "KEY_KEY_R" : "");
 
-	settings->setDefault("keymap_freemove", "KEY_KEY_K");
+	USEKEY2("keymap_freemove", "<14>", "KEY_KEY_K");
 	settings->setDefault("keymap_pitchmove", "");
-	settings->setDefault("keymap_fastmove", "KEY_KEY_J");
-	settings->setDefault("keymap_noclip", "KEY_KEY_H");
-	settings->setDefault("keymap_hotbar_next", "KEY_KEY_N");
-	settings->setDefault("keymap_hotbar_previous", "KEY_KEY_B");
-	settings->setDefault("keymap_mute", "KEY_KEY_M");
+	USEKEY2("keymap_fastmove", "<13>", "KEY_KEY_J");
+	USEKEY2("keymap_noclip", "<11>", "KEY_KEY_H");
+	USEKEY2("keymap_hotbar_next", "<17>", "KEY_KEY_N");
+	USEKEY2("keymap_hotbar_previous", "<5>", "KEY_KEY_B");
+	USEKEY2("keymap_mute", "<16>", "KEY_KEY_M");
 	settings->setDefault("keymap_increase_volume", "");
 	settings->setDefault("keymap_decrease_volume", "");
 	settings->setDefault("keymap_cinematic", "");
 	settings->setDefault("keymap_toggle_block_bounds", "");
-	settings->setDefault("keymap_toggle_hud", "KEY_F1");
-	settings->setDefault("keymap_toggle_chat", "KEY_F2");
-	settings->setDefault("keymap_toggle_fog", "KEY_F3");
+	USEKEY2("keymap_toggle_hud", "<58>", "KEY_F1");
+	USEKEY2("keymap_toggle_chat", "<59>", "KEY_F2");
+	USEKEY2("keymap_toggle_fog", "<60>", "KEY_F3");
 #ifndef NDEBUG
-	settings->setDefault("keymap_toggle_update_camera", "KEY_F4");
+	USEKEY2("keymap_toggle_update_camera", "<61>", "KEY_F4");
 #else
 	settings->setDefault("keymap_toggle_update_camera", "");
 #endif
-	settings->setDefault("keymap_toggle_debug", "KEY_F5");
-	settings->setDefault("keymap_toggle_profiler", "KEY_F6");
-	settings->setDefault("keymap_camera_mode", "KEY_KEY_C");
-	settings->setDefault("keymap_screenshot", "KEY_F12");
-	settings->setDefault("keymap_fullscreen", "KEY_F11");
-	settings->setDefault("keymap_increase_viewing_range_min", "+");
-	settings->setDefault("keymap_decrease_viewing_range_min", "-");
-	settings->setDefault("keymap_slot1", "KEY_KEY_1");
-	settings->setDefault("keymap_slot2", "KEY_KEY_2");
-	settings->setDefault("keymap_slot3", "KEY_KEY_3");
-	settings->setDefault("keymap_slot4", "KEY_KEY_4");
-	settings->setDefault("keymap_slot5", "KEY_KEY_5");
-	settings->setDefault("keymap_slot6", "KEY_KEY_6");
-	settings->setDefault("keymap_slot7", "KEY_KEY_7");
-	settings->setDefault("keymap_slot8", "KEY_KEY_8");
-	settings->setDefault("keymap_slot9", "KEY_KEY_9");
-	settings->setDefault("keymap_slot10", "KEY_KEY_0");
+	USEKEY2("keymap_toggle_debug", "<62>", "KEY_F5");
+	USEKEY2("keymap_toggle_profiler", "<63>", "KEY_F6");
+	USEKEY2("keymap_camera_mode", "<6>", "KEY_KEY_C");
+	USEKEY2("keymap_screenshot", "<69>", "KEY_F12");
+	USEKEY2("keymap_fullscreen", "<68>", "KEY_F11");
+	USEKEY2("keymap_increase_viewing_range_min", "<46>", "+");
+	USEKEY2("keymap_decrease_viewing_range_min", "<45>", "-");
+	USEKEY2("keymap_slot1", "<30>", "KEY_KEY_1");
+	USEKEY2("keymap_slot2", "<31>", "KEY_KEY_2");
+	USEKEY2("keymap_slot3", "<32>", "KEY_KEY_3");
+	USEKEY2("keymap_slot4", "<33>", "KEY_KEY_4");
+	USEKEY2("keymap_slot5", "<34>", "KEY_KEY_5");
+	USEKEY2("keymap_slot6", "<35>", "KEY_KEY_6");
+	USEKEY2("keymap_slot7", "<36>", "KEY_KEY_7");
+	USEKEY2("keymap_slot8", "<37>", "KEY_KEY_8");
+	USEKEY2("keymap_slot9", "<38>", "KEY_KEY_9");
+	USEKEY2("keymap_slot10", "<39>", "KEY_KEY_0");
 	settings->setDefault("keymap_slot11", "");
 	settings->setDefault("keymap_slot12", "");
 	settings->setDefault("keymap_slot13", "");
@@ -212,16 +222,18 @@ void set_default_settings()
 
 #ifndef NDEBUG
 	// Default keybinds for quicktune in debug builds
-	settings->setDefault("keymap_quicktune_prev", "KEY_HOME");
-	settings->setDefault("keymap_quicktune_next", "KEY_END");
-	settings->setDefault("keymap_quicktune_dec", "KEY_NEXT");
-	settings->setDefault("keymap_quicktune_inc", "KEY_PRIOR");
+	USEKEY2("keymap_quicktune_prev", "<74>", "KEY_HOME");
+	USEKEY2("keymap_quicktune_next", "<77>", "KEY_END");
+	USEKEY2("keymap_quicktune_dec", "<81>", "KEY_NEXT");
+	USEKEY2("keymap_quicktune_inc", "<82>", "KEY_PRIOR");
 #else
 	settings->setDefault("keymap_quicktune_prev", "");
 	settings->setDefault("keymap_quicktune_next", "");
 	settings->setDefault("keymap_quicktune_dec", "");
 	settings->setDefault("keymap_quicktune_inc", "");
 #endif
+#undef USEKEY
+#undef USEKEY2
 
 	// Visuals
 #ifdef NDEBUG
@@ -532,11 +544,6 @@ void set_default_settings()
 	settings->setDefault("enable_console", "false");
 	settings->setDefault("display_density_factor", "1");
 	settings->setDefault("dpi_change_notifier", "0");
-
-	// Altered settings for CIrrDeviceOSX
-#if !USE_SDL2 && defined(__MACH__) && defined(__APPLE__)
-	settings->setDefault("keymap_sneak", "KEY_SHIFT");
-#endif
 
 	settings->setDefault("touch_layout", "");
 	settings->setDefault("touchscreen_sensitivity", "0.2");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -158,7 +158,7 @@ void set_default_settings()
 	USEKEY2("keymap_minimap", "<25>", "KEY_KEY_V");
 	USEKEY2("keymap_console", "<67>", "KEY_F10");
 
-	// See https://github.com/minetest/minetest/issues/12792
+	// see <https://github.com/luanti-org/luanti/issues/12792>
 	USEKEY2("keymap_rangeselect", has_touch ? "<21>" : "", has_touch ? "KEY_KEY_R" : "");
 
 	USEKEY2("keymap_freemove", "<14>", "KEY_KEY_K");
@@ -232,7 +232,6 @@ void set_default_settings()
 	settings->setDefault("keymap_quicktune_dec", "");
 	settings->setDefault("keymap_quicktune_inc", "");
 #endif
-#undef USEKEY
 #undef USEKEY2
 
 	// Visuals

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -252,8 +252,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 	if (event.EventType == EET_KEY_INPUT_EVENT && active_key
 			&& event.KeyInput.PressedDown) {
 
-		bool prefer_character = shift_down;
-		KeyPress kp(event.KeyInput, prefer_character);
+		KeyPress kp(event.KeyInput);
 
 		if (event.KeyInput.Key == irr::KEY_DELETE)
 			kp = KeyPress(""); // To erase key settings
@@ -269,7 +268,7 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
 
 		// Display Key already in use message
 		bool key_in_use = false;
-		if (strcmp(kp.sym(), "") != 0) {
+		if (kp) {
 			for (key_setting *ks : key_settings) {
 				if (ks != active_key && ks->key == kp) {
 					key_in_use = true;

--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -147,12 +147,13 @@ bool GUIModalMenu::remapClickOutside(const SEvent &event)
 	if (event.MouseInput.Event == EMIE_LMOUSE_LEFT_UP &&
 			current.isRelated(last)) {
 		SEvent translated{};
-		translated.EventType            = EET_KEY_INPUT_EVENT;
-		translated.KeyInput.Key         = KEY_ESCAPE;
-		translated.KeyInput.Control     = false;
-		translated.KeyInput.Shift       = false;
-		translated.KeyInput.PressedDown = true;
-		translated.KeyInput.Char        = 0;
+		translated.EventType              = EET_KEY_INPUT_EVENT;
+		translated.KeyInput.Key           = KEY_ESCAPE;
+		translated.KeyInput.SystemKeyCode = EscapeKey.getScancode();
+		translated.KeyInput.Control       = false;
+		translated.KeyInput.Shift         = false;
+		translated.KeyInput.PressedDown   = true;
+		translated.KeyInput.Char          = 0;
 		OnEvent(translated);
 		return true;
 	}

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -196,7 +196,11 @@ static const KeyPress &id_to_keypress(touch_gui_button_id id)
 			break;
 	}
 	assert(!key.empty());
-	return getKeySetting("keymap_" + key);
+	auto &kp = getKeySetting("keymap_" + key);
+	if (!kp)
+		warningstream << "TouchControls: Unbound or invalid key for"
+				<< key << ", hiding button." << std::endl;
+	return kp;
 }
 
 

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -732,11 +732,11 @@ void TouchControls::releaseAll()
 	// Release those manually too since the change initiated by
 	// handleReleaseEvent will only be applied later by applyContextControls.
 	if (m_dig_pressed) {
-		emitKeyboardEvent(id_to_keycode(dig_id), false);
+		emitKeyboardEvent(id_to_keypress(dig_id), false);
 		m_dig_pressed = false;
 	}
 	if (m_place_pressed) {
-		emitKeyboardEvent(id_to_keycode(place_id), false);
+		emitKeyboardEvent(id_to_keypress(place_id), false);
 		m_place_pressed = false;
 	}
 }
@@ -817,20 +817,20 @@ void TouchControls::applyContextControls(const TouchInteractionMode &mode)
 	target_place_pressed |= now < m_place_pressed_until;
 
 	if (target_dig_pressed && !m_dig_pressed) {
-		emitKeyboardEvent(id_to_keycode(dig_id), true);
+		emitKeyboardEvent(id_to_keypress(dig_id), true);
 		m_dig_pressed = true;
 
 	} else if (!target_dig_pressed && m_dig_pressed) {
-		emitKeyboardEvent(id_to_keycode(dig_id), false);
+		emitKeyboardEvent(id_to_keypress(dig_id), false);
 		m_dig_pressed = false;
 	}
 
 	if (target_place_pressed && !m_place_pressed) {
-		emitKeyboardEvent(id_to_keycode(place_id), true);
+		emitKeyboardEvent(id_to_keypress(place_id), true);
 		m_place_pressed = true;
 
 	} else if (!target_place_pressed && m_place_pressed) {
-		emitKeyboardEvent(id_to_keycode(place_id), false);
+		emitKeyboardEvent(id_to_keypress(place_id), false);
 		m_place_pressed = false;
 	}
 }

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -32,7 +32,15 @@ TouchControls *g_touchcontrols;
 
 void TouchControls::emitKeyboardEvent(const KeyPress &key, bool pressed)
 {
-	m_receiver->OnEvent(key.toKeyEvent(pressed));
+	SEvent e{};
+	e.EventType              = EET_KEY_INPUT_EVENT;
+	e.KeyInput.Key           = key.getKeycode();
+	e.KeyInput.Control       = false;
+	e.KeyInput.Shift         = false;
+	e.KeyInput.Char          = key.getKeychar();
+	e.KeyInput.SystemKeyCode = key.getScancode();
+	e.KeyInput.PressedDown   = pressed;
+	m_receiver->OnEvent(e);
 }
 
 void TouchControls::loadButtonTexture(IGUIImage *gui_button, const std::string &path)

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -198,13 +198,7 @@ static EKEY_CODE id_to_keycode(touch_gui_button_id id)
 	}
 	assert(!key.empty());
 	std::string resolved = g_settings->get("keymap_" + key);
-	try {
-		code = keyname_to_keycode(resolved.c_str());
-	} catch (UnknownKeycode &e) {
-		code = KEY_UNKNOWN;
-		warningstream << "TouchControls: Unknown key '" << resolved
-			      << "' for '" << key << "', hiding button." << std::endl;
-	}
+	code = keyname_to_keycode(resolved.c_str());
 	return code;
 }
 

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -16,6 +16,7 @@
 #include "itemdef.h"
 #include "touchscreenlayout.h"
 #include "util/basic_macros.h"
+#include "client/keycode.h"
 
 namespace irr
 {
@@ -57,7 +58,7 @@ enum class TapState
 struct button_info
 {
 	float repeat_counter;
-	EKEY_CODE keycode;
+	KeyPress keypress;
 	std::vector<size_t> pointer_ids;
 	std::shared_ptr<IGUIImage> gui_button = nullptr;
 
@@ -202,7 +203,7 @@ private:
 	// for its buttons. We only want static image display, not interactivity,
 	// from Irrlicht.
 
-	void emitKeyboardEvent(EKEY_CODE keycode, bool pressed);
+	void emitKeyboardEvent(const KeyPress &keycode, bool pressed);
 
 	void loadButtonTexture(IGUIImage *gui_button, const std::string &path);
 	void buttonEmitAction(button_info &btn, bool action);

--- a/src/unittest/test_keycode.cpp
+++ b/src/unittest/test_keycode.cpp
@@ -15,19 +15,25 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
+	/* TODO: Re-introduce unittests after fully switching to SDL.
 	void testCreateFromString();
 	void testCreateFromSKeyInput();
 	void testCompare();
+	*/
 };
 
 static TestKeycode g_test_instance;
 
 void TestKeycode::runTests(IGameDef *gamedef)
 {
+	/*
 	TEST(testCreateFromString);
 	TEST(testCreateFromSKeyInput);
 	TEST(testCompare);
+	*/
 }
+
+#if 0
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -112,3 +118,5 @@ void TestKeycode::testCompare()
 	in2.Char = L';';
 	UASSERT(KeyPress(in) == KeyPress(in2));
 }
+
+#endif


### PR DESCRIPTION
This PR makes Minetest use scancodes for keybindings.

- Goal of the PR
  Make Minetest use scancodes (instead of keycodes) for key bindings.
- How does the PR work?
  The SDL scancode is passed to `SKeyInput::SystemKeyCode`. The `KeyPress` class is modified to be basically a wrapper around this.
- Does it resolve any reported issue?
  - Fixes #14940
  - Fixes #13904 (if not, this would be an upstream issue)
  - Fixes #15747
  - Resolves #12556 (relevant code path removed)
  - Resolves #8781 (keycode-based syntax deprecated)
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  Yes - SDL.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  This was discussed recently.

Related: #12507 (new default key), #14545, #14874 (allows people to continue using e.g. Shift+7 if they want to).

Documentation update: luanti-org/docs.luanti.org#211

## To do

This PR is ready for review.

- [x] Switch to scancodes for SDL. Address regressions:
  - [x] Fix: Escape and `AC_BACK` keys not working.
  - [x] Fix: (Android) Cannot close formspec when a text field is focused.
  - [x] Fix: actions without keybindings are bound to the left mouse button.
  - [x] Properly implement scancodes (using `std::variant`) for keypresses from non-keyboard input (mouse, joystick, etc.)
  - [x] Convert `KEY_OEM_*` keys to scancodes directly. (See note below)
  The current approach no longer requires changing non-SDL `IrrlichtDevices`.
- Partial rework of `KeyPress` and event handling
  - [x] Rework `KeyPress`
  - [x] Allow binding to keys with keychars (keycodes) not in the lookup table.
  - [x] Allow binding to keys with no keycode (e.g. dead keys).
  - [x] Change touchscreen GUI to send events with scancodes.
- Keybinding settings
  - [x] Add syntax for scancode settings. (see notes)
- Followup PRs:
  - Allow using secondary keybindings: #15577
  - Allow keybindings with modifer keys: #14874
  - **Important:** Warn users about new keybindings.
  - After removing non-SDL `IrrlichtDevice`s:
    - Expose SDL headers to Luanti.
    - Implement `std::hash<KeyPress>` and replace `KeyList` with `std::unordered_set<KeyPress>`
    - Implement SDL-specific scancode names (i.e. `SDL_SCANCODE_x`). (Useful for #12488) Note that this requires Luanti (not just Irrlicht) to have access to SDL headers.
    - Fix unittests

## How to test
* Set keybindings as usual or use existing keybinding settings. (In particular, test binding to keys such as backtick, `ü`, and dead keys). Observe that the keybinding (in terms of scancodes) is the same after switching to a different layout.
* Observe that both the Escape key and the Android back key work as the same key.

## Notes
* The scancode-based keybinding syntax introduced in this PR is only used (and enabled) for SDL builds.
* Unittests have been disabled:
  * The behavior of `KeyPress` is fully dependent on the Irrlicht device.
  * Scancode/keycode conversions for SDL require an active `IrrlichtDevice` which is not available in unittests.
* The "press Shift to bind to symbols" feature has been removed as it does not work with SDL scancodes. Note that this causes existing configurations to break *even when Minetest is built without SDL*.
* The Irrlicht source code suggests that the various OEM keys refer to phsical keys (similar to SDL scancodes), but on my non-SDL X11 build it appears that the _exact_ OEM key still depends on the keyboard layout.
* https://github.com/minetest/minetest/pull/14964#issuecomment-2299626800
* This PR uses scancodes for individual keys. In particular, left shift and right shift are treated as separate keys. *Addressing this requires a separate/followup PR that implements secondary keybindings.*
* We will end up (one way or another) requiring requiring some users to rebind their keys regardless of what we choose as the default. Scancode-based defaults basically break keyboard layouts where a key is located in a different position than its US counterpart, while keycode-based configurations would break on layouts where a key is not present in the **unshifted** position. (https://github.com/minetest/minetest/pull/14964#issuecomment-2559974639 and https://irc.minetest.net/minetest-dev/2024-12-26#i_6230893) Using a mixture of both can result in key conflicts (https://irc.minetest.net/minetest-dev/2024-11-10#i_6216414)