### PR TITLE
[no-sq] Return SRP-style hash from `core.get_password_hash`

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6841,13 +6841,28 @@ Authentication
       engine as returned as part of a `get_auth()` call on the auth handler.
     * Only use this function for making it possible to log in via password from
       external protocols such as IRC, other uses are frowned upon.
-* `core.get_password_hash(name, raw_password)`
+* `core.get_password_hash(name, password)`
     * Convert a name-password pair to a password hash that Luanti can use.
-    * The returned value alone is not a good basis for password checks based
-      on comparing the password hash in the database with the password hash
-      from the function, with an externally provided password, as the hash
-      in the db might use the new SRP verifier format.
-    * For this purpose, use `core.check_password_entry` instead.
+    * Player name *cannot* be empty, and both arguments *must* be strings.
+    * The returned value may not be the same for multiple invocations with the same name and password.
+    * The returned value therefore *cannot* be used for password checks based
+      on a direct string comparison, use `core.check_password_entry` instead.
+    * If you used this function as a hash you can replace it with `core.sha1`:
+    ```lua
+        -- Lua equivalent of the legacy core.get_password_hash algorithm
+        local function legacy_get_password_hash(name, password)
+            -- convert to strings
+            name = tostring(name)
+            password = tostring(password)
+            -- remove anything after the first null character
+            name = name:match("^[^%z]*")
+            password = password:match("^[^%z]*")
+            if password == "" then
+                return ""
+            end
+            return core.encode_base64(core.sha1(name..password, true))
+        end
+    ```
 * `core.get_player_ip(name)`: returns an IP address string for the player
   `name`.
     * The player needs to be online for this to be successful.

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -114,6 +114,32 @@ local function test_hashing()
 end
 unittests.register("test_hashing", test_hashing)
 
+local function test_password_hash()
+	local password = "hunter2"
+	local user = "Cthon98"
+
+	local hash = core.get_password_hash(user, password)
+	local hash_no_pass = core.get_password_hash(user, "")
+	assert(hash)
+	assert(type(hash_no_pass) == "string" and hash_no_pass ~= "")
+	assert(hash_no_pass ~= hash)
+
+	assert(core.check_password_entry(user, hash, password) == true)
+	assert(core.check_password_entry(user, hash, "") == false)
+	assert(core.check_password_entry(user, hash_no_pass, password) == false)
+	assert(core.check_password_entry(user, hash_no_pass, "") == true)
+
+	assert(pcall(core.get_password_hash, "", password) == false)
+	assert(pcall(core.get_password_hash, "", 2) == false)
+	assert(pcall(core.get_password_hash, user, 2) == false)
+	assert(pcall(core.get_password_hash, 98, 2) == false)
+	assert(pcall(core.get_password_hash, 98, password) == false)
+	assert(pcall(core.get_password_hash, user) == false)
+	assert(pcall(core.get_password_hash) == false)
+end
+
+unittests.register("test_password_hash", test_password_hash)
+
 local function test_compress()
 	-- This text should be compressible, to make sure the results are... normal
 	local text = "The\000 icey canoe couldn't move very well on the\128 lake. The\000 ice was too stiff and the icey canoe's paddles simply wouldn't punch through."

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -245,14 +245,27 @@ int ModApiUtil::l_check_password_entry(lua_State *L)
 	return 1;
 }
 
-// get_password_hash(name, raw_password)
+// get_password_hash(name, password)
 int ModApiUtil::l_get_password_hash(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
-	std::string name = luaL_checkstring(L, 1);
-	std::string raw_password = luaL_checkstring(L, 2);
-	std::string hash = translate_password(name, raw_password);
-	lua_pushstring(L, hash.c_str());
+	luaL_checktype(L, 1, LUA_TSTRING);
+	luaL_checktype(L, 2, LUA_TSTRING);
+
+	std::string_view name = readParam<std::string_view>(L, 1);
+
+	luaL_argcheck(L, !name.empty(), 1,
+		"User name must be non-empty, use core.sha1 or core.sha256 if you need a generic hash function.\n"
+		"See documentation for more details on how to migrate legacy code.");
+
+	std::string_view password = readParam<std::string_view>(L, 2);
+
+	std::string verifier;
+	std::string salt;
+	generate_srp_verifier_and_salt(name, password, &verifier, &salt);
+
+	std::string hash = encode_srp_verifier(verifier, salt);
+	lua_pushlstring(L, hash.c_str(), hash.length());
 	return 1;
 }
 

