### PR TITLE
Add an IPC channel for SSCSM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LUAJIT_VERSION v2.1
 
 RUN apk add --no-cache git build-base cmake curl-dev zlib-dev zstd-dev \
 		sqlite-dev postgresql-dev hiredis-dev leveldb-dev \
-		gmp-dev jsoncpp-dev ninja ca-certificates
+		gmp-dev jsoncpp-dev linux-headers ninja ca-certificates
 
 WORKDIR /usr/src/
 RUN git clone --recursive https://github.com/jupp0r/prometheus-cpp && \

--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -22,7 +22,7 @@
 
 For Debian/Ubuntu users:
 
-    sudo apt install g++ make libc6-dev cmake linux-libc-dev libpng-dev libjpeg-dev           libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev gettext libsdl2-dev
+    sudo apt install g++ make libc6-dev cmake linux-libc-dev libpng-dev libjpeg-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev gettext libsdl2-dev
 
 For Fedora users:
 

--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -22,7 +22,7 @@
 
 For Debian/Ubuntu users:
 
-    sudo apt install g++ make libc6-dev cmake libpng-dev libjpeg-dev libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev gettext libsdl2-dev
+    sudo apt install g++ make libc6-dev cmake linux-libc-dev libpng-dev libjpeg-dev           libgl1-mesa-dev libsqlite3-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-gnutls-dev libfreetype6-dev zlib1g-dev libgmp-dev libjsoncpp-dev libzstd-dev libluajit-5.1-dev gettext libsdl2-dev
 
 For Fedora users:
 
@@ -34,11 +34,11 @@ For openSUSE users:
 
 For Arch users:
 
-    sudo pacman -S --needed base-devel libcurl-gnutls cmake libpng libjpeg-turbo sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
+    sudo pacman -S --needed base-devel libcurl-gnutls cmake linux-api-headers libpng libjpeg-turbo sqlite libogg libvorbis openal freetype2 jsoncpp gmp luajit leveldb ncurses zstd gettext sdl2
 
 For Alpine users:
 
-    sudo apk add build-base cmake libpng-dev jpeg-dev mesa-dev sqlite-dev libogg-dev libvorbis-dev openal-soft-dev curl-dev freetype-dev zlib-dev gmp-dev jsoncpp-dev luajit-dev zstd-dev gettext sdl2-dev
+    sudo apk add build-base cmake linux-headers libpng-dev jpeg-dev mesa-dev sqlite-dev libogg-dev libvorbis-dev openal-soft-dev curl-dev freetype-dev zlib-dev gmp-dev jsoncpp-dev luajit-dev zstd-dev gettext sdl2-dev
 
 For Void users:
 

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -1,10 +1,11 @@
 set (BENCHMARK_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_activeobjectmgr.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_ipc_channel.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_lighting.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_serialize.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_mapblock.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_mapmodify.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_serialize.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/benchmark_sha.cpp
 	PARENT_SCOPE)
 

--- a/src/benchmark/benchmark_ipc_channel.cpp
+++ b/src/benchmark/benchmark_ipc_channel.cpp
@@ -17,11 +17,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 */
 
-#include "benchmark_setup.h"
+#include "catch.h"
 #include "threading/ipc_channel.h"
 #include <thread>
-
-#include "log.h"
 
 TEST_CASE("benchmark_ipc_channel")
 {
@@ -80,10 +78,20 @@ TEST_CASE("benchmark_ipc_channel")
 		}
 	});
 
