### PR TITLE
WIP: Allow biome assignments to be height dependent

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -45,6 +45,7 @@ core.features = {
 	hotbar_hud_element = true,
 	bulk_lbms = true,
 	abm_without_neighbors = true,
+	biome_weights = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10706,6 +10706,9 @@ performance and computing power the practical limit is much lower.
     -- distribution of the biomes.
     -- Heat and humidity have average values of 50, vary mostly between
     -- 0 and 100 but can exceed these values.
+
+    weight = 1.0,
+    -- Relative weight of the biome in the Voronoi diagram
 }
 ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -10708,7 +10708,8 @@ performance and computing power the practical limit is much lower.
     -- 0 and 100 but can exceed these values.
 
     weight = 1.0,
-    -- Relative weight of the biome in the Voronoi diagram
+    -- Relative weight of the biome in the Voronoi diagram.
+    -- A value of 0 (or less) is ignored and equivalent to 1.0.
 }
 ```
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5661,6 +5661,8 @@ Utilities
       abm_without_neighbors = true,
       -- biomes have a weight parameter (5.11.0)
       biome_weights = true,
+      -- biomes have height_point and height_weight parameters (5.11.0)
+      biome_heights = true,
   }
   ```
 
@@ -10708,6 +10710,14 @@ performance and computing power the practical limit is much lower.
     -- distribution of the biomes.
     -- Heat and humidity have average values of 50, vary mostly between
     -- 0 and 100 but can exceed these values.
+
+    height_point = 0,
+    -- Characteristic height of the biome.
+    height_weight = 0.0,
+    -- Weight of the height difference in the distance computations for the
+    -- Voronoi partitioning. A scaling is necessary because the value range
+    -- of humidity and heat differs from the range of the y axis.
+    -- A weight of 0 disables the use of heights for biome assignment.
 
     weight = 1.0,
     -- Relative weight of the biome in the Voronoi diagram.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5659,6 +5659,8 @@ Utilities
       bulk_lbms = true,
       -- ABM supports field without_neighbors (5.10.0)
       abm_without_neighbors = true,