--- a/src/util/auth.cpp
+++ b/src/util/auth.cpp
@@ -31,26 +31,26 @@ std::string translate_password(const std::string &name,
 // given pointers. Contains the preparations, call parameters
 // and error checking common to all srp verifier generation code.
 // See docs of srp_create_salted_verification_key for more info.
-static inline void gen_srp_v(const std::string &name,
-	const std::string &password, char **salt, size_t *salt_len,
+static inline void gen_srp_v(std::string_view name,
+	const std::string_view password, char **salt, size_t *salt_len,
 	char **bytes_v, size_t *len_v)
 {
 	std::string n_name = lowercase(name);
 	SRP_Result res = srp_create_salted_verification_key(SRP_SHA256, SRP_NG_2048,
-		n_name.c_str(), (const unsigned char *)password.c_str(),
+		n_name.c_str(), (const unsigned char *)password.data(),
 		password.size(), (unsigned char **)salt, salt_len,
 		(unsigned char **)bytes_v, len_v, NULL, NULL);
 	FATAL_ERROR_IF(res != SRP_OK, "Couldn't create salted SRP verifier");
 }
 
 /// Creates a verification key with given salt and password.
-std::string generate_srp_verifier(const std::string &name,
-	const std::string &password, const std::string &salt)
+std::string generate_srp_verifier(std::string_view name,
+	std::string_view password, std::string_view salt)
 {
 	size_t salt_len = salt.size();
 	// The API promises us that the salt doesn't
 	// get modified if &salt_ptr isn't NULL.
-	char *salt_ptr = (char *)salt.c_str();
+	char *salt_ptr = (char *)salt.data();
 
 	char *bytes_v = nullptr;
 	size_t verifier_len = 0;
@@ -61,8 +61,8 @@ std::string generate_srp_verifier(const std::string &name,
 }
 
 /// Creates a verification key and salt with given password.
-void generate_srp_verifier_and_salt(const std::string &name,
-	const std::string &password, std::string *verifier,
+void generate_srp_verifier_and_salt(std::string_view name,
+	std::string_view password, std::string *verifier,
 	std::string *salt)
 {
 	char *bytes_v = nullptr;
@@ -78,8 +78,8 @@ void generate_srp_verifier_and_salt(const std::string &name,
 
 /// Gets an SRP verifier, generating a salt,
 /// and encodes it as DB-ready string.
-std::string get_encoded_srp_verifier(const std::string &name,
-	const std::string &password)
+std::string get_encoded_srp_verifier(std::string_view name,
+	std::string_view password)
 {
 	std::string verifier;
 	std::string salt;
@@ -88,8 +88,8 @@ std::string get_encoded_srp_verifier(const std::string &name,
 }
 
 /// Converts the passed SRP verifier into a DB-ready format.
-std::string encode_srp_verifier(const std::string &verifier,
-	const std::string &salt)
+std::string encode_srp_verifier(std::string_view verifier,
+	std::string_view salt)
 {
 	std::ostringstream ret_str;
 	ret_str << "#1#"

--- a/src/util/auth.h
+++ b/src/util/auth.h
@@ -9,22 +9,22 @@ std::string translate_password(const std::string &name,
 	const std::string &password);
 
 /// Creates a verification key with given salt and password.
-std::string generate_srp_verifier(const std::string &name,
-	const std::string &password, const std::string &salt);
+std::string generate_srp_verifier(std::string_view name,
+	std::string_view password, std::string_view salt);
 
 /// Creates a verification key and salt with given password.
-void generate_srp_verifier_and_salt(const std::string &name,
-	const std::string &password, std::string *verifier,
+void generate_srp_verifier_and_salt(std::string_view name,
+	std::string_view password, std::string *verifier,
 	std::string *salt);
 
 /// Gets an SRP verifier, generating a salt,
 /// and encodes it as DB-ready string.
-std::string get_encoded_srp_verifier(const std::string &name,
-	const std::string &password);
+std::string get_encoded_srp_verifier(std::string_view name,
+	std::string_view password);
 
 /// Converts the passed SRP verifier into a DB-ready format.
-std::string encode_srp_verifier(const std::string &verifier,
-	const std::string &salt);
+std::string encode_srp_verifier(std::string_view verifier,
+	std::string_view salt);
 
 /// Reads the DB-formatted SRP verifier and gets the verifier
 /// and salt components.


### PR DESCRIPTION
Old documentation never made any requirements that the return value is stable across Luanti versions or deterministic. Also added some additional error checking to flag API misuse by mods.

Closes #12564

## How to test

- Run minimal unittests
- Check you can still set password using the chat command.

# AI Usage
automated rebasing only