### PR TITLE
Allow mods to force-show the crosshair on touchscreen for bows etc.

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -8561,6 +8561,15 @@ child will follow movement and rotation of that bone.
           Does not affect players with the `debug` privilege.
         * `chat`: Modifies the client's permission to view chat on the HUD.
           The client may locally elect to not view chat. Does not affect the console.
+        * `crosshair_force_show`: Show the crosshair even if touchscreen controls
+          are enabled and the `touch_use_crosshair` setting is set to false on
+          the client.
+          * This only affects crosshair visiblity, not behavior.
+          * This is useful for items that always work based on the player's look
+            direction, commonly bows or guns.
+          * Only affects clients with protocol version >= 47. Defaults to false.
+          * This doesn't have any effect if the `crosshair` flag is set to false.
+    * All flags except `crosshair_force_show` default to true.
     * If a flag equals `nil`, the flag is not modified
 * `hud_get_flags()`: returns a table of player HUD flags with boolean values.
     * See `hud_set_flags` for a list of flags that can be toggled.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -4366,7 +4366,8 @@ void Game::drawScene(ProfilerGraph *graph, RunStats *stats)
 			(player->hud_flags & HUD_FLAG_CROSSHAIR_VISIBLE) &&
 			(this->camera->getCameraMode() != CAMERA_MODE_THIRD_FRONT));
 
-	if (g_touchcontrols && isTouchCrosshairDisabled())
+	if (g_touchcontrols && isTouchCrosshairDisabled() &&
+			!(player->hud_flags & HUD_FLAG_CROSSHAIR_FORCE_SHOW))
 		draw_crosshair = false;
 
 	this->m_rendering_engine->draw_scene(sky_color, this->m_game_ui->m_flags.show_hud,

--- a/src/hud.cpp
+++ b/src/hud.cpp
@@ -40,7 +40,7 @@ const struct EnumString es_HudElementStat[] =
 	{0, NULL},
 };
 
-const struct EnumString es_HudBuiltinElement[] =
+const struct EnumString es_HudFlag[] =
 {
 	{HUD_FLAG_HOTBAR_VISIBLE,        "hotbar"},
 	{HUD_FLAG_HEALTHBAR_VISIBLE,     "healthbar"},
@@ -51,5 +51,6 @@ const struct EnumString es_HudBuiltinElement[] =
 	{HUD_FLAG_MINIMAP_RADAR_VISIBLE, "minimap_radar"},
 	{HUD_FLAG_BASIC_DEBUG,           "basic_debug"},
 	{HUD_FLAG_CHAT_VISIBLE,          "chat"},
+	{HUD_FLAG_CROSSHAIR_FORCE_SHOW,  "crosshair_force_show"},
 	{0, NULL},
 };

--- a/src/hud.h
+++ b/src/hud.h
@@ -34,6 +34,7 @@
 #define HUD_FLAG_MINIMAP_RADAR_VISIBLE (1 << 6)
 #define HUD_FLAG_BASIC_DEBUG           (1 << 7)
 #define HUD_FLAG_CHAT_VISIBLE          (1 << 8)
+#define HUD_FLAG_CROSSHAIR_FORCE_SHOW  (1 << 9)
 
 #define HUD_PARAM_HOTBAR_ITEMCOUNT 1
 #define HUD_PARAM_HOTBAR_IMAGE 2
@@ -101,7 +102,7 @@ struct HudElement {
 
 extern const EnumString es_HudElementType[];
 extern const EnumString es_HudElementStat[];
-extern const EnumString es_HudBuiltinElement[];
+extern const EnumString es_HudFlag[];
 
 // Minimap stuff
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1858,7 +1858,7 @@ int ObjectRef::l_hud_set_flags(lua_State *L)
 	u32 mask  = 0;
 	bool flag;
 
-	const EnumString *esp = es_HudBuiltinElement;
+	const EnumString *esp = es_HudFlag;
 	for (int i = 0; esp[i].str; i++) {
 		if (getboolfield(L, 2, esp[i].str, flag)) {
 			flags |= esp[i].num * flag;
@@ -1881,7 +1881,7 @@ int ObjectRef::l_hud_get_flags(lua_State *L)
 		return 0;
 
 	lua_newtable(L);
-	const EnumString *esp = es_HudBuiltinElement;
+	const EnumString *esp = es_HudFlag;
 	for (int i = 0; esp[i].str; i++) {
 		lua_pushboolean(L, (player->hud_flags & esp[i].num) != 0);
 		lua_setfield(L, -2, esp[i].str);


### PR DESCRIPTION
On touchscreens, there is no crosshair by default. However, mods might still use the player's look direction for certain items, for example bows or guns. For these items, a crosshair should be shown.

This PR allows mods to force-show the crosshair by setting the HUD flag `crosshair_force_show = true`.

Alternative to the proposal in https://codeberg.org/mineclonia/mineclonia/pulls/890#issuecomment-2340468, cc @j-r

## To do

This PR is a Ready for Review.

Feel free to comment on API design as well

## How to test

1. Set `touch_controls = true` (also possible on desktop) and `touch_use_crosshair = false`  (the default)
2. Start a Devtest world with Worldedit
3. The crosshair is hidden
4. `//lua player:hud_set_flags({crosshair = true, crosshair_force_show = true})` -> The crosshair is shown
5. `//lua player:hud_set_flags({crosshair = false, crosshair_force_show = true})` -> The crosshair is hidden