-	BENCHMARK("simple_call", i) {
+	BENCHMARK("simple_call_1", i) {
 		char buf[16] = {};
 		buf[i & 0xf] = i;
 		end_a.exchange(buf, 16);
+		return reinterpret_cast<const u8 *>(end_a.getRecvData())[i & 0xf];
+	};
+
+	BENCHMARK("simple_call_1000", i) {
+		char buf[16] = {};
+		buf[i & 0xf] = i;
+		for (int k = 0; k < 1000; ++k) {
+			buf[0] = k & 0xff;
+			end_a.exchange(buf, 16);
+		}
 		return reinterpret_cast<const u8 *>(end_a.getRecvData())[i & 0xf];
 	};
 

--- a/src/benchmark/benchmark_ipc_channel.cpp
+++ b/src/benchmark/benchmark_ipc_channel.cpp
@@ -37,14 +37,14 @@ TEST_CASE("benchmark_ipc_channel")
 	auto thread_b = std::move(end_a_thread_b_p.second);
 
 	BENCHMARK("simple_call_1", i) {
-		char buf[16] = {};
+		u8 buf[16] = {};
 		buf[i & 0xf] = i;
 		end_a.exchange(buf, 16);
 		return reinterpret_cast<const u8 *>(end_a.getRecvData())[i & 0xf];
 	};
 
 	BENCHMARK("simple_call_1000", i) {
-		char buf[16] = {};
+		u8 buf[16] = {};
 		buf[i & 0xf] = i;
 		for (int k = 0; k < 1000; ++k) {
 			buf[0] = k & 0xff;

--- a/src/benchmark/benchmark_ipc_channel.cpp
+++ b/src/benchmark/benchmark_ipc_channel.cpp
@@ -25,7 +25,7 @@ TEST_CASE("benchmark_ipc_channel")
 {
 	auto end_a_thread_b_p = make_test_ipc_channel([](IPCChannelEnd end_b) {
 		// echos back messages. stops if "" is sent
-		for (;;) {
+		while (true) {
 			end_b.recv();
 			end_b.send(end_b.getRecvData(), end_b.getRecvSize());
 			if (end_b.getRecvSize() == 0)

--- a/src/benchmark/benchmark_ipc_channel.cpp
+++ b/src/benchmark/benchmark_ipc_channel.cpp
@@ -1,0 +1,95 @@
+/*
+Minetest
+Copyright (C) 2024 DS
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "benchmark_setup.h"
+#include "threading/ipc_channel.h"
+#include <thread>
+
+#include "log.h"
+
+TEST_CASE("benchmark_ipc_channel")
+{
+	// same as in test_threading.cpp (TODO: remove duplication)
+	struct IPCChannelResourcesSingleProcess final : public IPCChannelResources
+	{
+		void cleanupLast() noexcept override
+		{
+			delete data.shared;
+#ifdef IPC_CHANNEL_IMPLEMENTATION_WIN32
+			CloseHandle(data.sem_b);
+			CloseHandle(data.sem_a);
+#endif
+		}
+
+		void cleanupNotLast() noexcept override
+		{
+			// nothing to do (i.e. no unmapping needed)
+		}
+
+		~IPCChannelResourcesSingleProcess() override { cleanup(); }
+	};
+
+	auto resource_data = [] {
+		auto shared = new IPCChannelShared();
+
+#ifdef IPC_CHANNEL_IMPLEMENTATION_WIN32
+		HANDLE sem_a = CreateSemaphoreA(nullptr, 0, 1, nullptr);
+		REQUIRE(sem_a != INVALID_HANDLE_VALUE);
+
+		HANDLE sem_b = CreateSemaphoreA(nullptr, 0, 1, nullptr);
+		REQUIRE(sem_b != INVALID_HANDLE_VALUE);
+
+		return IPCChannelResources::Data{shared, sem_a, sem_b};
+#else
+		return IPCChannelResources::Data{shared};
+#endif
+	}();
+
+	auto resources_first = std::make_unique<IPCChannelResourcesSingleProcess>();
+	resources_first->setFirst(resource_data);
+
+	IPCChannelEnd end_a = IPCChannelEnd::makeA(std::move(resources_first));
+
+	// echos back messages. stops if "" is sent
+	std::thread thread_b([=] {
+		auto resources_second = std::make_unique<IPCChannelResourcesSingleProcess>();
+		resources_second->setSecond(resource_data);
+		IPCChannelEnd end_b = IPCChannelEnd::makeB(std::move(resources_second));
+
+		for (;;) {
+			end_b.recv();
+			end_b.send(end_b.getRecvData(), end_b.getRecvSize());
+			if (end_b.getRecvSize() == 0)
+				break;
+		}
+	});
+
+	BENCHMARK("simple_call", i) {
+		char buf[16] = {};
+		buf[i & 0xf] = i;
+		end_a.exchange(buf, 16);
+		return reinterpret_cast<const u8 *>(end_a.getRecvData())[i & 0xf];
+	};
+
+	// stop thread_b
+	end_a.exchange(nullptr, 0);
+	REQUIRE(end_a.getRecvSize() == 0);
+
+	thread_b.join();
+}

--- a/src/benchmark/benchmark_ipc_channel.cpp
+++ b/src/benchmark/benchmark_ipc_channel.cpp
@@ -27,8 +27,8 @@ TEST_CASE("benchmark_ipc_channel")
 		// echos back messages. stops if "" is sent
 		for (;;) {
 			end_b.recv();
-			end_b.send(end_b.getRecvData(), end_b.getRecvSize());
-			if (end_b.getRecvSize() == 0)
+			end_b.send(end_b.getRecvData());
+			if (end_b.getRecvData().size() == 0)
 				break;
 		}
 	});
@@ -39,8 +39,8 @@ TEST_CASE("benchmark_ipc_channel")
 	BENCHMARK("simple_call_1", i) {
 		char buf[16] = {};
 		buf[i & 0xf] = i;
-		end_a.exchange(buf, 16);
-		return reinterpret_cast<const u8 *>(end_a.getRecvData())[i & 0xf];
+		end_a.exchange({buf, 16});
+		return end_a.getRecvData()[i & 0xf];
 	};
 
 	BENCHMARK("simple_call_1000", i) {
@@ -48,14 +48,14 @@ TEST_CASE("benchmark_ipc_channel")
 		buf[i & 0xf] = i;
 		for (int k = 0; k < 1000; ++k) {
 			buf[0] = k & 0xff;
-			end_a.exchange(buf, 16);
+			end_a.exchange({buf, 16});
 		}
-		return reinterpret_cast<const u8 *>(end_a.getRecvData())[i & 0xf];
+		return end_a.getRecvData()[i & 0xf];
 	};
 
 	// stop thread_b
-	end_a.exchange(nullptr, 0);
-	REQUIRE(end_a.getRecvSize() == 0);
+	end_a.exchange({nullptr, 0});
+	REQUIRE(end_a.getRecvData().size() == 0);
 
 	thread_b.join();
 }

--- a/src/benchmark/benchmark_ipc_channel.cpp
+++ b/src/benchmark/benchmark_ipc_channel.cpp
@@ -1,21 +1,6 @@
-/*
-Minetest
-Copyright (C) 2024 DS
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation; either version 2.1 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include "catch.h"
 #include "threading/ipc_channel.h"

--- a/src/threading/CMakeLists.txt
+++ b/src/threading/CMakeLists.txt
@@ -2,5 +2,6 @@ set(threading_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/thread.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/semaphore.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/ipc_channel.cpp
 	PARENT_SCOPE)
 

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -1,0 +1,281 @@
+/*
+Minetest
+Copyright (C) 2022 Desour <vorunbekannt75@web.de>
+Copyright (C) 2022 TurkeyMcMac, Jude Melton-Houghton <jwmhjwmh@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#include "ipc_channel.h"
+#include "debug.h"
+#include "exceptions.h"
+#include "porting.h"
+#include <errno.h>
+#include <utility>
+#if defined(__linux__)
+#include <linux/futex.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#if defined(__i386__) || defined(__x86_64__)
+#include <immintrin.h>
+#endif
+#endif
+
+IPCChannelBuffer::IPCChannelBuffer()
+{
+#if !defined(__linux__) && !defined(_WIN32)
+	pthread_condattr_t condattr;
+	pthread_mutexattr_t mutexattr;
+	if (pthread_condattr_init(&condattr) != 0)
+		goto error_condattr_init;
+	if (pthread_mutexattr_init(&mutexattr) != 0)
+		goto error_mutexattr_init;
+	if (pthread_condattr_setpshared(&condattr, 1) != 0)
+		goto error_condattr_setpshared;
+	if (pthread_mutexattr_setpshared(&mutexattr, 1) != 0)
+		goto error_mutexattr_setpshared;
+	if (pthread_cond_init(&cond, &condattr) != 0)
+		goto error_cond_init;
+	if (pthread_mutex_init(&mutex, &mutexattr) != 0)
+		goto error_mutex_init;
+	pthread_mutexattr_destroy(&mutexattr);
+	pthread_condattr_destroy(&condattr);
+	return;
+
+error_mutex_init:
+	pthread_cond_destroy(&cond);
+error_cond_init:
+error_mutexattr_setpshared:
+error_condattr_setpshared:
+	pthread_mutexattr_destroy(&mutexattr);
+error_mutexattr_init:
+	pthread_condattr_destroy(&condattr);
+error_condattr_init:
+	throw BaseException("Unable to initialize IPCChannelBuffer");
+#endif // !defined(__linux__) && !defined(_WIN32)
+}
+
+IPCChannelBuffer::~IPCChannelBuffer()
+{
+#if !defined(__linux__) && !defined(_WIN32)
+	pthread_mutex_destroy(&mutex);
+	pthread_cond_destroy(&cond);
+#endif // !defined(__linux__) && !defined(_WIN32)
+}
+
+#if defined(_WIN32)
+
+static bool wait(HANDLE sem, DWORD timeout)
+{
+	return WaitForSingleObject(sem, timeout) == WAIT_OBJECT_0;
+}
+
+static void post(HANDLE sem)
+{
+	if (!ReleaseSemaphore(sem, 1, nullptr))
+		FATAL_ERROR("ReleaseSemaphore failed unexpectedly");
+}
+
+#else
+
+#if defined(__linux__)
+
+#if defined(__i386__) || defined(__x86_64__)
+static void busy_wait(int n) noexcept
+{
+	for (int i = 0; i < n; i++)
+		_mm_pause();
+}
+#endif // defined(__i386__) || defined(__x86_64__)
+
+static int futex(std::atomic<u32> *uaddr, int futex_op, u32 val,
+		const struct timespec *timeout, u32 *uaddr2, u32 val3) noexcept
+{
+	return syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr2, val3);
+}
+
+#endif // defined(__linux__)
+
+static bool wait(IPCChannelBuffer *buf, const struct timespec *timeout) noexcept
+{
+#if defined(__linux__)
+	// try busy waiting
+	for (int i = 0; i < 100; i++) {
+		// posted?
+		if (buf->futex.exchange(0) == 1)
+			return true; // yes
+#if defined(__i386__) || defined(__x86_64__)
+		busy_wait(40);
+#else
+		break; // Busy wait not implemented
+#endif
+	}
+	// wait with futex
+	while (true) {
+		// write 2 to show that we're futexing
+		if (buf->futex.exchange(2) == 1) {
+			// futex was posted => change 2 to 0 (or 1 to 1)
+			buf->futex.fetch_and(1);
+			return true;
+		}
+		int s = futex(&buf->futex, FUTEX_WAIT, 2, timeout, nullptr, 0);
+		if (s == -1 && errno != EAGAIN)
+			return false;
+	}
+#else
+	bool timed_out = false;
+	pthread_mutex_lock(&buf->mutex);
+	if (!buf->posted) {
+		if (timeout)
+			timed_out = pthread_cond_timedwait(&buf->cond, &buf->mutex, timeout) == ETIMEDOUT;
+		else
+			pthread_cond_wait(&buf->cond, &buf->mutex);
+	}
+	buf->posted = false;
+	pthread_mutex_unlock(&buf->mutex);
+	return !timed_out;
+#endif // !defined(__linux__)
+}
+
+static void post(IPCChannelBuffer *buf) noexcept
+{
+#if defined(__linux__)
+	if (buf->futex.exchange(1) == 2) {
+		int s = futex(&buf->futex, FUTEX_WAKE, 1, nullptr, nullptr, 0);
+		if (s == -1)
+			FATAL_ERROR("FUTEX_WAKE failed unexpectedly");
+	}
+#else
+	pthread_mutex_lock(&buf->mutex);
+	buf->posted = true;
+	pthread_cond_broadcast(&buf->cond);
+	pthread_mutex_unlock(&buf->mutex);
+#endif // !defined(__linux__)
+}
+
+#endif // !defined(_WIN32)
+
+#if defined(_WIN32)
+static DWORD get_timeout(int timeout_ms)
+{
+	return timeout_ms < 0 ? INFINITE : (DWORD)timeout_ms;
+}
+#else
+static struct timespec *set_timespec(struct timespec *ts, int ms)
+{
+	if (ms < 0)
+		return nullptr;
+	u64 msu = ms;
+#if !defined(__linux__)
+	msu += porting::getTimeMs(); // Absolute time
+#endif
+	ts->tv_sec = msu / 1000;
+	ts->tv_nsec = msu % 1000 * 1000000UL;
+	return ts;
+}
+#endif // !defined(_WIN32)
+
+bool IPCChannelEnd::sendSmall(const void *data, size_t size) noexcept
+{
+	m_out->size = size;
+	memcpy(m_out->data, data, size);
+#if defined(_WIN32)
+	post(m_sem_out);
+#else
+	post(m_out);
+#endif
+	return true;
+}
+
+bool IPCChannelEnd::sendLarge(const void *data, size_t size, int timeout_ms) noexcept
+{
+#if defined(_WIN32)
+	DWORD timeout = get_timeout(timeout_ms);
+#else
+	struct timespec timeout, *timeoutp = set_timespec(&timeout, timeout_ms);
+#endif
+	m_out->size = size;
+	do {
+		memcpy(m_out->data, data, IPC_CHANNEL_MSG_SIZE);
+#if defined(_WIN32)
+		post(m_sem_out);
+#else
+		post(m_out);
+#endif
+#if defined(_WIN32)
+		if (!wait(m_sem_in, timeout))
+#else
+		if (!wait(m_in, timeoutp))
+#endif
+			return false;
+		size -= IPC_CHANNEL_MSG_SIZE;
+		data = (u8 *)data + IPC_CHANNEL_MSG_SIZE;
+	} while (size > IPC_CHANNEL_MSG_SIZE);
+	memcpy(m_out->data, data, size);
+#if defined(_WIN32)
+	post(m_sem_out);
+#else
+	post(m_out);
+#endif
+	return true;
+}
+
+bool IPCChannelEnd::recv(int timeout_ms) noexcept
+{
+#if defined(_WIN32)
+	DWORD timeout = get_timeout(timeout_ms);
+#else
+	struct timespec timeout, *timeoutp = set_timespec(&timeout, timeout_ms);
+#endif
+#if defined(_WIN32)
+	if (!wait(m_sem_in, timeout))
+#else
+	if (!wait(m_in, timeoutp))
+#endif
+		return false;
+	size_t size = m_in->size;
+	if (size <= IPC_CHANNEL_MSG_SIZE) {
+		m_recv_size = size;
+		m_recv_data = m_in->data;
+	} else {
+		try {
+			m_large_recv.resize(size);
+		} catch (...) {
+			return false;
+		}
+		u8 *recv_data = m_large_recv.data();
+		m_recv_size = size;
+		m_recv_data = recv_data;
+		do {
+			memcpy(recv_data, m_in->data, IPC_CHANNEL_MSG_SIZE);
+			size -= IPC_CHANNEL_MSG_SIZE;
+			recv_data += IPC_CHANNEL_MSG_SIZE;
+#if defined(_WIN32)
+			post(m_sem_out);
+#else
+			post(m_out);
+#endif
+#if defined(_WIN32)
+			if (!wait(m_sem_in, timeout))
+#else
+			if (!wait(m_in, timeoutp))
+#endif
+				return false;
+		} while (size > IPC_CHANNEL_MSG_SIZE);
+		memcpy(recv_data, m_in->data, size);
+	}
+	return true;
+}

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -284,7 +284,7 @@ bool IPCChannelEnd::sendLarge(const void *data, size_t size, int timeout_ms) noe
 	return true;
 }
 
-bool IPCChannelEnd::recv(int timeout_ms) noexcept
+bool IPCChannelEnd::recvWithTimeout(int timeout_ms) noexcept
 {
 #if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 	DWORD timeout = get_timeout(timeout_ms);
@@ -329,7 +329,7 @@ bool IPCChannelEnd::recv(int timeout_ms) noexcept
 #endif
 				return false;
 		} while (size > IPC_CHANNEL_MSG_SIZE);
-		memcpy(recv_data, m_in->data, size);
+		memcpy(recv_data, m_in->data, size); //TODO: memcpy volatile save?
 	}
 	return true;
 }

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -242,7 +242,8 @@ IPCChannelEnd IPCChannelEnd::makeB(std::unique_ptr<IPCChannelResources> resource
 void IPCChannelEnd::sendSmall(const void *data, size_t size) noexcept
 {
 	write_once(&m_out->size, size);
-	memcpy(m_out->data, data, size);
+	if (size != 0)
+		memcpy(m_out->data, data, size);
 #if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 	post(m_sem_out);
 #else
@@ -275,7 +276,8 @@ bool IPCChannelEnd::sendLarge(const void *data, size_t size, int timeout_ms) noe
 		size -= IPC_CHANNEL_MSG_SIZE;
 		data = (u8 *)data + IPC_CHANNEL_MSG_SIZE;
 	} while (size > IPC_CHANNEL_MSG_SIZE);
-	memcpy(m_out->data, data, size);
+	if (size != 0)
+		memcpy(m_out->data, data, size);
 #if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 	post(m_sem_out);
 #else

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -278,35 +278,38 @@ IPCChannelEnd IPCChannelEnd::makeB(std::unique_ptr<IPCChannelResources> resource
 #endif // !defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 }
 
-void IPCChannelEnd::sendSmall(const void *data, size_t size) noexcept
+void IPCChannelEnd::sendSmall(std::string_view data) noexcept
 {
-	write_once(&m_dir.buf_out->size, size);
+	write_once(&m_dir.buf_out->size, data.size());
 
-	if (size != 0)
-		memcpy(m_dir.buf_out->data, data, size);
+	if (data.size() != 0)
+		memcpy(m_dir.buf_out->data, data.data(), data.size());
 
 	post_out(&m_dir);
 }
 
-bool IPCChannelEnd::sendLarge(const void *data, size_t size, int timeout_ms) noexcept
+bool IPCChannelEnd::sendLarge(std::string_view data, int timeout_ms) noexcept
 {
 	u64 timeout_ms_abs = timeout_ms < 0 ? 0 : porting::getTimeMs() + timeout_ms;
 
-	write_once(&m_dir.buf_out->size, size);
+	write_once(&m_dir.buf_out->size, data.size());
 
-	do {
-		memcpy(m_dir.buf_out->data, data, IPC_CHANNEL_MSG_SIZE);
+	size_t size = data.size();
+	const u8 *ptr = reinterpret_cast<const u8 *>(data.data());
+
+	while (size > IPC_CHANNEL_MSG_SIZE) {
+		memcpy(m_dir.buf_out->data, ptr, IPC_CHANNEL_MSG_SIZE);
 		post_out(&m_dir);
 
 		if (!wait_in(&m_dir, timeout_ms_abs))
 			return false;
 
 		size -= IPC_CHANNEL_MSG_SIZE;
-		data = (u8 *)data + IPC_CHANNEL_MSG_SIZE;
-	} while (size > IPC_CHANNEL_MSG_SIZE);
+		ptr = ptr + IPC_CHANNEL_MSG_SIZE;
+	}
 
 	if (size != 0)
-		memcpy(m_dir.buf_out->data, data, size);
+		memcpy(m_dir.buf_out->data, ptr, size);
 	post_out(&m_dir);
 
 	return true;

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -302,7 +302,7 @@ bool IPCChannelEnd::sendLarge(const void *data, size_t size, int timeout_ms) noe
 			return false;
 
 		size -= IPC_CHANNEL_MSG_SIZE;
-		data = (u8 *)data + IPC_CHANNEL_MSG_SIZE;
+		data = reinterpret_cast<const u8 *>(data) + IPC_CHANNEL_MSG_SIZE;
 	} while (size > IPC_CHANNEL_MSG_SIZE);
 
 	if (size != 0)

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -1,6 +1,6 @@
 /*
 Minetest
-Copyright (C) 2022 Desour <vorunbekannt75@web.de>
+Copyright (C) 2022 DS
 Copyright (C) 2022 TurkeyMcMac, Jude Melton-Houghton <jwmhjwmh@gmail.com>
 
 This program is free software; you can redistribute it and/or modify
@@ -185,6 +185,37 @@ static struct timespec *set_timespec(struct timespec *ts, int ms)
 	ts->tv_sec = msu / 1000;
 	ts->tv_nsec = msu % 1000 * 1000000UL;
 	return ts;
+}
+#endif // !defined(_WIN32)
+
+#if defined(_WIN32)
+IPCChannelEnd IPCChannelEnd::makeA(std::unique_ptr<IPCChannelStuff> stuff)
+{
+	IPCChannelShared *shared = stuff->getShared();
+	HANDLE sem_a = stuff->getSemA();
+	HANDLE sem_b = stuff->getSemB();
+	return IPCChannelEnd(std::move(stuff), &shared->a, &shared->b, sem_a, sem_b);
+}
+
+IPCChannelEnd IPCChannelEnd::makeB(std::unique_ptr<IPCChannelStuff> stuff)
+{
+	IPCChannelShared *shared = stuff->getShared();
+	HANDLE sem_a = stuff->getSemA();
+	HANDLE sem_b = stuff->getSemB();
+	return IPCChannelEnd(std::move(stuff), &shared->b, &shared->a, sem_b, sem_a);
+}
+
+#else // defined(_WIN32)
+IPCChannelEnd IPCChannelEnd::makeA(std::unique_ptr<IPCChannelStuff> stuff)
+{
+	IPCChannelShared *shared = stuff->getShared();
+	return IPCChannelEnd(std::move(stuff), &shared->a, &shared->b);
+}
+
+IPCChannelEnd IPCChannelEnd::makeB(std::unique_ptr<IPCChannelStuff> stuff)
+{
+	IPCChannelShared *shared = stuff->getShared();
+	return IPCChannelEnd(std::move(stuff), &shared->b, &shared->a);
 }
 #endif // !defined(_WIN32)
 

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -24,10 +24,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "porting.h"
 #include <cerrno>
 #include <utility>
+#include <cstring>
 
 #if defined(IPC_CHANNEL_IMPLEMENTATION_LINUX_FUTEX)
 #include <linux/futex.h>
-#include <cstring>
 #include <sys/syscall.h>
 #include <sys/wait.h>
 #if defined(__i386__) || defined(__x86_64__)

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -215,27 +215,27 @@ static inline T read_once(const volatile T *var)
 	return *var;
 }
 
-IPCChannelEnd IPCChannelEnd::makeA(std::unique_ptr<IPCChannelStuff> stuff)
+IPCChannelEnd IPCChannelEnd::makeA(std::unique_ptr<IPCChannelResources> resources)
 {
-	IPCChannelShared *shared = stuff->getShared();
+	IPCChannelShared *shared = resources->data.shared;
 #if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
-	HANDLE sem_a = stuff->getSemA();
-	HANDLE sem_b = stuff->getSemB();
-	return IPCChannelEnd(std::move(stuff), &shared->a, &shared->b, sem_a, sem_b);
+	HANDLE sem_a = resources->data.sem_a;
+	HANDLE sem_b = resources->data.sem_b;
+	return IPCChannelEnd(std::move(resources), &shared->a, &shared->b, sem_a, sem_b);
 #else
-	return IPCChannelEnd(std::move(stuff), &shared->a, &shared->b);
+	return IPCChannelEnd(std::move(resources), &shared->a, &shared->b);
 #endif // !defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 }
 
-IPCChannelEnd IPCChannelEnd::makeB(std::unique_ptr<IPCChannelStuff> stuff)
+IPCChannelEnd IPCChannelEnd::makeB(std::unique_ptr<IPCChannelResources> resources)
 {
-	IPCChannelShared *shared = stuff->getShared();
+	IPCChannelShared *shared = resources->data.shared;
 #if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
-	HANDLE sem_a = stuff->getSemA();
-	HANDLE sem_b = stuff->getSemB();
-	return IPCChannelEnd(std::move(stuff), &shared->b, &shared->a, sem_b, sem_a);
+	HANDLE sem_a = resources->data.sem_a;
+	HANDLE sem_b = resources->data.sem_b;
+	return IPCChannelEnd(std::move(resources), &shared->b, &shared->a, sem_b, sem_a);
 #else
-	return IPCChannelEnd(std::move(stuff), &shared->b, &shared->a);
+	return IPCChannelEnd(std::move(resources), &shared->b, &shared->a);
 #endif // !defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 }
 

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2022 DS
 Copyright (C) 2022 TurkeyMcMac, Jude Melton-Houghton <jwmhjwmh@gmail.com>
+Copyright (C) 2024 DS
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -20,6 +20,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "ipc_channel.h"
 #include "debug.h"
+#include "exceptions.h"
 #include "porting.h"
 #include <cerrno>
 #include <utility>
@@ -179,7 +180,7 @@ static bool wait_in(IPCChannelEnd::Dir *dir, u64 timeout_ms_abs)
 		u64 timeout_ms = timeout_ms_abs - tnow;
 #elif defined(IPC_CHANNEL_IMPLEMENTATION_POSIX)
 		// Absolute time
-		u64 timeout_msu = timeout_ms_abs;
+		u64 timeout_ms = timeout_ms_abs;
 #endif
 		timeout.tv_sec = timeout_ms / 1000;
 		timeout.tv_nsec = timeout_ms % 1000 * 1000000UL;
@@ -200,13 +201,13 @@ static void post_out(IPCChannelEnd::Dir *dir)
 }
 
 template <typename T>
-static inline void write_once(volatile T *var, const T val)
+static void write_once(volatile T *var, const T val)
 {
 	*var = val;
 }
 
 template <typename T>
-static inline T read_once(const volatile T *var)
+static T read_once(const volatile T *var)
 {
 	return *var;
 }

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -44,9 +44,9 @@ IPCChannelBuffer::IPCChannelBuffer()
 		goto error_condattr_init;
 	if (pthread_mutexattr_init(&mutexattr) != 0)
 		goto error_mutexattr_init;
-	if (pthread_condattr_setpshared(&condattr, 1) != 0)
+	if (pthread_condattr_setpshared(&condattr, PTHREAD_PROCESS_SHARED) != 0)
 		goto error_condattr_setpshared;
-	if (pthread_mutexattr_setpshared(&mutexattr, 1) != 0)
+	if (pthread_mutexattr_setpshared(&mutexattr, PTHREAD_PROCESS_SHARED) != 0)
 		goto error_mutexattr_setpshared;
 	if (pthread_cond_init(&cond, &condattr) != 0)
 		goto error_cond_init;

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -147,8 +147,8 @@ static void post(IPCChannelBuffer *buf) noexcept
 {
 	pthread_mutex_lock(&buf->mutex);
 	buf->posted = true;
-	pthread_cond_broadcast(&buf->cond);
 	pthread_mutex_unlock(&buf->mutex);
+	pthread_cond_broadcast(&buf->cond);
 }
 
 #endif

--- a/src/threading/ipc_channel.cpp
+++ b/src/threading/ipc_channel.cpp
@@ -1,22 +1,6 @@
-/*
-Minetest
-Copyright (C) 2022 TurkeyMcMac, Jude Melton-Houghton <jwmhjwmh@gmail.com>
-Copyright (C) 2024 DS
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation; either version 2.1 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include "ipc_channel.h"
 #include "debug.h"

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -30,7 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #if defined(_WIN32)
 #define IPC_CHANNEL_IMPLEMENTATION_WIN32
-#elif defined(__linux__) && 0
+#elif defined(__linux__)
 #define IPC_CHANNEL_IMPLEMENTATION_LINUX_FUTEX
 #else
 #define IPC_CHANNEL_IMPLEMENTATION_POSIX

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -41,6 +41,11 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 	IPCChannelShared is situated in shared memory and is used by both ends of
 	the channel.
+
+	There are currently 3 implementations for synchronisation:
+	* win32: uses win32 semaphore
+	* linux: uses futex, and does busy waiting if on x86/x86_64
+	* other posix: uses posix mutex and condition variable
 */
 
 #define IPC_CHANNEL_MSG_SIZE 8192U
@@ -49,16 +54,21 @@ struct IPCChannelBuffer
 {
 #if !defined(_WIN32)
 #if defined(__linux__)
+	// possible values:
+	// 0: futex is not posted. reader will check value before blocking => no
+	//    notify needed when posting
+	// 1: futex is posted
+	// 2: futex is not posted. reader is waiting with futex syscall, and needs
+	//    to be notified
 	std::atomic<u32> futex{0};
 #else
 	pthread_cond_t cond;
 	pthread_mutex_t mutex;
-	// TODO: use atomic?
-	bool posted = false;
+	bool posted = false; // protected by mutex
 #endif
 #endif // !defined(_WIN32)
 	size_t size;
-	u8 data[IPC_CHANNEL_MSG_SIZE]; //TODO: volatile?
+	u8 data[IPC_CHANNEL_MSG_SIZE];
 
 	IPCChannelBuffer();
 	~IPCChannelBuffer();
@@ -90,13 +100,14 @@ public:
 	static IPCChannelEnd makeA(std::unique_ptr<IPCChannelStuff> stuff);
 	static IPCChannelEnd makeB(std::unique_ptr<IPCChannelStuff> stuff);
 
-	// If send, recv, or exchange return false, stop using the channel.
+	// If send, recv, or exchange return false (=timeout), stop using the channel.
 	// Note: timeouts may be for receiving any response, not a whole message.
 
 	bool send(const void *data, size_t size, int timeout_ms = -1) noexcept
 	{
 		if (size <= IPC_CHANNEL_MSG_SIZE) {
-			return sendSmall(data, size);
+			sendSmall(data, size);
+			return true;
 		} else {
 			return sendLarge(data, size, timeout_ms);
 		}
@@ -109,7 +120,7 @@ public:
 		return send(data, size, timeout_ms) && recv(timeout_ms);
 	}
 
-	// Get information about the last received message
+	// Get the content of the last received message
 	inline const void *getRecvData() const noexcept { return m_recv_data; }
 	inline size_t getRecvSize() const noexcept { return m_recv_size; }
 
@@ -132,8 +143,9 @@ private:
 	{}
 #endif
 
-	bool sendSmall(const void *data, size_t size) noexcept;
+	void sendSmall(const void *data, size_t size) noexcept;
 
+	// returns false on timeout
 	bool sendLarge(const void *data, size_t size, int timeout_ms) noexcept;
 
 	std::unique_ptr<IPCChannelStuff> m_stuff;
@@ -143,7 +155,7 @@ private:
 	HANDLE m_sem_in;
 	HANDLE m_sem_out;
 #endif
-	const void *m_recv_data;
-	size_t m_recv_size;
+	const void *m_recv_data = nullptr;
+	size_t m_recv_size = 0;
 	std::vector<u8> m_large_recv;
 };

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -26,6 +26,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <string>
 #include <type_traits>
 #include <vector>
+#include <atomic>
 
 #if defined(_WIN32)
 #define IPC_CHANNEL_IMPLEMENTATION_WIN32
@@ -37,8 +38,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 #include <windows.h>
-#elif defined(IPC_CHANNEL_IMPLEMENTATION_LINUX_FUTEX)
-#include <atomic>
 #elif defined(IPC_CHANNEL_IMPLEMENTATION_POSIX)
 #include <pthread.h>
 #endif

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -82,7 +82,7 @@ struct IPCChannelBuffer
 	u8 data[IPC_CHANNEL_MSG_SIZE] = {};
 
 	IPCChannelBuffer();
-	~IPCChannelBuffer();
+	~IPCChannelBuffer(); // Note: only destruct once, i.e. in one process
 };
 
 struct IPCChannelShared

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -1,0 +1,143 @@
+/*
+Minetest
+Copyright (C) 2022 Desour <vorunbekannt75@web.de>
+Copyright (C) 2022 TurkeyMcMac, Jude Melton-Houghton <jwmhjwmh@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*/
+
+#pragma once
+
+#include "irrlichttypes.h"
+#include <string>
+#include <type_traits>
+#include <vector>
+#if defined(_WIN32)
+#include <windows.h>
+#elif defined(__linux__)
+#include <atomic>
+#else
+#include <pthread.h>
+#endif
+
+/*
+	An IPC channel is used for synchronous communication between two processes.
+	Sending two messages in succession from one end is not allowed; messages
+	must alternate back and forth.
+
+	IPCChannelShared is situated in shared memory and is used by both ends of
+	the channel.
+*/
+
+#define IPC_CHANNEL_MSG_SIZE 8192U
+
+struct IPCChannelBuffer
+{
+#if !defined(_WIN32)
+#if defined(__linux__)
+	std::atomic<u32> futex = ATOMIC_VAR_INIT(0U);
+#else
+	pthread_cond_t cond;
+	pthread_mutex_t mutex;
+	// TODO: use atomic?
+	bool posted = false;
+#endif
+#endif // !defined(_WIN32)
+	size_t size;
+	u8 data[IPC_CHANNEL_MSG_SIZE];
+
+	IPCChannelBuffer();
+	~IPCChannelBuffer();
+};
+
+struct IPCChannelShared
+{
+	IPCChannelBuffer a;
+	IPCChannelBuffer b;
+};
+
+class IPCChannelEnd
+{
+public:
+	IPCChannelEnd() = default;
+
+#if defined(_WIN32)
+	static IPCChannelEnd makeA(IPCChannelShared *shared, HANDLE sem_a, HANDLE sem_b)
+	{
+		return IPCChannelEnd(&shared->a, &shared->b, sem_a, sem_b);
+	}
+
+	static IPCChannelEnd makeB(IPCChannelShared *shared, HANDLE sem_a, HANDLE sem_b)
+	{
+		return IPCChannelEnd(&shared->b, &shared->a, sem_b, sem_a);
+	}
+#else
+	static IPCChannelEnd makeA(IPCChannelShared *shared)
+	{
+		return IPCChannelEnd(&shared->a, &shared->b);
+	}
+
+	static IPCChannelEnd makeB(IPCChannelShared *shared)
+	{
+		return IPCChannelEnd(&shared->b, &shared->a);
+	}
+#endif // !defined(_WIN32)
+
+	// If send, recv, or exchange return false, stop using the channel.
+	// Note: timeouts may be for receiving any response, not a whole message.
+
+	bool send(const void *data, size_t size, int timeout_ms = -1) noexcept
+	{
+		if (size <= IPC_CHANNEL_MSG_SIZE) {
+			return sendSmall(data, size);
+		} else {
+			return sendLarge(data, size, timeout_ms);
+		}
+	}
+
+	bool recv(int timeout_ms = -1) noexcept;
+
+	bool exchange(const void *data, size_t size, int timeout_ms = -1) noexcept
+	{
+		return send(data, size, timeout_ms) && recv(timeout_ms);
+	}
+
+	// Get information about the last received message
+	inline const void *getRecvData() const noexcept { return m_recv_data; }
+	inline size_t getRecvSize() const noexcept { return m_recv_size; }
+
+private:
+#if defined(_WIN32)
+	IPCChannelEnd(IPCChannelBuffer *in, IPCChannelBuffer *out, HANDLE sem_in, HANDLE sem_out):
+			m_in(in), m_out(out), m_sem_in(sem_in), m_sem_out(sem_out)
+	{}
+#else
+	IPCChannelEnd(IPCChannelBuffer *in, IPCChannelBuffer *out): m_in(in), m_out(out) {}
+#endif
+
+	bool sendSmall(const void *data, size_t size) noexcept;
+
+	bool sendLarge(const void *data, size_t size, int timeout_ms) noexcept;
+
+	IPCChannelBuffer *m_in = nullptr;
+	IPCChannelBuffer *m_out = nullptr;
+#if defined(_WIN32)
+	HANDLE m_sem_in;
+	HANDLE m_sem_out;
+#endif
+	const void *m_recv_data;
+	size_t m_recv_size;
+	std::vector<u8> m_large_recv;
+};

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -1,7 +1,7 @@
 /*
 Minetest
-Copyright (C) 2022 DS
 Copyright (C) 2022 TurkeyMcMac, Jude Melton-Houghton <jwmhjwmh@gmail.com>
+Copyright (C) 2024 DS
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
@@ -237,8 +237,8 @@ public:
 
 	// Get the content of the last received message
 	// TODO: u8 *, or string_view?
-	inline const void *getRecvData() const noexcept { return m_large_recv.data(); }
-	inline size_t getRecvSize() const noexcept { return m_recv_size; }
+	const void *getRecvData() const noexcept { return m_large_recv.data(); }
+	size_t getRecvSize() const noexcept { return m_recv_size; }
 
 private:
 	IPCChannelEnd(std::unique_ptr<IPCChannelResources> resources, Dir dir) :

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -30,7 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #if defined(_WIN32)
 #define IPC_CHANNEL_IMPLEMENTATION_WIN32
-#elif defined(__linux__)
+#elif defined(__linux__) && 0
 #define IPC_CHANNEL_IMPLEMENTATION_LINUX_FUTEX
 #else
 #define IPC_CHANNEL_IMPLEMENTATION_POSIX
@@ -71,7 +71,6 @@ struct IPCChannelBuffer
 
 #elif defined(IPC_CHANNEL_IMPLEMENTATION_POSIX)
 	pthread_cond_t cond;
-	clockid_t cond_clockid;
 	pthread_mutex_t mutex;
 	bool posted = false; // protected by mutex
 #endif

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -27,7 +27,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <atomic>
 #include <thread>
 #include <functional>
-#include <string_view>
 
 #if defined(_WIN32)
 #define IPC_CHANNEL_IMPLEMENTATION_WIN32
@@ -194,20 +193,20 @@ public:
 
 	// Returns false on timeout
 	[[nodiscard]]
-	bool sendWithTimeout(std::string_view data, int timeout_ms) noexcept
+	bool sendWithTimeout(const void *data, size_t size, int timeout_ms) noexcept
 	{
-		if (data.size() <= IPC_CHANNEL_MSG_SIZE) {
-			sendSmall(data);
+		if (size <= IPC_CHANNEL_MSG_SIZE) {
+			sendSmall(data, size);
 			return true;
 		} else {
-			return sendLarge(data, timeout_ms);
+			return sendLarge(data, size, timeout_ms);
 		}
 	}
 
 	// Same as above
-	void send(std::string_view data) noexcept
+	void send(const void *data, size_t size) noexcept
 	{
-		(void)sendWithTimeout(data, -1);
+		(void)sendWithTimeout(data, size, -1);
 	}
 
 	// Returns false on timeout.
@@ -224,31 +223,33 @@ public:
 	// Returns false on timeout
 	// Otherwise returns true, and data is available via getRecvData().
 	[[nodiscard]]
-	bool exchangeWithTimeout(std::string_view data, int timeout_ms) noexcept
+	bool exchangeWithTimeout(const void *data, size_t size, int timeout_ms) noexcept
 	{
-		return sendWithTimeout(data, timeout_ms)
+		return sendWithTimeout(data, size, timeout_ms)
 				&& recvWithTimeout(timeout_ms);
 	}
 
 	// Same as above
-	void exchange(std::string_view data) noexcept
+	void exchange(const void *data, size_t size) noexcept
 	{
-		(void)exchangeWithTimeout(data, -1);
+		(void)exchangeWithTimeout(data, size, -1);
 	}
 
 	// Get the content of the last received message
-	std::string_view getRecvData() const noexcept
-	{ return {reinterpret_cast<const char *>(m_large_recv.data()), m_recv_size}; }
+	// TODO: u8 *, or string_view?
+	const void *getRecvData() const noexcept { return m_large_recv.data(); }
+	size_t getRecvSize() const noexcept { return m_recv_size; }
 
 private:
 	IPCChannelEnd(std::unique_ptr<IPCChannelResources> resources, Dir dir) :
 		m_resources(std::move(resources)), m_dir(dir)
 	{}
 
-	void sendSmall(std::string_view data) noexcept;
+	// TODO: u8 *, or string_view?
+	void sendSmall(const void *data, size_t size) noexcept;
 
 	// returns false on timeout
-	bool sendLarge(std::string_view data, int timeout_ms) noexcept;
+	bool sendLarge(const void *data, size_t size, int timeout_ms) noexcept;
 
 	std::unique_ptr<IPCChannelResources> m_resources;
 	Dir m_dir;

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -236,7 +236,6 @@ public:
 	}
 
 	// Get the content of the last received message
-	// TODO: u8 *, or string_view?
 	const void *getRecvData() const noexcept { return m_large_recv.data(); }
 	size_t getRecvSize() const noexcept { return m_recv_size; }
 
@@ -245,7 +244,6 @@ private:
 		m_resources(std::move(resources)), m_dir(dir)
 	{}
 
-	// TODO: u8 *, or string_view?
 	void sendSmall(const void *data, size_t size) noexcept;
 
 	// returns false on timeout

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -71,6 +71,7 @@ struct IPCChannelBuffer
 
 #elif defined(IPC_CHANNEL_IMPLEMENTATION_POSIX)
 	pthread_cond_t cond;
+	clockid_t cond_clockid;
 	pthread_mutex_t mutex;
 	bool posted = false; // protected by mutex
 #endif

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -188,8 +188,8 @@ public:
 	static IPCChannelEnd makeA(std::unique_ptr<IPCChannelResources> resources);
 	static IPCChannelEnd makeB(std::unique_ptr<IPCChannelResources> resources);
 
-	// If send, recv, or exchange return false (=timeout), stop using the channel. <--- TODO:why?
 	// Note: timeouts may be for receiving any response, not a whole message.
+	// If send, recv, or exchange return false (=timeout), stop using the channel.
 
 	// Returns false on timeout
 	[[nodiscard]]

--- a/src/threading/ipc_channel.h
+++ b/src/threading/ipc_channel.h
@@ -1,22 +1,6 @@
-/*
-Minetest
-Copyright (C) 2022 TurkeyMcMac, Jude Melton-Houghton <jwmhjwmh@gmail.com>
-Copyright (C) 2024 DS
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation; either version 2.1 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-*/
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
 
 #pragma once
 

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -285,8 +285,8 @@ void TestThreading::testIPCChannel()
 		IPCChannelEnd end_b = IPCChannelEnd::makeB(std::make_unique<IPCChannelStuffSingleProcess>(stuff));
 
 		for (;;) {
-			end_b.recv();
-			end_b.send(end_b.getRecvData(), end_b.getRecvSize());
+			UASSERT(end_b.recv());
+			UASSERT(end_b.send(end_b.getRecvData(), end_b.getRecvSize()));
 			if (end_b.getRecvSize() == 0)
 				break;
 		}
@@ -295,12 +295,12 @@ void TestThreading::testIPCChannel()
 	char buf[20000] = {};
 	for (int i = sizeof(buf); i > 0; i -= 1000) {
 		buf[i - 1] = 123;
-		end_a.exchange(buf, i);
+		UASSERT(end_a.exchange(buf, i));
 		UASSERTEQ(int, end_a.getRecvSize(), i);
 		UASSERTEQ(int, ((const char *)end_a.getRecvData())[i - 1], 123);
 	}
 
-	end_a.exchange(buf, 0);
+	UASSERT(end_a.exchange(buf, 0));
 	UASSERTEQ(int, end_a.getRecvSize(), 0);
 
 	thread_b.join();

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -237,8 +237,8 @@ void TestThreading::testIPCChannel()
 		// echos back messages. stops if "" is sent
 		for (;;) {
 			UASSERT(end_b.recvWithTimeout(-1));
-			UASSERT(end_b.sendWithTimeout(end_b.getRecvData(), -1));
-			if (end_b.getRecvData().size() == 0)
+			UASSERT(end_b.sendWithTimeout(end_b.getRecvData(), end_b.getRecvSize(), -1));
+			if (end_b.getRecvSize() == 0)
 				break;
 		}
 	});
@@ -246,17 +246,17 @@ void TestThreading::testIPCChannel()
 	char buf[20000] = {};
 	for (int i = sizeof(buf); i > 0; i -= 100) {
 		buf[i - 1] = 123;
-		UASSERT(end_a.exchangeWithTimeout({buf, (size_t)i}, -1));
-		UASSERTEQ(int, end_a.getRecvData().size(), i);
-		UASSERTEQ(int, end_a.getRecvData().data()[i - 1], 123);
+		UASSERT(end_a.exchangeWithTimeout(buf, i, -1));
+		UASSERTEQ(int, end_a.getRecvSize(), i);
+		UASSERTEQ(int, ((const char *)end_a.getRecvData())[i - 1], 123);
 	}
 
 	// stop thread_b
-	UASSERT(end_a.exchangeWithTimeout({buf, 0}, -1));
-	UASSERTEQ(int, end_a.getRecvData().size(), 0);
+	UASSERT(end_a.exchangeWithTimeout(buf, 0, -1));
+	UASSERTEQ(int, end_a.getRecvSize(), 0);
 
 	thread_b.join();
 
 	// other side dead ==> should time out
-	UASSERT(!end_a.exchangeWithTimeout({buf, 0}, 200));
+	UASSERT(!end_a.exchangeWithTimeout(buf, 0, 200));
 }

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -243,12 +243,12 @@ void TestThreading::testIPCChannel()
 		}
 	});
 
-	char buf[20000] = {};
+	u8 buf[20000] = {};
 	for (int i = sizeof(buf); i > 0; i -= 100) {
 		buf[i - 1] = 123;
 		UASSERT(end_a.exchangeWithTimeout(buf, i, -1));
 		UASSERTEQ(int, end_a.getRecvSize(), i);
-		UASSERTEQ(int, ((const char *)end_a.getRecvData())[i - 1], 123);
+		UASSERTEQ(int, reinterpret_cast<const u8 *>(end_a.getRecvData())[i - 1], 123);
 	}
 
 	// stop thread_b

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -6,6 +6,10 @@
 
 #include <atomic>
 #include <iostream>
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+#include "threading/ipc_channel.h"
 #include "threading/semaphore.h"
 #include "threading/thread.h"
 
@@ -19,6 +23,7 @@ public:
 	void testStartStopWait();
 	void testAtomicSemaphoreThread();
 	void testTLS();
+	void testIPCChannel();
 };
 
 static TestThreading g_test_instance;