+      -- biomes have a weight parameter (5.11.0)
+      biome_weights = true,
   }
   ```
 

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -54,6 +54,7 @@ BiomeManager::BiomeManager(Server *server) :
 	b->heat_point      = 0.0;
 	b->humidity_point  = 0.0;
 	b->vertical_blend  = 0;
+	b->weight          = 1.0f;
 
 	b->m_nodenames.emplace_back("mapgen_stone");
 	b->m_nodenames.emplace_back("mapgen_stone");
@@ -271,7 +272,9 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 
 		float d_heat = heat - b->heat_point;
 		float d_humidity = humidity - b->humidity_point;
-		float dist = (d_heat * d_heat) + (d_humidity * d_humidity);
+		float dist = ((d_heat * d_heat) + (d_humidity * d_humidity));
+		if (b->weight > 0.f)
+		       dist /= b->weight;
 
 		if (pos.Y <= b->max_pos.Y) { // Within y limits of biome b
 			if (dist < dist_min) {
@@ -336,6 +339,7 @@ ObjDef *Biome::clone() const
 	obj->heat_point = heat_point;
 	obj->humidity_point = humidity_point;
 	obj->vertical_blend = vertical_blend;
+	obj->weight = weight;
 
 	return obj;
 }

--- a/src/mapgen/mg_biome.cpp
+++ b/src/mapgen/mg_biome.cpp
@@ -53,8 +53,10 @@ BiomeManager::BiomeManager(Server *server) :
 			MAX_MAP_GENERATION_LIMIT, MAX_MAP_GENERATION_LIMIT);
 	b->heat_point      = 0.0;
 	b->humidity_point  = 0.0;
+	b->height_point    = 0;
 	b->vertical_blend  = 0;
 	b->weight          = 1.0f;
+	b->height_weight   = 0.0f;
 
 	b->m_nodenames.emplace_back("mapgen_stone");
 	b->m_nodenames.emplace_back("mapgen_stone");
@@ -272,7 +274,8 @@ Biome *BiomeGenOriginal::calcBiomeFromNoise(float heat, float humidity, v3s16 po
 
 		float d_heat = heat - b->heat_point;
 		float d_humidity = humidity - b->humidity_point;
-		float dist = ((d_heat * d_heat) + (d_humidity * d_humidity));
+		float d_height = b->height_weight == 0 ? 0 : (pos.Y - b->height_point) * b->height_weight;
+		float dist = ((d_heat * d_heat) + (d_humidity * d_humidity) + (d_height * d_height));
 		if (b->weight > 0.f)
 		       dist /= b->weight;
 
@@ -338,6 +341,7 @@ ObjDef *Biome::clone() const
 	obj->max_pos = max_pos;
 	obj->heat_point = heat_point;
 	obj->humidity_point = humidity_point;
+	obj->height_point = height_point;
 	obj->vertical_blend = vertical_blend;
 	obj->weight = weight;
 

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -68,8 +68,10 @@ public:
 	v3s16 max_pos;
 	float heat_point;
 	float humidity_point;
+	float height_point;
 	s16 vertical_blend;
 	float weight;
+	float height_weight;
 
 	virtual void resolveNodeNames();
 };

--- a/src/mapgen/mg_biome.h
+++ b/src/mapgen/mg_biome.h
@@ -69,6 +69,7 @@ public:
 	float heat_point;
 	float humidity_point;
 	s16 vertical_blend;
+	float weight;
 
 	virtual void resolveNodeNames();
 };

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -388,8 +388,10 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 	b->depth_riverbed  = getintfield_default(L,    index, "depth_riverbed",  0);
 	b->heat_point      = getfloatfield_default(L,  index, "heat_point",      0.f);
 	b->humidity_point  = getfloatfield_default(L,  index, "humidity_point",  0.f);
+	b->height_point    = getfloatfield_default(L,  index, "height_point",    0.f);
 	b->vertical_blend  = getintfield_default(L,    index, "vertical_blend",  0);
 	b->weight          = getfloatfield_default(L,  index, "weight",          1.f);
+	b->height_weight   = getfloatfield_default(L,  index, "height_weight",   0.f);
 	b->flags           = 0; // reserved
 
 	b->min_pos = getv3s16field_default(

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -389,6 +389,7 @@ Biome *read_biome_def(lua_State *L, int index, const NodeDefManager *ndef)
 	b->heat_point      = getfloatfield_default(L,  index, "heat_point",      0.f);
 	b->humidity_point  = getfloatfield_default(L,  index, "humidity_point",  0.f);
 	b->vertical_blend  = getintfield_default(L,    index, "vertical_blend",  0);
+	b->weight          = getfloatfield_default(L,  index, "weight",          1.f);
 	b->flags           = 0; // reserved
 
 	b->min_pos = getv3s16field_default(


### PR DESCRIPTION
This enhances the biome matching system as follows:
- each biome is given a height point (similarly to the heat and humidity points)
- because heat/humidity and height have a different value range, there also is a (biome-specific) weight factor
- the "nearest" biome is assigned using `d_heat^2 + d_humidity^2 + (d_height * weight)^2` as dissimilarity
- the default weight of 0 obviously restores the previous behavior for compatbility
- additional cost is pretty low (some additional biome computations may become necessary)

Benefit:
This will allow us to specify, for example, underground biomes, or mountain biomes, without having to rely on a hard y limit as before.
For discussions on limitations of the current biome system, see #15318 #15215 #13741 #5228

Note: this branch is extending #15142

Open issues:
- [ ] for water vs. underground biomes, it is more relevant what the base floor height is, not the individual floor height that we are looking at? So this does not solve the issue with ocean biomes yet; it cannot tell whether a negative y value is just under water, or an underground cave.
- [ ] y transitions still use the old code, which is based on the assumption of hard y thresholds. Maybe we should use a 3d noise, or another 2d noise map to generate y variation for vertical blending of biomes?
- [ ] upgrade path for games: how can a game recognize that the map was generated with an old version, and fall back to the old generator (e.g., setting height weights to 0, possibly restoring earlier heat_point and humidity_point values)? #11789
- [ ] how do we test this?