### PR TITLE
Rework guiKeyChangeMenu

### DIFF
--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -487,8 +487,8 @@ bool GameFormSpec::handleCallbacks()
 	}
 
 	if (g_gamecallback->keyconfig_requested) {
-		(void)make_irr<GUIKeyChangeMenu>(guienv, guiroot, -1,
-				      &g_menumgr, texture_src);
+		(void)make_irr<GUIKeyChangeMenu>(m_client, guienv, &m_input->joystick,
+				texture_src, m_client->getSoundManager(), m_client->getFormspecPrepend());
 		g_gamecallback->keyconfig_requested = false;
 	}
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -115,6 +115,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 	m_menumanager(menumgr),
 	m_smgr(rendering_engine->get_scene_manager()),
 	m_data(data),
+	m_joystick(joystick),
 	m_kill(kill)
 {
 	// initialize texture pointers

--- a/src/gui/guiEngine.h
+++ b/src/gui/guiEngine.h
@@ -190,6 +190,8 @@ private:
 	std::unique_ptr<ISimpleTextureSource> m_texture_source;
 	/** sound manager */
 	std::unique_ptr<ISoundManager>        m_sound_manager;
+	/** joystick controller */
+	JoystickController                   *m_joystick;
 
 	/** representation of form source to be used in mainmenu formspec */
 	FormspecFormSource                   *m_formspecgui = nullptr;

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -5,399 +5,208 @@
 // Copyright (C) 2013 teddydestodes <derkomtur@schattengang.net>
 
 #include "guiKeyChangeMenu.h"
-#include "debug.h"
-#include "guiButton.h"
-#include "serialization.h"
-#include <string>
-#include <IGUICheckBox.h>
-#include <IGUIEditBox.h>
-#include <IGUIButton.h>
-#include <IGUIStaticText.h>
-#include <IGUIFont.h>
-#include <IVideoDriver.h>
-#include "settings.h"
-#include <algorithm>
+#include "filesys.h"
+#include "gettext.h"
+#include "porting.h"
+#include <sstream>
+#include <vector>
 
-#include "mainmenumanager.h"  // for g_gamecallback
-
-#define KMaxButtonPerColumns 12
-
-extern MainGameCallback *g_gamecallback;
-
-enum
-{
-	GUI_ID_BACK_BUTTON = 101, GUI_ID_ABORT_BUTTON, GUI_ID_SCROLL_BAR,
-	// buttons
-	GUI_ID_KEY_FORWARD_BUTTON,
-	GUI_ID_KEY_BACKWARD_BUTTON,
-	GUI_ID_KEY_LEFT_BUTTON,
-	GUI_ID_KEY_RIGHT_BUTTON,
-	GUI_ID_KEY_AUX1_BUTTON,
-	GUI_ID_KEY_FLY_BUTTON,
-	GUI_ID_KEY_FAST_BUTTON,
-	GUI_ID_KEY_JUMP_BUTTON,
-	GUI_ID_KEY_NOCLIP_BUTTON,
-	GUI_ID_KEY_PITCH_MOVE,
-	GUI_ID_KEY_CHAT_BUTTON,
-	GUI_ID_KEY_CMD_BUTTON,
-	GUI_ID_KEY_CMD_LOCAL_BUTTON,
-	GUI_ID_KEY_CONSOLE_BUTTON,
-	GUI_ID_KEY_SNEAK_BUTTON,
-	GUI_ID_KEY_DROP_BUTTON,
-	GUI_ID_KEY_INVENTORY_BUTTON,
-	GUI_ID_KEY_HOTBAR_PREV_BUTTON,
-	GUI_ID_KEY_HOTBAR_NEXT_BUTTON,
-	GUI_ID_KEY_MUTE_BUTTON,
-	GUI_ID_KEY_DEC_VOLUME_BUTTON,
-	GUI_ID_KEY_INC_VOLUME_BUTTON,
-	GUI_ID_KEY_RANGE_BUTTON,
-	GUI_ID_KEY_ZOOM_BUTTON,
-	GUI_ID_KEY_CAMERA_BUTTON,
-	GUI_ID_KEY_MINIMAP_BUTTON,
-	GUI_ID_KEY_SCREENSHOT_BUTTON,
-	GUI_ID_KEY_CHATLOG_BUTTON,
-	GUI_ID_KEY_BLOCK_BOUNDS_BUTTON,
-	GUI_ID_KEY_HUD_BUTTON,
-	GUI_ID_KEY_FOG_BUTTON,
-	GUI_ID_KEY_DEC_RANGE_BUTTON,
-	GUI_ID_KEY_INC_RANGE_BUTTON,
-	GUI_ID_KEY_AUTOFWD_BUTTON,
-	// other
-	GUI_ID_CB_AUX1_DESCENDS,
-	GUI_ID_CB_DOUBLETAP_JUMP,
-	GUI_ID_CB_AUTOJUMP,
+struct setting_entry {
+	const std::string display_name;
+	const std::string setting_name;
 };
 
-GUIKeyChangeMenu::GUIKeyChangeMenu(gui::IGUIEnvironment* env,
-		gui::IGUIElement* parent, s32 id, IMenuManager *menumgr,
-		ISimpleTextureSource *tsrc) :
-		GUIModalMenu(env, parent, id, menumgr),
-		m_tsrc(tsrc)
+// compare with button_titles in touchcontrols.cpp
+static const std::vector<setting_entry> key_settings {
+	{N_("Forward"),          "keymap_forward"},
+	{N_("Backward"),         "keymap_backward"},
+	{N_("Left"),             "keymap_left"},
+	{N_("Right"),            "keymap_right"},
+	{N_("Aux1"),             "keymap_aux1"},
+	{N_("Jump"),             "keymap_jump"},
+	{N_("Sneak"),            "keymap_sneak"},
+	{N_("Drop"),             "keymap_drop"},
+	{N_("Inventory"),        "keymap_inventory"},
+	{N_("Prev. item"),       "keymap_hotbar_previous"},
+	{N_("Next item"),        "keymap_hotbar_next"},
+	{N_("Zoom"),             "keymap_zoom"},
+	{N_("Change camera"),    "keymap_camera_mode"},
+	{N_("Toggle minimap"),   "keymap_minimap"},
+	{N_("Toggle fly"),       "keymap_freemove"},
+	{N_("Toggle pitchmove"), "keymap_pitchmove"},
+	{N_("Toggle fast"),      "keymap_fastmove"},
+	{N_("Toggle noclip"),    "keymap_noclip"},
+	{N_("Mute"),             "keymap_mute"},
+	{N_("Dec. volume"),      "keymap_decrease_volume"},
+	{N_("Inc. volume"),      "keymap_increase_volume"},
+	{N_("Autoforward"),      "keymap_autoforward"},
+	{N_("Chat"),             "keymap_chat"},
+	{N_("Screenshot"),       "keymap_screenshot"},
+	{N_("Range select"),     "keymap_rangeselect"},
+	{N_("Dec. range"),       "keymap_decrease_viewing_range_min"},
+	{N_("Inc. range"),       "keymap_increase_viewing_range_min"},
+	{N_("Console"),          "keymap_console"},
+	{N_("Command"),          "keymap_cmd"},
+	{N_("Local command"),    "keymap_cmd_local"},
+	{N_("Block bounds"),     "keymap_toggle_block_bounds"},
+	{N_("Toggle HUD"),       "keymap_toggle_hud"},
+	{N_("Toggle chat log"),  "keymap_toggle_chat"},
+	{N_("Toggle fog"),       "keymap_toggle_fog"}
+};
+
+static const std::vector<setting_entry> control_settings {
+	{N_("\"Aux1\" = climb down"), "aux1_descends"},
+	{N_("Double tap \"jump\" to toggle fly"), "doubletap_jump"},
+	{N_("Automatic jumping"), "autojump"}
+};
+
+void GUIKeyChangeMenu::KeyChangeFormspecHandler::gotText(const StringMap &fields)
 {
-	init_keys();
-}
-
-GUIKeyChangeMenu::~GUIKeyChangeMenu()
-{
-	removeAllChildren();
-	key_used_text = nullptr;
-
-	for (key_setting *ks : key_settings) {
-		delete ks;
-	}
-	key_settings.clear();
-}
-
-void GUIKeyChangeMenu::regenerateGui(v2u32 screensize)
-{
-	removeAllChildren();
-	key_used_text = nullptr;
-
-	ScalingInfo info = getScalingInfo(screensize, v2u32(835, 430));
-	const float s = info.scale;
-	DesiredRect = info.rect;
-	recalculateAbsolutePosition(false);
-
-	v2s32 size = DesiredRect.getSize();
-	v2s32 topleft(0, 0);
-
-	{
-		core::rect<s32> rect(0, 0, 600 * s, 40 * s);
-		rect += topleft + v2s32(25 * s, 3 * s);
-		//gui::IGUIStaticText *t =
-		gui::StaticText::add(Environment, wstrgettext("Keybindings."), rect,
-				false, true, this, -1);
-		//t->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
-	}
-
-	// Build buttons
-
-	v2s32 offset(25 * s, 60 * s);
-
-	for(size_t i = 0; i < key_settings.size(); i++)
-	{
-		key_setting *k = key_settings.at(i);
-		{
-			core::rect<s32> rect(0, 0, 150 * s, 20 * s);
-			rect += topleft + v2s32(offset.X, offset.Y);
-			gui::StaticText::add(Environment, k->button_name, rect,
-					false, true, this, -1);
-		}
-
-		{
-			core::rect<s32> rect(0, 0, 100 * s, 30 * s);
-			rect += topleft + v2s32(offset.X + 150 * s, offset.Y - 5 * s);
-			k->button = GUIButton::addButton(Environment, rect, m_tsrc, this, k->id,
-					wstrgettext(k->key.name()).c_str());
-		}
-		if ((i + 1) % KMaxButtonPerColumns == 0) {
-			offset.X += 260 * s;
-			offset.Y = 60 * s;
-		} else {
-			offset += v2s32(0, 25 * s);
-		}
-	}
-
-	{
-		s32 option_x = offset.X;
-		s32 option_y = offset.Y + 5 * s;
-		u32 option_w = 180 * s;
-		{
-			core::rect<s32> rect(0, 0, option_w, 30 * s);
-			rect += topleft + v2s32(option_x, option_y);
-			Environment->addCheckBox(g_settings->getBool("aux1_descends"), rect, this,
-					GUI_ID_CB_AUX1_DESCENDS, wstrgettext("\"Aux1\" = climb down").c_str());
-		}
-		offset += v2s32(0, 25 * s);
-	}
-
-	{
-		s32 option_x = offset.X;
-		s32 option_y = offset.Y + 5 * s;
-		u32 option_w = 280 * s;
-		{
-			core::rect<s32> rect(0, 0, option_w, 30 * s);
-			rect += topleft + v2s32(option_x, option_y);
-			Environment->addCheckBox(g_settings->getBool("doubletap_jump"), rect, this,
-					GUI_ID_CB_DOUBLETAP_JUMP, wstrgettext("Double tap \"jump\" to toggle fly").c_str());
-		}
-		offset += v2s32(0, 25 * s);
-	}
-
-	{
-		s32 option_x = offset.X;
-		s32 option_y = offset.Y + 5 * s;
-		u32 option_w = 280;
-		{
-			core::rect<s32> rect(0, 0, option_w, 30 * s);
-			rect += topleft + v2s32(option_x, option_y);
-			Environment->addCheckBox(g_settings->getBool("autojump"), rect, this,
-					GUI_ID_CB_AUTOJUMP, wstrgettext("Automatic jumping").c_str());
-		}
-		offset += v2s32(0, 25);
-	}
-
-	{
-		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
-		rect += topleft + v2s32(size.X / 2 - 105 * s, size.Y - 40 * s);
-		GUIButton::addButton(Environment, rect, m_tsrc, this, GUI_ID_BACK_BUTTON,
-				wstrgettext("Save").c_str());
-	}
-	{
-		core::rect<s32> rect(0, 0, 100 * s, 30 * s);
-		rect += topleft + v2s32(size.X / 2 + 5 * s, size.Y - 40 * s);
-		GUIButton::addButton(Environment, rect, m_tsrc, this, GUI_ID_ABORT_BUTTON,
-				wstrgettext("Cancel").c_str());
-	}
-}
-
-void GUIKeyChangeMenu::drawMenu()
-{
-	gui::IGUISkin* skin = Environment->getSkin();
-	if (!skin)
+	if (fields.find("btn_save") != fields.end()) {
+		form->acceptInput();
 		return;
-	video::IVideoDriver* driver = Environment->getVideoDriver();
+	}
+	if (fields.find("btn_cancel") != fields.end())
+		return;
 
-	video::SColor bgcolor(140, 0, 0, 0);
-	driver->draw2DRectangle(bgcolor, AbsoluteRect, &AbsoluteClippingRect);
+	if (const auto &field = fields.find("scrollbar"); field != fields.end()) {
+		if (const auto &stringval = field->second; str_starts_with(stringval, "CHG:"))
+			form->scroll_position = stof(stringval.substr(4));
+	}
 
-	gui::IGUIElement::draw();
+	for (const auto &field: fields) {
+		const auto &name = field.first;
+		if (str_starts_with(name, "checkbox_"))
+			form->control_options[name.substr(9)] = (field.second == "true");
+		else if (str_starts_with(name, "btn_clear_"))
+			form->keymap[name.substr(10)] = KeyPress();
+		else if (str_starts_with(name, "btn_set_")) {
+			const auto &setting = name.substr(8);
+			if (setting == form->active_key)
+				form->active_key = "";
+			else
+				form->active_key = setting;
+		}
+	}
+
+	form->updateFormSource();
 }
 
-bool GUIKeyChangeMenu::acceptInput()
+std::string GUIKeyChangeMenu::getTexture(const std::string &name) const
 {
-	for (key_setting *k : key_settings) {
-		std::string default_key;
-		Settings::getLayer(SL_DEFAULTS)->getNoEx(k->setting_name, default_key);
+	return has_client ? name : porting::path_share + "/textures/base/pack/" + name;
+}
 
-		if (k->key.sym() != default_key)
-			g_settings->set(k->setting_name, k->key.sym());
-		else
-			g_settings->remove(k->setting_name);
+void GUIKeyChangeMenu::updateFormSource(const std::string &message)
+{
+	// this is more or less make_scrollbaroptions_for_scroll_container from Lua
+	float formspec_height = 13;
+	float control_options_offset = formspec_height - 2 - (control_settings.size()/2)*0.5;
+
+	std::ostringstream os;
+	os << "formspec_version[7]"
+		<< "size[15.5," << formspec_height << "]"
+		<< "button_exit[3.5," << formspec_height-1.5 << ";4,1;btn_save;" << strgettext("Save") << "]"
+		<< "button_exit[8," << formspec_height-1.5 << ";4,1;btn_cancel;" << strgettext("Cancel") << "]";
+
+	if (!message.empty()) {
+		os << "label[0.5," << formspec_height - 2 << ";" << message << "]";
+		control_options_offset -= 0.5;
 	}
 
-	{
-		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUX1_DESCENDS);
-		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("aux1_descends", ((gui::IGUICheckBox*)e)->isChecked());
+	float pos_x = 0.5;
+	float pos_y = control_options_offset;
+
+	bool alt = false;
+	for (const auto &setting: control_settings) {
+		os << "checkbox[" << pos_x << "," << pos_y << ";"
+			<< "checkbox_" << setting.setting_name << ";"
+			<< strgettext(setting.display_name) << ";"
+			<< (getControlOption(setting.setting_name)?"true":"false") << "]";
+		if (alt) {
+			pos_x = 0.5;
+			pos_y += 0.5;
+		} else {
+			pos_x = 8;
+		}
+		alt = !alt;
 	}
-	{
-		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_DOUBLETAP_JUMP);
-		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("doubletap_jump", ((gui::IGUICheckBox*)e)->isChecked());
+
+	float container_height = control_options_offset - 1;
+	float container_total_height = 1.5*key_settings.size()-0.5;
+	float container_scroll_max = (container_total_height-container_height)*10;
+	float container_scroll_thumb = container_height / container_total_height * container_scroll_max;
+	os << "scrollbaroptions[min=0;max=" << container_scroll_max << ";"
+		<< "thumbsize=" << container_scroll_thumb <<  "]"
+		<< "scrollbar[14.5,0.5;0.5," << container_height << ";vertical;scrollbar;" << scroll_position << "]"
+		<< "scroll_container[0.5,0.5;14," << container_height << ";scrollbar;vertical]";
+
+	pos_y = 0;
+	for (const auto &setting: key_settings) {
+		const auto &key = getKeySetting(setting.setting_name);
+		std::string keydesc(key.name());
+		bool show_clear = false;
+		if (!keydesc.empty()) {
+			keydesc = strgettext(keydesc);
+			show_clear = true;
+		}
+		if (active_key == setting.setting_name) {
+			keydesc = strgettext("press key");
+			show_clear = false;
+		}
+
+		float btn_width = show_clear ? 5 : 6;
+		os << "label[0," << pos_y + 0.5 << ";" << strgettext(setting.display_name) << "]"
+			<< "button[7.5," << pos_y << ";" << btn_width << ",1;btn_set_" << setting.setting_name << ";"
+			<< keydesc << "]";
+		if (show_clear)
+			os << "image_button[12.5," << pos_y << ";1,1;" << getTexture("clear.png")
+				<< ";btn_clear_" << setting.setting_name << ";]";
+		pos_y += 1.5;
 	}
-	{
-		gui::IGUIElement *e = getElementFromId(GUI_ID_CB_AUTOJUMP);
-		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
-			g_settings->setBool("autojump", ((gui::IGUICheckBox*)e)->isChecked());
-	}
+
+	os << "scroll_container_end[]";
+
+	// The formspec text is deleted by guiFormSpecMenu
+	auto *form_src = new FormspecFormSource(os.str());
+	setFormSource(form_src);
+}
+
+void GUIKeyChangeMenu::acceptInput()
+{
+	for (const auto &setting: keymap)
+		g_settings->set(setting.first, setting.second.sym());
+
+	for (const auto &setting: control_options)
+		g_settings->setBool(setting.first, setting.second);
 
 	clearKeyCache();
-
 	g_gamecallback->signalKeyConfigChange();
-
-	return true;
 }
 
-bool GUIKeyChangeMenu::resetMenu()
+bool GUIKeyChangeMenu::OnEvent(const SEvent &event)
 {
-	if (active_key) {
-		active_key->button->setText(wstrgettext(active_key->key.name()).c_str());
-		active_key = nullptr;
+	if (!active_key.empty() && event.EventType == EET_KEY_INPUT_EVENT
+			&& event.KeyInput.PressedDown) {
+		KeyPress kp(event.KeyInput);
+		keymap[active_key] = kp;
+
+		std::string conflict;
+		for (const auto &setting: key_settings) {
+			if (setting.setting_name == active_key)
+				continue;
+			if (getKeySetting(setting.setting_name) == kp) {
+				conflict = strgettext(setting.display_name);
+				break;
+			}
+		}
+		active_key = "";
+		if (conflict.empty())
+			updateFormSource();
+		else
+			updateFormSource(fmtgettext("Key already in use for another action: %s", conflict.c_str()));
+
 		return false;
 	}
-	return true;
-}
-bool GUIKeyChangeMenu::OnEvent(const SEvent& event)
-{
-	if (event.EventType == EET_KEY_INPUT_EVENT && active_key
-			&& event.KeyInput.PressedDown) {
-
-		bool prefer_character = shift_down;
-		KeyPress kp(event.KeyInput, prefer_character);
-
-		if (event.KeyInput.Key == irr::KEY_DELETE)
-			kp = KeyPress(""); // To erase key settings
-		else if (event.KeyInput.Key == irr::KEY_ESCAPE)
-			kp = active_key->key; // Cancel
-
-		bool shift_went_down = false;
-		if(!shift_down &&
-				(event.KeyInput.Key == irr::KEY_SHIFT ||
-				event.KeyInput.Key == irr::KEY_LSHIFT ||
-				event.KeyInput.Key == irr::KEY_RSHIFT))
-			shift_went_down = true;
-
-		// Display Key already in use message
-		bool key_in_use = false;
-		if (strcmp(kp.sym(), "") != 0) {
-			for (key_setting *ks : key_settings) {
-				if (ks != active_key && ks->key == kp) {
-					key_in_use = true;
-					break;
-				}
-			}
-		}
-
-		if (key_in_use && !this->key_used_text) {
-			core::rect<s32> rect(0, 0, 600, 40);
-			rect += v2s32(0, 0) + v2s32(25, 30);
-			this->key_used_text = gui::StaticText::add(Environment,
-					wstrgettext("Key already in use"),
-					rect, false, true, this, -1);
-		} else if (!key_in_use && this->key_used_text) {
-			this->key_used_text->remove();
-			this->key_used_text = nullptr;
-		}
-
-		// But go on
-		{
-			active_key->key = kp;
-			active_key->button->setText(wstrgettext(kp.name()).c_str());
-
-			// Allow characters made with shift
-			if (shift_went_down){
-				shift_down = true;
-				return false;
-			}
-
-			active_key = nullptr;
-			return true;
-		}
-	} else if (event.EventType == EET_KEY_INPUT_EVENT && !active_key
-			&& event.KeyInput.PressedDown
-			&& event.KeyInput.Key == irr::KEY_ESCAPE) {
-		quitMenu();
-		return true;
-	} else if (event.EventType == EET_GUI_EVENT) {
-		if (event.GUIEvent.EventType == gui::EGET_ELEMENT_FOCUS_LOST
-			&& isVisible())
-		{
-			if (!canTakeFocus(event.GUIEvent.Element))
-			{
-				infostream << "GUIKeyChangeMenu: Not allowing focus change."
-				<< std::endl;
-				// Returning true disables focus change
-				return true;
-			}
-		}
-		if (event.GUIEvent.EventType == gui::EGET_BUTTON_CLICKED)
-		{
-			switch (event.GUIEvent.Caller->getID())
-			{
-				case GUI_ID_BACK_BUTTON: //back
-					acceptInput();
-					quitMenu();
-					return true;
-				case GUI_ID_ABORT_BUTTON: //abort
-					quitMenu();
-					return true;
-				default:
-					resetMenu();
-					for (key_setting *ks : key_settings) {
-						if (ks->id == event.GUIEvent.Caller->getID()) {
-							active_key = ks;
-							break;
-						}
-					}
-					FATAL_ERROR_IF(!active_key, "Key setting not found");
-
-					shift_down = false;
-					active_key->button->setText(wstrgettext("press key").c_str());
-					break;
-			}
-			Environment->setFocus(this);
-		}
-	}
-	return Parent ? Parent->OnEvent(event) : false;
-}
-
-void GUIKeyChangeMenu::add_key(int id, std::wstring button_name, const std::string &setting_name)
-{
-	key_setting *k = new key_setting;
-	k->id = id;
-
-	k->button_name = std::move(button_name);
-	k->setting_name = setting_name;
-	k->key = getKeySetting(k->setting_name.c_str());
-	key_settings.push_back(k);
-}
-
-// compare with button_titles in touchcontrols.cpp
-void GUIKeyChangeMenu::init_keys()
-{
-	this->add_key(GUI_ID_KEY_FORWARD_BUTTON,      wstrgettext("Forward"),          "keymap_forward");
-	this->add_key(GUI_ID_KEY_BACKWARD_BUTTON,     wstrgettext("Backward"),         "keymap_backward");
-	this->add_key(GUI_ID_KEY_LEFT_BUTTON,         wstrgettext("Left"),             "keymap_left");
-	this->add_key(GUI_ID_KEY_RIGHT_BUTTON,        wstrgettext("Right"),            "keymap_right");
-	this->add_key(GUI_ID_KEY_AUX1_BUTTON,         wstrgettext("Aux1"),             "keymap_aux1");
-	this->add_key(GUI_ID_KEY_JUMP_BUTTON,         wstrgettext("Jump"),             "keymap_jump");
-	this->add_key(GUI_ID_KEY_SNEAK_BUTTON,        wstrgettext("Sneak"),            "keymap_sneak");
-	this->add_key(GUI_ID_KEY_DROP_BUTTON,         wstrgettext("Drop"),             "keymap_drop");
-	this->add_key(GUI_ID_KEY_INVENTORY_BUTTON,    wstrgettext("Inventory"),        "keymap_inventory");
-	this->add_key(GUI_ID_KEY_HOTBAR_PREV_BUTTON,  wstrgettext("Prev. item"),       "keymap_hotbar_previous");
-	this->add_key(GUI_ID_KEY_HOTBAR_NEXT_BUTTON,  wstrgettext("Next item"),        "keymap_hotbar_next");
-	this->add_key(GUI_ID_KEY_ZOOM_BUTTON,         wstrgettext("Zoom"),             "keymap_zoom");
-	this->add_key(GUI_ID_KEY_CAMERA_BUTTON,       wstrgettext("Change camera"),    "keymap_camera_mode");
-	this->add_key(GUI_ID_KEY_MINIMAP_BUTTON,      wstrgettext("Toggle minimap"),   "keymap_minimap");
-	this->add_key(GUI_ID_KEY_FLY_BUTTON,          wstrgettext("Toggle fly"),       "keymap_freemove");
-	this->add_key(GUI_ID_KEY_PITCH_MOVE,          wstrgettext("Toggle pitchmove"), "keymap_pitchmove");
-	this->add_key(GUI_ID_KEY_FAST_BUTTON,         wstrgettext("Toggle fast"),      "keymap_fastmove");
-	this->add_key(GUI_ID_KEY_NOCLIP_BUTTON,       wstrgettext("Toggle noclip"),    "keymap_noclip");
-	this->add_key(GUI_ID_KEY_MUTE_BUTTON,         wstrgettext("Mute"),             "keymap_mute");
-	this->add_key(GUI_ID_KEY_DEC_VOLUME_BUTTON,   wstrgettext("Dec. volume"),      "keymap_decrease_volume");
-	this->add_key(GUI_ID_KEY_INC_VOLUME_BUTTON,   wstrgettext("Inc. volume"),      "keymap_increase_volume");
-	this->add_key(GUI_ID_KEY_AUTOFWD_BUTTON,      wstrgettext("Autoforward"),      "keymap_autoforward");
-	this->add_key(GUI_ID_KEY_CHAT_BUTTON,         wstrgettext("Chat"),             "keymap_chat");
-	this->add_key(GUI_ID_KEY_SCREENSHOT_BUTTON,   wstrgettext("Screenshot"),       "keymap_screenshot");
-	this->add_key(GUI_ID_KEY_RANGE_BUTTON,        wstrgettext("Range select"),     "keymap_rangeselect");
-	this->add_key(GUI_ID_KEY_DEC_RANGE_BUTTON,    wstrgettext("Dec. range"),       "keymap_decrease_viewing_range_min");
-	this->add_key(GUI_ID_KEY_INC_RANGE_BUTTON,    wstrgettext("Inc. range"),       "keymap_increase_viewing_range_min");
-	this->add_key(GUI_ID_KEY_CONSOLE_BUTTON,      wstrgettext("Console"),          "keymap_console");
-	this->add_key(GUI_ID_KEY_CMD_BUTTON,          wstrgettext("Command"),          "keymap_cmd");
-	this->add_key(GUI_ID_KEY_CMD_LOCAL_BUTTON,    wstrgettext("Local command"),    "keymap_cmd_local");
-	this->add_key(GUI_ID_KEY_BLOCK_BOUNDS_BUTTON, wstrgettext("Block bounds"),     "keymap_toggle_block_bounds");
-	this->add_key(GUI_ID_KEY_HUD_BUTTON,          wstrgettext("Toggle HUD"),       "keymap_toggle_hud");
-	this->add_key(GUI_ID_KEY_CHATLOG_BUTTON,      wstrgettext("Toggle chat log"),  "keymap_toggle_chat");
-	this->add_key(GUI_ID_KEY_FOG_BUTTON,          wstrgettext("Toggle fog"),       "keymap_toggle_fog");
+	return super::OnEvent(event);
 }

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -63,7 +63,7 @@ static const std::vector<setting_entry> control_settings {
 void GUIKeyChangeMenu::KeyChangeFormspecHandler::gotText(const StringMap &fields)
 {
 	if (fields.find("btn_save") != fields.end()) {
-		form->acceptInput();
+		form->saveSettings();
 		return;
 	}
 	if (fields.find("btn_cancel") != fields.end())
@@ -172,7 +172,7 @@ void GUIKeyChangeMenu::updateFormSource(const std::string &message)
 	setFormSource(form_src);
 }
 
-void GUIKeyChangeMenu::acceptInput()
+void GUIKeyChangeMenu::saveSettings()
 {
 	for (const auto &setting: keymap)
 		g_settings->set(setting.first, setting.second.sym());

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -188,6 +188,12 @@ bool GUIKeyChangeMenu::OnEvent(const SEvent &event)
 {
 	if (!active_key.empty() && event.EventType == EET_KEY_INPUT_EVENT
 			&& event.KeyInput.PressedDown) {
+		if (event.KeyInput.Key == irr::KEY_ESCAPE) {
+			// Do not allow binding to the escape key
+			updateFormSource(fmtgettext("Binding to the Escape key is not allowed"));
+			return true;
+		}
+
 		KeyPress kp(event.KeyInput);
 		keymap[active_key] = kp;
 

--- a/src/gui/guiKeyChangeMenu.h
+++ b/src/gui/guiKeyChangeMenu.h
@@ -6,59 +6,80 @@
 
 #pragma once
 
-#include "irrlichttypes_extrabloated.h"
-#include "modalMenu.h"
-#include "gettext.h"
+#include "guiFormSpecMenu.h"
+#include "mainmenumanager.h"
+#include "settings.h"
+#include "client/client.h"
 #include "client/keycode.h"
 #include <string>
-#include <vector>
+#include <unordered_map>
 
-class ISimpleTextureSource;
-
-struct key_setting
+class GUIKeyChangeMenu : public GUIFormSpecMenu
 {
-	int id;
-	std::wstring button_name;
-	KeyPress key;
-	std::string setting_name;
-	gui::IGUIButton *button;
-};
+	using super = GUIFormSpecMenu;
 
-class GUIKeyChangeMenu : public GUIModalMenu
-{
 public:
-	GUIKeyChangeMenu(gui::IGUIEnvironment *env, gui::IGUIElement *parent, s32 id,
-			IMenuManager *menumgr, ISimpleTextureSource *tsrc);
-	~GUIKeyChangeMenu();
+	// We can't use Client* in the mainmenu
+	GUIKeyChangeMenu(Client * client, gui::IGUIEnvironment *guienv, JoystickController *joystick,
+			ISimpleTextureSource *tsrc, ISoundManager *sound_manager,
+			const std::string &formspec_prepend = "") :
+		super(joystick, guiroot, -1, &g_menumgr, client, guienv, tsrc,
+				sound_manager, nullptr, nullptr, formspec_prepend),
+		has_client(client != nullptr)
+		{
+			updateFormSource();
+			setFormspecHandler();
+		}
 
 	/*
 	 Remove and re-add (or reposition) stuff
 	 */
-	void regenerateGui(v2u32 screensize);
-
-	void drawMenu();
-
-	bool acceptInput();
+	void acceptInput();
 
 	bool OnEvent(const SEvent &event);
 
 	bool pausesGame() { return true; }
 
-protected:
-	std::wstring getLabelByID(s32 id) { return L""; }
-	std::string getNameByID(s32 id) { return ""; }
-
 private:
-	void init_keys();
+	class KeyChangeFormspecHandler : public TextDest
+	{
+	public:
+		const std::string formname = "MT_KEY_CHANGE_MENU";
+		KeyChangeFormspecHandler(GUIKeyChangeMenu *form) :
+			form(form) {};
+		void gotText(const StringMap &fields);
+	private:
+		GUIKeyChangeMenu *form;
+	};
 
-	bool resetMenu();
+	void updateFormSource(const std::string &message = "");
+	void setFormspecHandler()
+	{
+		// The formspec handler is deleted by guiFormSpecMenu
+		setTextDest(new KeyChangeFormspecHandler(this));
+	}
 
-	void add_key(int id, std::wstring button_name, const std::string &setting_name);
+	const KeyPress &getKeySetting(const std::string &name) const
+	{
+		const auto &found = keymap.find(name);
+		if (found != keymap.end())
+			return found->second;
+		return ::getKeySetting(name.c_str());
+	}
 
-	bool shift_down = false;
+	bool getControlOption(const std::string &name) const
+	{
+		const auto &found = control_options.find(name);
+		if (found != control_options.end())
+			return found->second;
+		return g_settings->getBool(name);
+	}
 
-	key_setting *active_key = nullptr;
-	gui::IGUIStaticText *key_used_text = nullptr;
-	std::vector<key_setting *> key_settings;
-	ISimpleTextureSource *m_tsrc;
+	std::string getTexture(const std::string &name) const;
+
+	std::unordered_map<std::string, KeyPress> keymap;
+	std::unordered_map<std::string, bool> control_options;
+	std::string active_key;
+	bool has_client;
+	float scroll_position = 0;
 };

--- a/src/gui/guiKeyChangeMenu.h
+++ b/src/gui/guiKeyChangeMenu.h
@@ -25,7 +25,7 @@ public:
 			const std::string &formspec_prepend = "") :
 		super(joystick, guiroot, -1, &g_menumgr, client, guienv, tsrc,
 				sound_manager, nullptr, nullptr, formspec_prepend),
-		has_client(client != nullptr)
+		has_client(client != nullptr), guienv(guienv)
 		{
 			updateFormSource();
 			setFormspecHandler();
@@ -34,6 +34,12 @@ public:
 	/*
 	 Remove and re-add (or reposition) stuff
 	 */
+	void regenerateGui(v2u32 screensize) {
+		super::regenerateGui(screensize);
+		if (!active_key.empty())
+			guienv->setFocus(this);
+	}
+
 	void acceptInput();
 
 	bool OnEvent(const SEvent &event);
@@ -81,5 +87,6 @@ private:
 	std::unordered_map<std::string, bool> control_options;
 	std::string active_key;
 	bool has_client;
+	gui::IGUIEnvironment *guienv;
 	float scroll_position = 0;
 };

--- a/src/gui/guiKeyChangeMenu.h
+++ b/src/gui/guiKeyChangeMenu.h
@@ -40,7 +40,7 @@ public:
 			guienv->setFocus(this);
 	}
 
-	void acceptInput();
+	void saveSettings();
 
 	bool OnEvent(const SEvent &event);
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -15,6 +15,7 @@
 #include "version.h"
 #include "porting.h"
 #include "filesys.h"
+#include "gettext.h"
 #include "convert_json.h"
 #include "content/content.h"
 #include "content/subgames.h"
@@ -526,12 +527,9 @@ int ModApiMainMenu::l_show_keys_menu(lua_State *L)
 	GUIEngine *engine = getGuiEngine(L);
 	sanity_check(engine != NULL);
 
-	GUIKeyChangeMenu *kmenu = new GUIKeyChangeMenu(
+	GUIKeyChangeMenu *kmenu = new GUIKeyChangeMenu(nullptr, /* no Client object here */
 			engine->m_rendering_engine->get_gui_env(),
-			engine->m_parent,
-			-1,
-			engine->m_menumanager,
-			engine->m_texture_source.get());
+			engine->m_joystick, engine->m_texture_source.get(), engine->m_sound_manager.get());
 	kmenu->drop();
 	return 0;
 }


### PR DESCRIPTION
This PR reworks `GUIKeyChangeMenu` to use `GUIFormSpecMenu`. This partly changes the behavior of the menu:
* It is no longer possible to remove a keybinding by pressing the delete key. Use the "X" button instead.
* It is no longer possible to cancel keybinding by pressing the escape key. Press the "Press key" button to cancel binding to a key. (Please suggest a better better label to make this more obvious).
* The shift key is ignored. In particular, it is no longer possible to _bind_ to e.g. Shift+7 even in non-SDL devices. However, this will be broken by #14964 anyway and can be restored later by adjusting #14874.

---

- Goal of the PR
  Rework `GUIKeyChangeMenu` to use (more or less)
- How does the PR work?
  The `GUIKeyChangeMenu` is largely rewritten.
- Does it resolve any reported issue?
  Fixes #9602 (as the relevant logic has been reworked).
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  2.2 Internal code refactoring.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  This makes it easier to change this form in the future. In particular, this is required by #15577.

## To do

This PR is a Work in Progress.

- [x] Refactor `GUIKeyChangeMenu` to use `GUIFormSpecMenu`
- [x] Rework control option checkboxes.
- [x] Rework keybinding buttons.
- [x] Add buttons to remove keybindings.
- [x] Fix bug: icon for removing keybindings is not shown when the form is opened from the main menu (i.e. Settings -> Keyboard and Mouse -> Controls)
- [x] Restore scrollbar position when appropriate.
- [x] Disallow binding to the Escape key.
- [x] Fix bug: Cannot bind to Return or Space keys.

## How to test
* Check that the form for rebinding keys continue to work.
* Check that the to-dos above are actually done. In particular:
  * Press the escape key when binding a key and observe that the keybinding does not work.
  * Observe that you can then press another key to bind the action (i.e. pressing the Escape key does not cancel keybinding).
  * Press the return or space key when binding a key and observe that it works (i.e. it binds the key instead of closing the formspec).
  * Observe that there is an "X" (with the `clear.png` texture) button to clear the keybinding and that the button is present only for entries with a keybinding. Observe that it actually removes the keybinding.

## Screenshot
![2024-09-12-11-47-05](https://github.com/user-attachments/assets/581b54db-5a34-457d-87ca-72c3788c3753)