@@ -28,6 +33,7 @@ void TestThreading::runTests(IGameDef *gamedef)
 	TEST(testStartStopWait);
 	TEST(testAtomicSemaphoreThread);
 	TEST(testTLS);
+	TEST(testIPCChannel);
 }
 
 class SimpleTestThread : public Thread {
@@ -226,4 +232,59 @@ void TestThreading::testTLS()
 			UASSERT(!g_tls_broken);
 		}
 	}
+}
+
+void TestThreading::testIPCChannel()
+{
+#if defined(_WIN32)
+	HANDLE sem_a = CreateSemaphoreA(nullptr, 0, 1, nullptr);
+	UASSERT(sem_a != INVALID_HANDLE_VALUE);
+
+	HANDLE sem_b = CreateSemaphoreA(nullptr, 0, 1, nullptr);
+	UASSERT(sem_b != INVALID_HANDLE_VALUE);
+#endif
+
+	IPCChannelShared shared, *sharedp = &shared;
+
+#if defined(_WIN32)
+	IPCChannelEnd end_a = IPCChannelEnd::makeA(sharedp, sem_a, sem_b);
+#else
+	IPCChannelEnd end_a = IPCChannelEnd::makeA(sharedp);
+#endif
+
+	std::thread thread_b([=] {
+#if defined(_WIN32)
+		IPCChannelEnd end_b = IPCChannelEnd::makeB(sharedp, sem_a, sem_b);
+#else
+		IPCChannelEnd end_b = IPCChannelEnd::makeB(sharedp);
+#endif
+
+		for (;;) {
+			end_b.recv();
+			end_b.send(end_b.getRecvData(), end_b.getRecvSize());
+			if (end_b.getRecvSize() == 0)
+				break;
+		}
+	});
+
+	char buf[20000] = {};
+	for (int i = sizeof(buf); i > 0; i -= 1000) {
+		buf[i - 1] = 123;
+		end_a.exchange(buf, i);
+		UASSERTEQ(int, end_a.getRecvSize(), i);
+		UASSERTEQ(int, ((const char *)end_a.getRecvData())[i - 1], 123);
+	}
+
+	end_a.exchange(buf, 0);
+	UASSERTEQ(int, end_a.getRecvSize(), 0);
+
+	thread_b.join();
+
+	UASSERT(!end_a.exchange(buf, 0, 1000));
+
+#if defined(_WIN32)
+	CloseHandle(sem_b);
+
+	CloseHandle(sem_a);
+#endif
 }

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -276,6 +276,7 @@ void TestThreading::testIPCChannel()
 
 	IPCChannelEnd end_a = IPCChannelEnd::makeA(std::move(resources_first));
 
