### PR TITLE
Proper incomplete mod handling

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -100,8 +100,7 @@ local function check_mod_configuration(world_path, all_mods)
 	local with_error = {}
 	for _, mod in ipairs(config_status.satisfied_mods) do
 		if not mod.valid then
-			local error = { type = "error", reason = "invalid" }
-			with_error[mod.virtual_path] = error
+			with_error[mod.virtual_path] = { type = "error", reason = "invalid" }
 		end
 	end
 	for _, mod in ipairs(config_status.unsatisfied_mods) do
@@ -174,22 +173,22 @@ local function get_formspec(data)
 		local hard_deps_str = table.concat(hard_deps, ",")
 		local soft_deps_str = table.concat(soft_deps, ",")
 
-		local error_messages = ""
+		local error_message = ""
 
 		local error = with_error[mod.virtual_path]
 		if error and
 			error.type == "error" and
-			-- do not handle this error by message because is is handled by
-			-- dependency list
+			-- do not display "unsatisfied_depends" error as message because is
+			-- is displayed by dependency list
 			error.reason ~= "unsatisfied_depends"
-			then
-				error_messages = error_messages ..
-				fgettext(minetest.colorize(mt_color_red, "Errors:") .. "\n")
-				if error.reason == "invalid" then
-					error_messages = error_messages .. fgettext(
-					"Mod is incomplete because it has no \"init.lua\" file. " ..
-					"Dependencies are not visible because of this.")
-				end
+		then
+			error_message = error_message ..
+			fgettext(minetest.colorize(mt_color_red, "Errors:") .. "\n")
+			if error.reason == "invalid" then
+				error_message = error_message .. fgettext(
+				"Mod is incomplete because it has no \"init.lua\" file. " ..
+				"Dependencies are not visible because of this.")
+			end
 		end
 
 		retval = retval ..
@@ -201,7 +200,7 @@ local function get_formspec(data)
 				retval = retval ..
 					"label[0,1.25;" ..
 					fgettext("No (optional) dependencies") .. "]" ..
-					"textarea[0.25,1.75;5.75,7.2;;" .. error_messages .. ";]"
+					"textarea[0.25,1.75;5.75,7.2;;" .. error_message .. ";]"
 			else
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("No hard dependencies") ..
@@ -210,7 +209,7 @@ local function get_formspec(data)
 					"]" ..
 					"textlist[0,2.25;5,4;world_config_optdepends;" ..
 					soft_deps_str .. ";0]" ..
-					"textarea[0.25,6.5;3.45,1.75;;" .. error_messages .. ";]"
+					"textarea[0.25,6.5;3.45,1.75;;" .. error_message .. ";]"
 			end
 		else
 			if soft_deps_str == "" then
@@ -219,7 +218,7 @@ local function get_formspec(data)
 					"textlist[0,1.75;5,4;world_config_depends;" ..
 					hard_deps_str .. ";0]" ..
 					"label[0,6;" .. fgettext("No optional dependencies") .. "]" ..
-					"textarea[0.25,6.5;3.45,1.75;;" .. error_messages .. ";]"
+					"textarea[0.25,6.5;3.45,1.75;;" .. error_message .. ";]"
 			else
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
@@ -229,7 +228,7 @@ local function get_formspec(data)
 					"]" ..
 					"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
 					soft_deps_str .. ";0]" ..
-					"textarea[0.25,6.5;3.45,1.75;;" .. error_messages .. ";]"
+					"textarea[0.25,6.5;3.45,1.75;;" .. error_message .. ";]"
 			end
 		end
 	end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -98,8 +98,14 @@ local function check_mod_configuration(world_path, all_mods)
 
 	-- Build the table of errors
 	local with_error = {}
+	for _, mod in ipairs(config_status.satisfied_mods) do
+		if not mod.valid then
+			local error = { type = "error", reason = "invalid" }
+			with_error[mod.virtual_path] = error
+		end
+	end
 	for _, mod in ipairs(config_status.unsatisfied_mods) do
-		local error = { type = "warning" }
+		local error = { type = "warning", reason = "unsatisfied_depends" }
 		with_error[mod.virtual_path] = error
 
 		for _, depname in ipairs(mod.unsatisfied_depends) do
@@ -168,6 +174,24 @@ local function get_formspec(data)
 		local hard_deps_str = table.concat(hard_deps, ",")
 		local soft_deps_str = table.concat(soft_deps, ",")
 
+		local error_messages = ""
+
+		local error = with_error[mod.virtual_path]
+		if error and
+			error.type == "error" and
+			-- do not handle this error by message because is is handled by
+			-- dependency list
+			error.reason ~= "unsatisfied_depends"
+			then
+				error_messages = error_messages ..
+				fgettext(minetest.colorize(mt_color_red, "Errors:") .. "\n")
+				if error.reason == "invalid" then
+					error_messages = error_messages .. fgettext(
+					"Mod is incomplete because it has no \"init.lua\" file. " ..
+					"Dependencies are not visible because of this.")
+				end
+		end
+
 		retval = retval ..
 			"label[0,0.7;" .. fgettext("Mod:") .. "]" ..
 			"label[0.75,0.7;" .. mod.name .. "]"
@@ -176,7 +200,8 @@ local function get_formspec(data)
 			if soft_deps_str == "" then
 				retval = retval ..
 					"label[0,1.25;" ..
-					fgettext("No (optional) dependencies") .. "]"
+					fgettext("No (optional) dependencies") .. "]" ..
+					"textarea[0.25,1.75;5.75,7.2;;" .. error_messages .. ";]"
 			else
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("No hard dependencies") ..
@@ -184,7 +209,8 @@ local function get_formspec(data)
 					"label[0,1.75;" .. fgettext("Optional dependencies:") ..
 					"]" ..
 					"textlist[0,2.25;5,4;world_config_optdepends;" ..
