### PR TITLE
Client: Extend [combine modifier with optional width parameter

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -728,12 +728,18 @@ Example:
 
     default_cobble.png^[crack:10:1
 
-#### `[combine:<w>x<h>:<x1>,<y1>=<file1>:<x2>,<y2>=<file2>:...`
+#### `[combine:<w>x<h>:<x1>,<y1>,<w1>=<file1>:<x2>,<y2>,<w2>=<file2>:...`
 
 * `<w>`: width (integer [imagesize])
 * `<h>`: height (integer [imagesize])
-* `<x>`: x position (integer [s32])
-* `<y>`: y position (integer [s32])
+* `<xN>`: x position (integer [s32])
+* `<yN>`: y position (integer [s32])
+* `<wN>` (optional): Expected texture width (integer [s32])
+   * If the provided texture width is (e.g. 2 times) larger than `<wN>`, it will
+     result in an output texture that is also (2 times) larger.
+   * If the provided texture width is smaller, it will be upscaled proportionally
+     to match the width `<wN>`.
+   * Supported since version 5.17.0. Old clients will ignore this parameter.
 * `<file>`: texture to combine
 
 Creates a texture of size `<w>` times `<h>` and blits the listed source images

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -759,19 +759,21 @@ Examples:
 
 * Blits a 3x3 grid of crack textures, each at frame 0, on `example.png`
 
-#### `[combine:<w>x<h>:<parts>`
+#### `[combine:<w>x<h>:<x1>,<y1>,<w1>=<texture1>:<x2>,<y2>,<w2>=<texture2>:...`
 
-* `<w>`: width of resulting texture (integer [imagesize])
-* `<h>`: height of resulting texture (integer [imagesize])
-* `<parts>`: Colon-separated (`:`) list of locations `x`, `y` and textures to
-  blit; written in the form `<x>,<y>=<texture>` for each texture. Can be empty.
+* `<wN>`: width of resulting texture (integer [imagesize])
+* `<hN>`: height of resulting texture (integer [imagesize])
+* `<wN>` (optional): Expected texture width (integer [s32])
+   * If the provided texture width is (e.g. 2 times) larger than `<wN>`, it will
+     result in an output texture that is also (2 times) larger.
+   * If the provided texture width is smaller, it will be upscaled proportionally
+     to match the width `<wN>`.
+   * Supported since version 5.18.0. Old clients will ignore this parameter.
+* `<textureN>`: texture to combine. Can contain texture modifiers, but these must
+     be escaped according to the rules in [Escaping](#Escaping).
 
-`x` and `y` are integers [imageframe].
-A `<texture>` (in `<textures>`) can contain texture modifiers, but these must
-be escaped according to the rules in [Escaping](#Escaping).
-
-Creates a texture of size `<w>` times `<h>` and blits the listed files to their
-specified coordinates. The background is black and transparent (`#00000000`).
+Creates a texture of size `<w>` times `<h>` and blits the listed source images
+to their specified `<x>,<y>` coordinates of the target texture. The background is black and transparent (`#00000000`).
 
 Example:
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -777,6 +777,7 @@ Examples:
 Creates a texture of size `<w>` times `<h>` (unless `<sN>` is provided) and blits the
 listed source images to their specified `<xN>,<yN>` coordinates of the target texture.
 The background is black and transparent (`#00000000`).
+Since 5.18.0, note `TEXMOD_UPSCALE` applies if a base image is present.
 
 Example:
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -766,7 +766,7 @@ Examples:
 * `<xN>`: x position (integer [s32])
 * `<yN>`: y position (integer [s32])
 * `<sN>` (optional): Expected texture width (integer [s32])
-   * If the provided texture width is (e.g. 2 times) larger than `<wN>`, it will
+   * If the provided texture width is (e.g. 2 times) larger than `<sN>`, it will
      result in an output texture that is also (2 times) larger.
    * If the provided texture width is smaller, it will be upscaled proportionally
      to match the width `<sN>`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -759,21 +759,24 @@ Examples:
 
 * Blits a 3x3 grid of crack textures, each at frame 0, on `example.png`
 
-#### `[combine:<w>x<h>:<x1>,<y1>,<w1>=<texture1>:<x2>,<y2>,<w2>=<texture2>:...`
+#### `[combine:<w>x<h>:<x1>,<y1>,<s1>=<texture1>:<x2>,<y2>,<s2>=<texture2>:...`
 
-* `<wN>`: width of resulting texture (integer [imagesize])
-* `<hN>`: height of resulting texture (integer [imagesize])
-* `<wN>` (optional): Expected texture width (integer [s32])
+* `<w>`: width of resulting texture (integer [imagesize])
+* `<h>`: height of resulting texture (integer [imagesize])
+* `<xN>`: x position (integer [s32])
+* `<yN>`: y position (integer [s32])
+* `<sN>` (optional): Expected texture width (integer [s32])
    * If the provided texture width is (e.g. 2 times) larger than `<wN>`, it will
      result in an output texture that is also (2 times) larger.
    * If the provided texture width is smaller, it will be upscaled proportionally
-     to match the width `<wN>`.
+     to match the width `<sN>`.
    * Supported since version 5.18.0. Old clients will ignore this parameter.
 * `<textureN>`: texture to combine. Can contain texture modifiers, but these must
      be escaped according to the rules in [Escaping](#Escaping).
 
-Creates a texture of size `<w>` times `<h>` and blits the listed source images
-to their specified `<x>,<y>` coordinates of the target texture. The background is black and transparent (`#00000000`).
+Creates a texture of size `<w>` times `<h>` (unless `<sN>` is provided) and blits the
+listed source images to their specified `<xN>,<yN>` coordinates of the target texture.
+The background is black and transparent (`#00000000`).
 
 Example:
 

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1090,21 +1090,78 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 		{
 			Strfnd sf(part_of_name);
 			sf.next(":");
+			// grid size
 			u32 w0 = stoi(sf.next("x"));
 			u32 h0 = stoi(sf.next(":"));
+
+			struct ImagePart {
+				v2s32 offset;
+				std::string filename;
+				video::IImage *img = nullptr;
+				int expected_width = 0;
+
+				~ImagePart()
+				{
+					if (img)
+						img->drop();
+				}
+			};
+			std::list<ImagePart> image_parts;
+
+			// fixed point precision to allow textures smaller than the grid size
+			constexpr int FX_FACTOR = 1024;
+			// By how much to scale (w0, h0) for the resulting image
+			u32 scale = 0; // includes FX_FACTOR
+
+			while (!sf.at_end()) {
+				// X,Y(,W)=image_esc(:X,Y...)
+
+				auto &it = image_parts.emplace_back();
+
+				auto parts = str_split(sf.next("="), ',');
+				if (parts.size() >= 1)
+					it.offset.X = stoi(parts[0]);
+				if (parts.size() >= 2)
+					it.offset.Y = stoi(parts[1]);
+				if (parts.size() >= 3)
+					it.expected_width = stoi(parts[2]);
+
+				it.filename = unescape_string(sf.next_esc(":", escape), escape);
+				it.img = generateImage(it.filename, source_image_names);
+				if (!it.img) {
+					errorstream << "generateImagePart(): Failed to load image \""
+						<< it.filename << "\" for [combine" << std::endl;
+					image_parts.pop_back();
+					continue;
+				}
+
+				const auto dim = it.img->getDimension();
+				if (it.expected_width <= 0) {
+					// Parameter not specified -> do not scale
+					it.expected_width = dim.Width;
+				}
+
+				scale = std::max<u32>(scale, FX_FACTOR * dim.Width / it.expected_width);
+			}
+
 			if (!baseimg) {
+				if (scale > 0) {
+					w0 = w0 * scale / FX_FACTOR;
+					h0 = h0 * scale / FX_FACTOR;
+				}
 				CHECK_DIM(w0, h0);
+
+				// create desired
 				baseimg = driver->createImage(video::ECF_A8R8G8B8, {w0, h0});
 				baseimg->fill(video::SColor(0,0,0,0));
 			}
 
-			while (!sf.at_end()) {
-				v2s32 pos_base;
-				pos_base.X = stoi(sf.next(","));
-				pos_base.Y = stoi(sf.next("="));
-				std::string filename = unescape_string(sf.next_esc(":", escape), escape);
+			const auto basedim = baseimg->getDimension();
+			for (ImagePart &it : image_parts) {
+				// Shift insertion offset by the same factor as we scaled `baseimg`
+				const v2s32 pos_base = it.offset * scale / FX_FACTOR;
+				const std::string &filename = it.filename;
 
-				auto basedim = baseimg->getDimension();
 				if (pos_base.X > (s32)basedim.Width || pos_base.Y > (s32)basedim.Height) {
 					warningstream << "generateImagePart(): Skipping \""
 						<< filename << "\" as it's out-of-bounds " << pos_base
@@ -1114,23 +1171,27 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 				tracestream << "Adding \"" << filename << "\" to combined "
 					<< pos_base << std::endl;
 
-				video::IImage *img = generateImage(filename, source_image_names);
-				if (!img) {
-					errorstream << "generateImagePart(): Failed to load image \""
-						<< filename << "\" for [combine" << std::endl;
-					continue;
+				auto dim = it.img->getDimension();
+				u32 wanted_width = it.expected_width * scale / FX_FACTOR;
+				if (dim.Width != wanted_width) {
+					// needs resize
+					video::IImage *newimg = driver->createImage(
+						baseimg->getColorFormat(),
+						{ wanted_width, (dim.Height * wanted_width) / dim.Width }
+					);
+					it.img->copyToScaling(newimg);
+					it.img->drop();
+					it.img = newimg;
+					dim = it.img->getDimension();
 				}
-				const auto dim = img->getDimension();
 				if (pos_base.X + dim.Width <= 0 || pos_base.Y + dim.Height <= 0) {
 					warningstream << "generateImagePart(): Skipping \""
 						<< filename << "\" as it's out-of-bounds " << pos_base
 						<< " for [combine" << std::endl;
-					img->drop();
 					continue;
 				}
 
-				blit_with_alpha(img, baseimg, pos_base, dim);
-				img->drop();
+				blit_with_alpha(it.img, baseimg, pos_base, dim);;
 			}
 		}
 		/*

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1071,24 +1071,19 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 				scale = std::max<u32>(scale, FX_FACTOR * dim.Width / it.expected_width);
 			}
 
-			if (!baseimg) {
-				if (scale > FX_FACTOR) {
-					w0 = w0 * scale / FX_FACTOR;
-					h0 = h0 * scale / FX_FACTOR;
-				}
-				CHECK_DIM(w0, h0);
+			w0 = w0 * scale / FX_FACTOR;
+			h0 = h0 * scale / FX_FACTOR;
+			CHECK_DIM(w0, h0);
 
-				// create desired
-				baseimg = driver->createImage(video::ECF_A8R8G8B8, {w0, h0});
-				baseimg->fill(video::SColor(0,0,0,0));
-			}
+			irr_ptr<video::IImage> output;
+			output.reset(driver->createImage(video::ECF_A8R8G8B8, {w0, h0}));
+			output->fill(video::SColor(0,0,0,0));
 
-			const auto basedim = baseimg->getDimension();
 			for (ImagePart &it : image_parts) {
-				// Shift insertion offset by the same factor as we scaled `baseimg`
+				// Shift insertion offset by the same factor as we scaled `output`
 				const v2s32 pos_base = it.offset * scale / FX_FACTOR;
 
-				if (pos_base.X > (s32)basedim.Width || pos_base.Y > (s32)basedim.Height) {
+				if (pos_base.X > (s32)w0 || pos_base.Y > (s32)h0) {
 					warningstream << "generateImagePart(): Skipping \""
 						<< it.filename << "\" as it's out-of-bounds " << pos_base
 						<< " for [combine" << std::endl;
@@ -1102,7 +1097,7 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 				if (dim.Width != wanted_part_width) {
 					// needs resize
 					video::IImage *newimg = driver->createImage(
-						baseimg->getColorFormat(),
+						video::ECF_A8R8G8B8,
 						{ wanted_part_width, (dim.Height * wanted_part_width) / dim.Width }
 					);
 					it.img->copyToScaling(newimg);
@@ -1117,7 +1112,17 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 					continue;
 				}
 
-				blit_with_alpha(it.img, baseimg, pos_base, dim);
+				blit_with_alpha(it.img, output.get(), pos_base, dim);
+			}
+
+			if (baseimg) {
+				// Same as '^'. The code above could be extended to make this more
+				// performant at the cost of making it hardly readable.
+				video::IImage *out = output.release();
+				blitBaseImage(out, baseimg);
+				out->drop();
+			} else {
+				baseimg = output.release();
 			}
 		}
 		/*

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1087,15 +1087,14 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 			for (ImagePart &it : image_parts) {
 				// Shift insertion offset by the same factor as we scaled `baseimg`
 				const v2s32 pos_base = it.offset * scale / FX_FACTOR;
-				const std::string &filename = it.filename;
 
 				if (pos_base.X > (s32)basedim.Width || pos_base.Y > (s32)basedim.Height) {
 					warningstream << "generateImagePart(): Skipping \""
-						<< filename << "\" as it's out-of-bounds " << pos_base
+						<< it.filename << "\" as it's out-of-bounds " << pos_base
 						<< " for [combine" << std::endl;
 					continue;
 				}
-				tracestream << "Adding \"" << filename << "\" to combined "
+				tracestream << "Adding \"" << it.filename << "\" to combined "
 					<< pos_base << std::endl;
 
 				auto dim = it.img->getDimension();
@@ -1113,12 +1112,12 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 				}
 				if (pos_base.X + dim.Width <= 0 || pos_base.Y + dim.Height <= 0) {
 					warningstream << "generateImagePart(): Skipping \""
-						<< filename << "\" as it's out-of-bounds " << pos_base
+						<< it.filename << "\" as it's out-of-bounds " << pos_base
 						<< " for [combine" << std::endl;
 					continue;
 				}
 
-				blit_with_alpha(it.img, baseimg, pos_base, dim);;
+				blit_with_alpha(it.img, baseimg, pos_base, dim);
 			}
 		}
 		/*

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1037,8 +1037,8 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 
 			// fixed point precision to allow textures smaller than the grid size
 			constexpr int FX_FACTOR = 1024;
-			// By how much to scale (w0, h0) for the resulting image
-			u32 scale = 0; // includes FX_FACTOR
+			// By how much to scale (w0, h0) for the resulting image (must include FX_FACTOR)
+			u32 scale = 1 * FX_FACTOR;
 
 			while (!sf.at_end()) {
 				// X,Y(,W)=image_esc(:X,Y...)
@@ -1072,7 +1072,7 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 			}
 
 			if (!baseimg) {
-				if (scale > 0) {
+				if (scale > FX_FACTOR) {
 					w0 = w0 * scale / FX_FACTOR;
 					h0 = h0 * scale / FX_FACTOR;
 				}
@@ -1098,12 +1098,12 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 					<< pos_base << std::endl;
 
 				auto dim = it.img->getDimension();
-				u32 wanted_width = it.expected_width * scale / FX_FACTOR;
-				if (dim.Width != wanted_width) {
+				const u32 wanted_part_width = it.expected_width * scale / FX_FACTOR;
+				if (dim.Width != wanted_part_width) {
 					// needs resize
 					video::IImage *newimg = driver->createImage(
 						baseimg->getColorFormat(),
-						{ wanted_width, (dim.Height * wanted_width) / dim.Width }
+						{ wanted_part_width, (dim.Height * wanted_part_width) / dim.Width }
 					);
 					it.img->copyToScaling(newimg);
 					it.img->drop();

--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -1017,21 +1017,78 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 		{
 			Strfnd sf(part_of_name);
 			sf.next(":");
+			// grid size
 			u32 w0 = stoi(sf.next("x"));
 			u32 h0 = stoi(sf.next(":"));
+
+			struct ImagePart {
+				v2s32 offset;
+				std::string filename;
+				video::IImage *img = nullptr;
+				int expected_width = 0;
+
+				~ImagePart()
+				{
+					if (img)
+						img->drop();
+				}
+			};
+			std::list<ImagePart> image_parts;
+
+			// fixed point precision to allow textures smaller than the grid size
+			constexpr int FX_FACTOR = 1024;
+			// By how much to scale (w0, h0) for the resulting image
+			u32 scale = 0; // includes FX_FACTOR
+
+			while (!sf.at_end()) {
+				// X,Y(,W)=image_esc(:X,Y...)
+
+				auto &it = image_parts.emplace_back();
+
+				auto parts = str_split(sf.next("="), ',');
+				if (parts.size() >= 1)
+					it.offset.X = stoi(parts[0]);
+				if (parts.size() >= 2)
+					it.offset.Y = stoi(parts[1]);
+				if (parts.size() >= 3)
+					it.expected_width = stoi(parts[2]);
+
+				it.filename = unescape_string(sf.next_esc(":", escape), escape);
+				it.img = generateImage(it.filename, source_image_names);
+				if (!it.img) {
+					errorstream << "generateImagePart(): Failed to load image \""
+						<< it.filename << "\" for [combine" << std::endl;
+					image_parts.pop_back();
+					continue;
+				}
+
+				const auto dim = it.img->getDimension();
+				if (it.expected_width <= 0) {
+					// Parameter not specified -> do not scale
+					it.expected_width = dim.Width;
+				}
+
+				scale = std::max<u32>(scale, FX_FACTOR * dim.Width / it.expected_width);
+			}
+
 			if (!baseimg) {
+				if (scale > 0) {
+					w0 = w0 * scale / FX_FACTOR;
+					h0 = h0 * scale / FX_FACTOR;
+				}
 				CHECK_DIM(w0, h0);
+
+				// create desired
 				baseimg = driver->createImage(video::ECF_A8R8G8B8, {w0, h0});
 				baseimg->fill(video::SColor(0,0,0,0));
 			}
 
-			while (!sf.at_end()) {
-				v2s32 pos_base;
-				pos_base.X = stoi(sf.next(","));
-				pos_base.Y = stoi(sf.next("="));
-				std::string filename = unescape_string(sf.next_esc(":", escape), escape);
+			const auto basedim = baseimg->getDimension();
+			for (ImagePart &it : image_parts) {
+				// Shift insertion offset by the same factor as we scaled `baseimg`
+				const v2s32 pos_base = it.offset * scale / FX_FACTOR;
+				const std::string &filename = it.filename;
 
-				auto basedim = baseimg->getDimension();
 				if (pos_base.X > (s32)basedim.Width || pos_base.Y > (s32)basedim.Height) {
 					warningstream << "generateImagePart(): Skipping \""
 						<< filename << "\" as it's out-of-bounds " << pos_base
@@ -1041,23 +1098,27 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 				tracestream << "Adding \"" << filename << "\" to combined "
 					<< pos_base << std::endl;
 
-				video::IImage *img = generateImage(filename, source_image_names);
-				if (!img) {
-					errorstream << "generateImagePart(): Failed to load image \""
-						<< filename << "\" for [combine" << std::endl;
-					continue;
+				auto dim = it.img->getDimension();
+				u32 wanted_width = it.expected_width * scale / FX_FACTOR;
+				if (dim.Width != wanted_width) {
+					// needs resize
+					video::IImage *newimg = driver->createImage(
+						baseimg->getColorFormat(),
+						{ wanted_width, (dim.Height * wanted_width) / dim.Width }
+					);
+					it.img->copyToScaling(newimg);
+					it.img->drop();
+					it.img = newimg;
+					dim = it.img->getDimension();
 				}
-				const auto dim = img->getDimension();
 				if (pos_base.X + dim.Width <= 0 || pos_base.Y + dim.Height <= 0) {
 					warningstream << "generateImagePart(): Skipping \""
 						<< filename << "\" as it's out-of-bounds " << pos_base
 						<< " for [combine" << std::endl;
-					img->drop();
 					continue;
 				}
 
-				blit_with_alpha(img, baseimg, pos_base, dim);
-				img->drop();
+				blit_with_alpha(it.img, baseimg, pos_base, dim);;
 			}
 		}
 		/*

--- a/src/network/networkprotocol.cpp
+++ b/src/network/networkprotocol.cpp
@@ -78,6 +78,9 @@
 		Added "skip_wield_anim" to TOCLIENT_INVENTORY
 		Type of TOCLIENT_HUDADD `size` changed from v2s32 to v2f
 		[scheduled bump for 5.16.0]
+	PROTOCOL VERSION 53
+		"[combine:WxH:x1,y1,w1=" 3rd parameter extension
+		<TODO for 5.17.0>
 */
 
 // Note: Also update core.protocol_versions in builtin when bumping

--- a/src/network/networkprotocol.cpp
+++ b/src/network/networkprotocol.cpp
@@ -80,10 +80,13 @@
 		[scheduled bump for 5.16.0]
 	PROTOCOL VERSION 53
 		[scheduled bump for 5.17.0]
+	PROTOCOL VERSION 54
+		"[combine:WxH:x1,y1,w1=" 3rd parameter extension
+		<TODO for 5.18.0>
 */
 
 // Note: Also update core.protocol_versions in builtin when bumping
-const u16 LATEST_PROTOCOL_VERSION = 53;
+const u16 LATEST_PROTOCOL_VERSION = 54;
 
 // See also formspec [Version History] in doc/lua_api.md
 const u16 FORMSPEC_API_VERSION = 11;

--- a/src/network/networkprotocol.cpp
+++ b/src/network/networkprotocol.cpp
@@ -86,7 +86,7 @@
 */
 
 // Note: Also update core.protocol_versions in builtin when bumping
-const u16 LATEST_PROTOCOL_VERSION = 54;
+const u16 LATEST_PROTOCOL_VERSION = 53;
 
 // See also formspec [Version History] in doc/lua_api.md
 const u16 FORMSPEC_API_VERSION = 11;


### PR DESCRIPTION
Fixes #15054

Implementation is based on the concept described here: https://github.com/minetest/minetest/issues/15054#issuecomment-2309870847

`w, h` is treated as a grid (relevant for insertion positions), which is then scaled according to the texture pack resolution.

## To do

This PR is Ready for Review.

.. perhaps the code to devtest?

## How to test

1. Use the devtest game
2. Code

```Lua
assert(core.get_modpath("testformspec"), "Use devtest")

core.register_chatcommand("f", {
	func = function(name, param)
		local function generate(img, with_baseimg)
			return table.concat({
				"[fill:96x64:red", -- background (to be upscaled)
				"^", with_baseimg and "" or "(", -- `(` == force create new texture
				"[combine:48x32",
				":0,16,16=default_chest_front.png", -- bottom left quarter (texture is 16x16)
				":16,-8,16=" .. img,                -- top right quarter
				with_baseimg and "" or ")",
			})
		end
		-- New clients: any input texture size is fine
		-- Old clients: expected width must be the same as the texture size for visual compatibility

		local texmod_32         = generate("testformspec_bg_9slice.png", false) -- 32x32 input
		local texmod_16         = generate("testformspec_node.png",      false) -- 16x16 input
		local texmod_32_baseimg = generate("testformspec_bg_9slice.png", true)  -- 32x32 input
		local texmod_16_baseimg = generate("testformspec_node.png",      true)  -- 16x16 input

		core.show_formspec(name, "lab:combinetest", table.concat({
			"formspec_version[7]",
			"size[10,9]",
			"image[1,0.5;3,2;", core.formspec_escape(texmod_32), "]",
			"image[1,3.0;3,2;", core.formspec_escape(texmod_16), "]",
			"image[6,0.5;3,2;", core.formspec_escape(texmod_32_baseimg), "]",
			"image[6,3.0;3,2;", core.formspec_escape(texmod_16_baseimg), "]",
			-- base 32x32 <-- blit 16x16 (autoscale)
			"image[1,6.0;2,2;", core.formspec_escape("testformspec_bg_9slice.png^testformspec_item.png"), "]",
			-- base 16x16 <-- blit 32x32 (autoscale)
			"image[4,6.0;2,2;", core.formspec_escape("testformspec_node.png^testformspec_bg_9slice.png"), "]",
			-- base 16x16 <-- blit 32x32 (no scale)
			"image[7,6.0;2,2;", core.formspec_escape("testformspec_node.png^(testformspec_bg_9slice.png)"), "]",
		}))
		return true, "OK!"
	end
})
```

3. Investigate the result

<img width="539" height="488" alt="grafik" src="https://github.com/user-attachments/assets/863a2cc5-277d-40f9-9cc3-73f734868d7c" />