+	// echos back messages. stops if "" is sent
 	std::thread thread_b([=] {
 		auto resources_second = std::make_unique<IPCChannelResourcesSingleProcess>();
 		resources_second->setSecond(resource_data);
@@ -297,6 +298,7 @@ void TestThreading::testIPCChannel()
 		UASSERTEQ(int, ((const char *)end_a.getRecvData())[i - 1], 123);
 	}
 
+	// stop thread_b
 	UASSERT(end_a.exchangeWithTimeout(buf, 0, -1));
 	UASSERTEQ(int, end_a.getRecvSize(), 0);
 

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -6,9 +6,6 @@
 
 #include <atomic>
 #include <iostream>
-#if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
-#include <windows.h>
-#endif
 #include "threading/ipc_channel.h"
 #include "threading/semaphore.h"
 #include "threading/thread.h"

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -6,7 +6,7 @@
 
 #include <atomic>
 #include <iostream>
-#if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32) || defined(_WIN32)
+#if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 #include <windows.h>
 #endif
 #include "threading/ipc_channel.h"

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -237,8 +237,8 @@ void TestThreading::testIPCChannel()
 		// echos back messages. stops if "" is sent
 		for (;;) {
 			UASSERT(end_b.recvWithTimeout(-1));
-			UASSERT(end_b.sendWithTimeout(end_b.getRecvData(), end_b.getRecvSize(), -1));
-			if (end_b.getRecvSize() == 0)
+			UASSERT(end_b.sendWithTimeout(end_b.getRecvData(), -1));
+			if (end_b.getRecvData().size() == 0)
 				break;
 		}
 	});