-					soft_deps_str .. ";0]"
+					soft_deps_str .. ";0]" ..
+					"textarea[0.25,6.5;3.45,1.75;;" .. error_messages .. ";]"
 			end
 		else
 			if soft_deps_str == "" then
@@ -192,7 +218,8 @@ local function get_formspec(data)
 					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
 					"textlist[0,1.75;5,4;world_config_depends;" ..
 					hard_deps_str .. ";0]" ..
-					"label[0,6;" .. fgettext("No optional dependencies") .. "]"
+					"label[0,6;" .. fgettext("No optional dependencies") .. "]" ..
+					"textarea[0.25,6.5;3.45,1.75;;" .. error_messages .. ";]"
 			else
 				retval = retval ..
 					"label[0,1.25;" .. fgettext("Dependencies:") .. "]" ..
@@ -201,7 +228,8 @@ local function get_formspec(data)
 					"label[0,3.9;" .. fgettext("Optional dependencies:") ..
 					"]" ..
 					"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
-					soft_deps_str .. ";0]"
+					soft_deps_str .. ";0]" ..
+					"textarea[0.25,6.5;3.45,1.75;;" .. error_messages .. ";]"
 			end
 		end
 	end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -183,7 +183,7 @@ local function get_formspec(data)
 			error.reason ~= "unsatisfied_depends"
 		then
 			error_message = error_message ..
-			fgettext(minetest.colorize(mt_color_red, "Errors:") .. "\n")
+			minetest.colorize(mt_color_red, fgettext("Errors:")) .. "\n"
 			if error.reason == "invalid" then
 				error_message = error_message .. fgettext(
 				"Mod is incomplete because it has no \"init.lua\" file. " ..

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -49,6 +49,7 @@ struct ModSpec
 	std::unordered_set<std::string> optdepends;
 	std::unordered_set<std::string> unsatisfied_depends;
 
+	bool valid = true;  /// False if incomplete
 	bool part_of_modpack = false;
 	bool is_modpack = false;
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -2576,4 +2576,7 @@ void push_mod_spec(lua_State *L, const ModSpec &spec, bool include_unsatisfied)
 		lua_rawseti(L, -2, i++);
 	}
 	lua_setfield(L, -2, "unsatisfied_depends");
+
+	lua_pushboolean(L, spec.valid);
+	lua_setfield(L, -2, "valid");
 }

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -267,9 +267,9 @@ void ScriptApiBase::loadMod(const std::string &script_path,
 		const std::string &mod_name)
 {
 	if (!fs::IsFile(script_path)) {
-		errorstream << "Mod error: Failed to load mod \"" << mod_name
-			<< "\" as script \"" << script_path << "\" does not exist" << std::endl;
-		return;
+		throw ModError("Failed to load mod \"" + mod_name
+			+ "\" as it's initialization script at \"" + script_path
+			+ "\" does not exist. Try to reinstall/update mod or disable it.");
 	}
 	ModNameStorer mod_name_storer(getStack(), mod_name);
 

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -266,6 +266,11 @@ std::string ScriptApiBase::getCurrentModName(lua_State *L)
 void ScriptApiBase::loadMod(const std::string &script_path,
 		const std::string &mod_name)
 {
+	if (!fs::IsFile(script_path)) {
+		errorstream << "Mod error: Failed to load mod \"" << mod_name
+			<< "\" as script \"" << script_path << "\" does not exist" << std::endl;
+		return;
+	}
 	ModNameStorer mod_name_storer(getStack(), mod_name);
 
 	loadScript(script_path);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -450,10 +450,7 @@ int ModApiMainMenu::l_check_mod_configuration(lua_State *L)
 		spec.name = fs::GetFilenameFromPath(modpath.c_str());
 		spec.path = modpath;
 		spec.virtual_path = virtual_path;
-		if (!parseModContents(spec)) {
-			warningstream << "Mod \"" << spec.name
-				<< "\" has no \"init.lua\" or \"modpack.conf\"" << std::endl;
-		}
+		spec.valid = parseModContents(spec);
 	}
 
 	modmgr.addMods(modSpecs);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -451,7 +451,8 @@ int ModApiMainMenu::l_check_mod_configuration(lua_State *L)
 		spec.path = modpath;
 		spec.virtual_path = virtual_path;
 		if (!parseModContents(spec)) {
-			throw LuaError("Not a mod!");
+			warningstream << "Mod \"" << spec.name
+				<< "\" has no \"init.lua\" or \"modpack.conf\"" << std::endl;
 		}
 	}
 


### PR DESCRIPTION
Fixes #14172

**src/script/cpp_api/s_base.cpp**
On server startup, check mod initialization script presence before loading it, and throw ModError exception on fail.

**src/content/mods.h** and **src/script/lua_api/l_mainmenu.cpp**
Add `valid` field and save `parseModContents()` result into it. That make invalid only mods without `init.lua` and mod packs without `modpack.{conf|txt}`

**src/script/common/c_content.cpp**
Add `valid` field to mod table.

**src/script/lua_api/l_mainmenu.cpp**
In mod config dialog ("Select mods"), mark invalid content with error icon and red color (same as content with unsatisfied dependencies). Add error message for such content. Add text box for error message.

![изображение](https://github.com/user-attachments/assets/1dc51df6-adb8-45db-9a29-a61217ff0ba4)


## To do

This PR is a Ready for Review.


## How to test

1. Create empty folder `mods/empty`
2. Enable `empty` mod for any world via "Select mods" and see error mark and message
3. Re-open "Select mods" menu to ensure that it still be accessible
4. Launch this world to see exception.

Or reproduce #14172 and ensure that there is no more blocking exceptions.