@@ -246,17 +246,17 @@ void TestThreading::testIPCChannel()
 	char buf[20000] = {};
 	for (int i = sizeof(buf); i > 0; i -= 100) {
 		buf[i - 1] = 123;
-		UASSERT(end_a.exchangeWithTimeout(buf, i, -1));
-		UASSERTEQ(int, end_a.getRecvSize(), i);
-		UASSERTEQ(int, ((const char *)end_a.getRecvData())[i - 1], 123);
+		UASSERT(end_a.exchangeWithTimeout({buf, (size_t)i}, -1));
+		UASSERTEQ(int, end_a.getRecvData().size(), i);
+		UASSERTEQ(int, end_a.getRecvData().data()[i - 1], 123);
 	}
 
 	// stop thread_b
-	UASSERT(end_a.exchangeWithTimeout(buf, 0, -1));
-	UASSERTEQ(int, end_a.getRecvSize(), 0);
+	UASSERT(end_a.exchangeWithTimeout({buf, 0}, -1));
+	UASSERTEQ(int, end_a.getRecvData().size(), 0);
 
 	thread_b.join();
 
 	// other side dead ==> should time out
-	UASSERT(!end_a.exchangeWithTimeout(buf, 0, 200));
+	UASSERT(!end_a.exchangeWithTimeout({buf, 0}, 200));
 }

--- a/src/unittest/test_threading.cpp
+++ b/src/unittest/test_threading.cpp
@@ -6,7 +6,7 @@
 
 #include <atomic>
 #include <iostream>
-#if defined(_WIN32)
+#if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32) || defined(_WIN32)
 #include <windows.h>
 #endif
 #include "threading/ipc_channel.h"
@@ -239,13 +239,13 @@ void TestThreading::testIPCChannel()
 	struct Stuff
 	{
 		IPCChannelShared shared{};
-#if defined(_WIN32)
+#if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 		HANDLE sem_a;
 		HANDLE sem_b;
 #endif
 		Stuff()
 		{
-#ifdef _WIN32
+#ifdef IPC_CHANNEL_IMPLEMENTATION_WIN32
 			HANDLE sem_a = CreateSemaphoreA(nullptr, 0, 1, nullptr);
 			UASSERT(sem_a != INVALID_HANDLE_VALUE);
 
@@ -256,7 +256,7 @@ void TestThreading::testIPCChannel()
 
 		~Stuff()
 		{
-#ifdef _WIN32
+#ifdef IPC_CHANNEL_IMPLEMENTATION_WIN32
 			CloseHandle(sem_b);
 			CloseHandle(sem_a);
 #endif
@@ -271,7 +271,7 @@ void TestThreading::testIPCChannel()
 		~IPCChannelStuffSingleProcess() override = default;
 
 		IPCChannelShared *getShared() override { return &stuff->shared; }
-#if defined(_WIN32)
+#if defined(IPC_CHANNEL_IMPLEMENTATION_WIN32)
 		HANDLE getSemA() override { return stuff->sem_a; }
 		HANDLE getSemB() override { return stuff->sem_b; }
 #endif

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -9,7 +9,6 @@
 #include "exceptions.h"
 #include "threading/mutex_auto_lock.h"
 #include "threading/semaphore.h"
-#include "debug.h"
 #include <list>
 #include <vector>
 #include <map>

--- a/src/util/container.h
+++ b/src/util/container.h
@@ -9,6 +9,7 @@
 #include "exceptions.h"
 #include "threading/mutex_auto_lock.h"
 #include "threading/semaphore.h"
+#include "debug.h"
 #include <list>
 #include <vector>
 #include <map>


### PR DESCRIPTION
Partial adoption of #13046.

It's only the ipc channel. E.g. process spawning is not done.
Code is only executed in unittest and benchmark (hence it's unlikely to cause issues, and should be easy to merge, right, right?).

It's not much, but it's a start, and I shouldn't just leave this lying about.

## To do

This PR is a TODO.

~~If you want to review an SSCSM PR, please review #15818 first. (Therefore, I marked this one as waiting. (It is not strictly waiting though.))~~
Edit: Before this can be used for SSCSM, we first need serialization.
Also, I'd like to change some things in the implementation.

## How to test

* Build.
* If on linux, also try the posix implementation.
* `luanti --run-unittests --test-module TestThreading`
* `luanti --run-benchmarks --test-module benchmark_ipc_channel`
* (I haven't ever run the win implementation on my machine.)

Benchmark output on my machine:
```
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
simple_call_1                                  100           113 4825.100000 us 
                                       0.362883 us   0.348476 us   0.388474 us 
                                       0.095173 us   0.061671 us   0.148670 us 
                                                                               
simple_call_1000                               100             1 36443.200000 us 
                                     346.990880 us 341.668110 us 351.688450 us 
                                      25.482886 us  19.670571 us  34.213818 us
```