### PR TITLE
[no sq] Make Luanti buildable with ANGLE for macOS, iOS and iPhoneSimulator and runnable on iPhoneSimulator

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,61 @@
+name: iOS
+
+# build on c/cpp changes or workflow changes
+on:
+  push:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - 'irr/**.[ch]'
+      - 'irr/**.cpp'
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - 'po/**.po'
+      - '.github/workflows/ios.yml'
+  pull_request:
+    paths:
+      - 'lib/**.[ch]'
+      - 'lib/**.cpp'
+      - 'src/**.[ch]'
+      - 'src/**.cpp'
+      - 'irr/**.[ch]'
+      - 'irr/**.cpp'
+      - '**/CMakeLists.txt'
+      - 'cmake/Modules/**'
+      - 'po/**.po'
+      - '.github/workflows/ios.yml'
+
+jobs:
+  build-ios:
+    strategy:
+      matrix:
+        osver: [18.2]
+        xcodever: [16.2]
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare environment
+        run: |
+          echo "REPDIR=$(pwd)" >> $GITHUB_ENV
+          echo "osver=${{matrix.osver}}" >> $GITHUB_ENV
+          echo "xcodever=${{matrix.xcodever}}" >> $GITHUB_ENV
+
+      - name: Install deps
+        run: |
+          source ./util/ci/common.sh
+          install_ios_deps $osver
+
+      - name: Build and Archive with Xcode
+        run: |
+          mkdir build
+          cd build
+          export DEPS_DIR=/Users/Shared/ios${osver}_deps/iPhoneSimulator
+          ../util/ci/build_ios.sh
+
+      - name: Run in iPhoneSimulator 
+        run: |
+          ./util/ci/run_ios.sh "iPad Air 13-inch (M2)" 150
+          cat log.txt

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,17 +38,26 @@ jobs:
         osver: [11.3]
         xcodever: [16.2]
         arch: ["x86_64"]
+        angle: ["no"]
         build_type: ["Debug"]
         xcode: ["no"]
         include:
           - osver: 11.3
             xcodever: 16.2
             arch: "x86_64"
+            angle: "no"
             build_type: "Debug"
             xcode: "no"
           - osver: 11.3
             xcodever: 16.2
             arch: "arm64"
+            angle: "no"
+            build_type: "Release"
+            xcode: "yes"
+          - osver: 12.3
+            xcodever: 16.2
+            arch: "arm64"
+            angle: "yes"
             build_type: "Release"
             xcode: "yes"
     runs-on: macos-15
@@ -61,21 +70,28 @@ jobs:
           echo "osver=${{matrix.osver}}" >> $GITHUB_ENV
           echo "xcodever=${{matrix.xcodever}}" >> $GITHUB_ENV
           echo "arch=${{matrix.arch}}" >> $GITHUB_ENV
+          echo "angle=${{matrix.angle}}" >> $GITHUB_ENV
           echo "build_type=${{matrix.build_type}}" >> $GITHUB_ENV
+          
+          if [[ "${{matrix.angle}}" == "yes" ]]; then
+            echo "angle_suffix=_angle" >> $GITHUB_ENV
+          else
+            echo "angle_suffix=" >> $GITHUB_ENV
+          fi
 
       - name: Install deps
         run: |
           mkdir downloads
           source ./util/ci/common.sh
           source ./util/ci/macos_sdk.sh
-          install_macos_precompiled_deps $osver $arch
+          install_macos_precompiled_deps $osver $arch $angle
           install_macos_sdk $osver "$xcodever" downloads
 
       - name: Build with GNU Make
         run: |
           mkdir build
           cd build
-          export DEPS_DIR=/Users/Shared/macos${osver}_${arch}_deps
+          export DEPS_DIR=/Users/Shared/macos${osver}_${arch}${angle_suffix}_deps
           export USE_XCODE=no
           ../util/ci/build_macos.sh
 
@@ -84,7 +100,7 @@ jobs:
         run: |
           mkdir build_xcode
           cd build_xcode
-          export DEPS_DIR=/Users/Shared/macos${osver}_${arch}_deps
+          export DEPS_DIR=/Users/Shared/macos${osver}_${arch}${angle_suffix}_deps
           export USE_XCODE=yes
           ../util/ci/build_macos.sh
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,30 @@ if(CMAKE_GENERATOR STREQUAL "Xcode")
 	set(client_RESOURCES "${CMAKE_SOURCE_DIR}/misc/luanti-icon.icns")
 endif()
 
+# Global check of dependencies
+include(CheckIncludeFiles)
+include(CheckCSourceCompiles)
+
+check_include_files(endian.h HAVE_ENDIAN_H)
+
+if(HAVE_ENDIAN_H)
+	set(ENDIAN_CHECK_CODE "
+	#include <endian.h>
+	#inlucde <stdint.h>
+	int main() {
+			uint16_t x = be16toh(1);
+			uint16_t y = htobe16(1);
+			uint32_t a = be32toh(1);
+			uint32_t b = htobe32(1);
+			uint64_t c = be64toh(1);
+			uint64_t d = htobe64(1);
+			return 0;
+	}
+	")
+
+	check_c_source_compiles("${ENDIAN_CHECK_CODE}" HAVE_ENDIAN_H)
+endif()
+
 # Library pack
 find_package(GMP REQUIRED)
 find_package(Json 1.0.0 REQUIRED)

--- a/doc/compiling/README.md
+++ b/doc/compiling/README.md
@@ -25,6 +25,7 @@ General options and their default values:
     USE_SDL2_STATIC=TRUE       - Links with SDL2::SDL2-static instead of SDL2::SDL2
     USE_SDL3=FALSE             - Build with SDL3; Enables IrrlichtMt device SDL3 (experimental)
     USE_SDL3_STATIC=TRUE       - Links with SDL3::SDL3-static instead of SDL3::SDL3-shared
+    USE_ANGLE=FALSE/TRUE       - Build with Google ANGLE; IrrlichtMt device SDL2 on iOS, default TRUE only for iOS
     ENABLE_CURL=ON             - Build with cURL; Enables use of server list, content browser and more
     ENABLE_CURSES=ON           - Build with (n)curses; Enables a server side terminal (command line option: --terminal)
     ENABLE_GETTEXT=ON          - Build with Gettext; Allows using translations

--- a/doc/compiling/ios.md
+++ b/doc/compiling/ios.md
@@ -1,0 +1,103 @@
+# Compiling for iOS
+
+## Requirements
+
+- macOS
+- [Homebrew](https://brew.sh/)
+- Xcode
+- iOS/iPhoneSimulator SDK
+- iOS Simulator for newest iOS is supported only on Apple Silicon devices.
+
+Install dependencies with homebrew:
+
+```
+brew install cmake git
+```
+
+## Prebuild Luanti dependencies
+
+For manual build, use `build.sh` script from cloned repository https://github.com/luanti-org/luanti_ios_deps
+
+- iPhoneSimulator
+	`./build.sh /dir/to/download/sources /dir/to/instal/built/deps iPhoneSimulator iPhoneSimulatorSDKVersion all`
+	(Replace iPhoneSimulatorSDKVersion with your installed SDK version, e.g. 26.2)
+
+- iPhoneOS
+	`./build.sh /dir/to/download/sources /dir/to/instal/built/deps iPhoneOS iPhoneOSSDKVersion all`
+	(Replace iPhoneOSSDKVersion with your installed SDK version, e.g. 26.2)
+
+## Generate Xcode project
+
+Clone Luanti git repository.
+And do something like:
+
+```bash
+mkdir build
+cd build
+
+DEPS_DIR=/absolute/path/to/ios/precompiled/deps
+REPDIR=/absolute/path/to/luanti/repository
+
+export CMAKE_PREFIX_PATH=${DEPS_DIR}
+export SDKROOT="/path/to/sdk/for/iPhoneOS/or/iPhoneSimulator"
+
+cmake .. \
+	-DCMAKE_SYSTEM_NAME=iOS \
+	-DCMAKE_OSX_DEPLOYMENT_TARGET=26.2 \
+	-DCMAKE_FIND_FRAMEWORK=LAST \
+	-DCMAKE_OSX_ARCHITECTURES=arm64 \
+	-DCMAKE_INSTALL_PREFIX=../build/ios/ \
+	-DRUN_IN_PLACE=FALSE \
+	-DENABLE_GETTEXT=TRUE \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_PREFIX_PATH=${DEPS_DIR} \
+	-DENABLE_OPENGL=OFF \
+	-DENABLE_OPENGL3=OFF \
+	-DENABLE_GLES2=ON \
+	-DUSE_SDL2_STATIC=ON \
+	-DSDL2_DIR=${DEPS_DIR}/lib/cmake/SDL2 \
+	-DOPENGLES2_LIBRARY=${DEPS_DIR}/lib/libGLESv2_static.a \
+	-DOPENGL_INCLUDE_DIR=${DEPS_DIR}/include/ANGLE \
+	-DCURL_LIBRARY=${DEPS_DIR}/lib/libcurl.a \
+	-DCURL_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DFREETYPE_LIBRARY=${DEPS_DIR}/lib/libfreetype.a \
+	-DFREETYPE_INCLUDE_DIRS=${DEPS_DIR}/include/freetype2 \
+	-DGETTEXT_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DGETTEXT_LIBRARY=${DEPS_DIR}/lib/libintl.a \
+	-DLUA_LIBRARY=${DEPS_DIR}/lib/libluajit-5.1.a \
+	-DLUA_INCLUDE_DIR=${DEPS_DIR}/include/luajit-2.1 \
+	-DOGG_LIBRARY=${DEPS_DIR}/lib/libogg.a \
+	-DOGG_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DVORBIS_LIBRARY=${DEPS_DIR}/lib/libvorbis.a \
+	-DVORBISFILE_LIBRARY=${DEPS_DIR}/lib/libvorbisfile.a \
+	-DVORBIS_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DZSTD_LIBRARY=${DEPS_DIR}/lib/libzstd.a \
+	-DZSTD_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DGMP_LIBRARY=${DEPS_DIR}/lib/libgmp.a \
+	-DGMP_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DJSON_LIBRARY=${DEPS_DIR}/lib/libjsoncpp.a \
+	-DJSON_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DENABLE_LEVELDB=OFF \
+	-DENABLE_POSTGRESQL=OFF \
+	-DENABLE_REDIS=OFF \
+	-DJPEG_LIBRARY=${DEPS_DIR}/lib/libjpeg.a \
+	-DJPEG_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DPNG_LIBRARY=${DEPS_DIR}/lib/libpng.a \
+	-DPNG_PNG_INCLUDE_DIR=${DEPS_DIR}/include \
+	-DCMAKE_EXE_LINKER_FLAGS="-lbz2 ${DEPS_DIR}/lib/libANGLE_static.a ${DEPS_DIR}/lib/libEGL_static.a" \
+	-DXCODE_CODE_SIGN_ENTITLEMENTS=${REPDIR}/misc/ios/entitlements/release.entitlements \
+	-GXcode
+```
+
+### Build and Run for developing purposes
+
+* Open generated Xcode project
+* Select scheme `luanti`
+* Configure signing Team etc.
+* If building for simulator, select simulator target device
+* Run Build command
+* Run app from Xcode
+
+### Example of automated build from CI
+
+Script [build_ios.sh](util/ci/build_ios.sh) called from [ios.yml](.github/workflows/ios.yml).

--- a/irr/README.md
+++ b/irr/README.md
@@ -31,6 +31,7 @@ We aim to support these platforms:
 * Windows via MinGW
 * Linux (GL or GLES)
 * macOS
+* iOS (ANGLE)
 * Android
 
 This doesn't mean other platforms don't work or won't be supported, if you find something that doesn't work contributions are welcome.

--- a/irr/src/CFileSystem.cpp
+++ b/irr/src/CFileSystem.cpp
@@ -22,7 +22,8 @@
 #include <direct.h> // for _chdir
 #include <io.h>     // for _access
 #include <tchar.h>
-#elif (defined(_IRR_POSIX_API_) || defined(_IRR_OSX_PLATFORM_) || defined(_IRR_ANDROID_PLATFORM_))
+#elif (defined(_IRR_POSIX_API_) || defined(_IRR_OSX_PLATFORM_) || \
+		defined(_IRR_IOS_PLATFORM_) || defined(_IRR_ANDROID_PLATFORM_) )
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1,4 +1,5 @@
 // Copyright (C) 2002-2012 Nikolaus Gebhardt
+// Copyright (C) 2025 Luanti contributors
 // This file is part of the "Irrlicht Engine".
 // For conditions of distribution and use, see copyright notice in irrlicht.h
 
@@ -35,6 +36,13 @@
 #endif
 
 #include "CSDLManager.h"
+
+#ifdef _IRR_COMPILE_WITH_ANGLE_ON_APPLE_
+#include <EGL/egl.h>
+#include <EGL/eglext.h>
+#include <GLES2/gl2.h>
+#include <GLES3/gl3.h>
+#endif
 
 #ifndef _IRR_USE_SDL3_
 	// SDL2 backwards compatibility for things that were renamed in SDL3.
@@ -517,10 +525,29 @@ CIrrDeviceSDL::~CIrrDeviceSDL()
 	for (const auto &p: gamepads)
 		SDL_CloseGamepad(p.second);
 #endif
+#ifndef _IRR_COMPILE_WITH_ANGLE_ON_APPLE_
 	if (Window && Context) {
 		SDL_GL_MakeCurrent(Window, NULL);
 		SDL_GL_DestroyContext(Context);
 	}
+#else
+	if (Display != EGL_NO_DISPLAY) {
+		eglMakeCurrent(Display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	}
+
+	if (Surface != EGL_NO_SURFACE) {
+		eglDestroySurface(Display, Surface);
+	}
+	if (Context != EGL_NO_CONTEXT) {
+		eglDestroyContext(Display, Context);
+	}
+	if (Display != EGL_NO_DISPLAY) {
+		eglTerminate(Display);
+	}
+	if (View) {
+		SDL_Metal_DestroyView(View);
+	}
+#endif
 	if (Window) {
 		SDL_DestroyWindow(Window);
 	}
@@ -637,23 +664,9 @@ bool CIrrDeviceSDL::createWindow()
 	return false;
 }
 
-bool CIrrDeviceSDL::createWindowWithContext()
-{
-	u32 SDL_Flags = 0;
-	SDL_Flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
-
-#ifndef _IRR_USE_SDL3_
-	SDL_Flags |= getFullscreenFlag(CreationParams.Fullscreen);
-#endif
-	if (Resizable)
-		SDL_Flags |= SDL_WINDOW_RESIZABLE;
-	if (CreationParams.WindowMaximized)
-		SDL_Flags |= SDL_WINDOW_MAXIMIZED;
-	SDL_Flags |= SDL_WINDOW_OPENGL;
-
-	SDL_GL_ResetAttributes();
-
 #ifdef _IRR_EMSCRIPTEN_PLATFORM_
+bool CIrrDeviceSDL::createWindowWithContextEmscripten()
+{
 	if (Width != 0 || Height != 0)
 		emscripten_set_canvas_size(Width, Height);
 	else {
@@ -691,7 +704,115 @@ bool CIrrDeviceSDL::createWindowWithContext()
 	emscripten_set_mouseleave_callback("#canvas", (void *)this, false, MouseLeaveCallback);
 
 	return true;
-#else // !_IRR_EMSCRIPTEN_PLATFORM_
+}
+#elif defined(_IRR_COMPILE_WITH_ANGLE_ON_APPLE_)
+bool CIrrDeviceSDL::createWindowWithContextAppleANGLE()
+{
+	u32 SDL_Flags = 0;
+	SDL_Flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
+
+#if not TARGET_OS_IPHONE
+#ifndef _IRR_USE_SDL3_
+	SDL_Flags |= getFullscreenFlag(CreationParams.Fullscreen);
+#endif
+	if (Resizable)
+		SDL_Flags |= SDL_WINDOW_RESIZABLE;
+	if (CreationParams.WindowMaximized)
+		SDL_Flags |= SDL_WINDOW_MAXIMIZED;
+#endif
+	SDL_Flags |= SDL_WINDOW_METAL;
+
+	Window = SDL_CreateWindow("", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, Width, Height, SDL_Flags);
+	if (!Window) {
+		os::Printer::log("Could not create window", SDL_GetError(), ELL_WARNING);
+		return false;
+	}
+
+	auto metal_view = SDL_Metal_CreateView(Window);
+	auto metal_layer = SDL_Metal_GetLayer(metal_view);
+
+	EGLAttrib egl_display_attribs[] = {
+		EGL_PLATFORM_ANGLE_TYPE_ANGLE, EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE,
+		EGL_POWER_PREFERENCE_ANGLE, EGL_HIGH_POWER_ANGLE,
+		EGL_NONE
+	};
+
+	Display = eglGetPlatformDisplay(EGL_PLATFORM_ANGLE_ANGLE, (void*) EGL_DEFAULT_DISPLAY, egl_display_attribs);
+	if (Display == EGL_NO_DISPLAY)
+	{
+		os::Printer::log("Failed to get EGL display");
+		return false;
+	}
+
+	if (eglInitialize(Display, NULL, NULL) == false)
+	{
+		os::Printer::log("Failed to initialize EGL");
+		return false;
+	}
+
+	EGLint egl_config_attribs[] = {
+		EGL_RED_SIZE, (CreationParams.Bits == 16 ? 5 : 8),
+		EGL_GREEN_SIZE, (CreationParams.Bits == 16 ? 5 : 8),
+		EGL_BLUE_SIZE, (CreationParams.Bits == 16 ? 5 : 8),
+		EGL_ALPHA_SIZE, (CreationParams.WithAlphaChannel ? (CreationParams.Bits == 16 ? 1 : 8) : 0),
+		EGL_DEPTH_SIZE, CreationParams.ZBufferBits,
+		EGL_STENCIL_SIZE, CreationParams.Stencilbuffer ? 8 : 0,
+		EGL_SAMPLE_BUFFERS, CreationParams.AntiAlias > 1 ? 1 : 0,
+		EGL_SAMPLES, CreationParams.AntiAlias > 1 ? CreationParams.AntiAlias : 0,
+		EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+		EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT,
+		EGL_NONE
+	};
+
+	EGLConfig config;
+	EGLint configs_count;
+	if (!eglChooseConfig(Display, egl_config_attribs, &config, 1, &configs_count))
+	{
+		os::Printer::log("Failed to choose EGL config");
+		return false;
+	}
+
+	EGLint egl_context_attribs[] = {
+		EGL_CONTEXT_CLIENT_VERSION, 3,
+		EGL_NONE
+	};
+	Context = eglCreateContext(Display, config, EGL_NO_CONTEXT, egl_context_attribs);
+	if (Context == EGL_NO_CONTEXT) {
+		os::Printer::log("Failed to create EGL context");
+		return false;
+	}
+
+	Surface = eglCreateWindowSurface(Display, config, metal_layer, NULL);
+	if (Surface == EGL_NO_SURFACE)
+	{
+		os::Printer::log("Failed to create EGL surface");
+		return false;
+	}
+
+	if (!eglMakeCurrent(Display, Surface, Surface, Context))
+	{
+		os::Printer::log("Failed to make EGL context current");
+		return false;
+	}
+	return true;
+}
+#else
+bool CIrrDeviceSDL::createWindowWithContextSDL()
+{
+	u32 SDL_Flags = 0;
+	SDL_Flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
+
+#ifndef _IRR_USE_SDL3_
+	SDL_Flags |= getFullscreenFlag(CreationParams.Fullscreen);
+#endif
+	if (Resizable)
+		SDL_Flags |= SDL_WINDOW_RESIZABLE;
+	if (CreationParams.WindowMaximized)
+		SDL_Flags |= SDL_WINDOW_MAXIMIZED;
+	SDL_Flags |= SDL_WINDOW_OPENGL;
+
+	SDL_GL_ResetAttributes();
+
 	switch (CreationParams.DriverType) {
 	case video::EDT_OPENGL:
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
@@ -760,6 +881,26 @@ bool CIrrDeviceSDL::createWindowWithContext()
 #ifdef _IRR_USE_SDL3_
 	if (CreationParams.Fullscreen)
 		SDL_SetWindowFullscreen(Window, true);
+#endif
+	return true;
+}
+#endif
+
+bool CIrrDeviceSDL::createWindowWithContext()
+{
+	SDL_GL_ResetAttributes();
+
+#ifdef _IRR_EMSCRIPTEN_PLATFORM_
+	if (!createWindowWithContextEmscripten())
+		return false;
+#else // !_IRR_EMSCRIPTEN_PLATFORM_
+
+#ifndef _IRR_COMPILE_WITH_ANGLE_ON_APPLE_
+	if (!createWindowWithContextSDL())
+		return false;
+#else
+	if (!createWindowWithContextAppleANGLE())
+		return false;
 #endif
 
 	updateSizeAndScale();
@@ -1275,7 +1416,11 @@ float CIrrDeviceSDL::getDisplayDensity() const
 
 void CIrrDeviceSDL::SwapWindow()
 {
+#ifndef _IRR_COMPILE_WITH_ANGLE_ON_APPLE_
 	SDL_GL_SwapWindow(Window);
+#else
+	eglSwapBuffers(Display, Surface);
+#endif
 }
 
 //! pause execution temporarily

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -24,6 +24,10 @@
 #include <SDL.h>
 #endif
 
+#ifdef _IRR_COMPILE_WITH_ANGLE_ON_APPLE_
+#include <EGL/egl.h>
+#endif
+
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -315,13 +319,28 @@ private:
 	void createDriver();
 
 	bool createWindow();
+#ifdef _IRR_EMSCRIPTEN_PLATFORM_
+	bool createWindowWithContextEmscripten();
+#elif defined(_IRR_COMPILE_WITH_ANGLE_ON_APPLE_)
+	bool createWindowWithContextAppleANGLE();
+#else
+	bool createWindowWithContextSDL();
+#endif
 	bool createWindowWithContext();
 
 	void createKeyMap();
 
 	void logAttributes();
-	SDL_GLContext Context;
+
 	SDL_Window *Window;
+#ifndef _IRR_COMPILE_WITH_ANGLE_ON_APPLE_
+	SDL_GLContext Context;
+#else
+	SDL_MetalView View;
+	EGLSurface Surface;
+	EGLContext Context;
+	EGLDisplay Display;
+#endif
 #if defined(_IRR_COMPILE_WITH_JOYSTICK_EVENTS_)
 	std::map<SDL_JoystickID, SDL_Gamepad*> gamepads;
 #ifdef _IRR_USE_SDL3

--- a/irr/src/CMakeLists.txt
+++ b/irr/src/CMakeLists.txt
@@ -4,6 +4,19 @@ include(CheckCXXCompilerFlag)
 
 set(DEFAULT_SDL3 OFF)
 
+if (APPLE)
+	if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+		set(APPLE_MACOS TRUE)
+	elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+		set(APPLE_IOS TRUE)
+		set(DEFAULT_ANGLE ON)
+	else()
+		message(FATAL_ERROR "Unrecognized Apple device: ${CMAKE_SYSTEM_NAME}")
+	endif()
+endif()
+
+option(USE_ANGLE "Use the Google ANGLE EGL and OpenGL ES" ${DEFAULT_ANGLE})
+
 option(USE_SDL2_STATIC "Link with SDL2 static libraries" FALSE)
 
 option(USE_SDL3 "Use the SDL3 backend instead of SDL2" ${DEFAULT_SDL3})
@@ -71,8 +84,10 @@ endif()
 
 if(WIN32)
 	add_compile_definitions(_IRR_WINDOWS_ _IRR_WINDOWS_API_)
-elseif(APPLE)
+elseif(APPLE_MACOS)
 	add_compile_definitions(_IRR_OSX_PLATFORM_)
+elseif(APPLE_IOS)
+	add_compile_definitions(_IRR_IOS_PLATFORM_)
 elseif(ANDROID)
 	add_compile_definitions(_IRR_ANDROID_PLATFORM_)
 elseif(EMSCRIPTEN)
@@ -85,6 +100,14 @@ endif()
 
 add_compile_definitions("_IRR_COMPILE_WITH_SDL_DEVICE_")
 
+if(USE_ANGLE)
+	if(APPLE)
+		add_definitions("-D_IRR_COMPILE_WITH_ANGLE_ON_APPLE_")
+	else()
+		message(FATAL_ERROR "ANGLE is avaliable only for macOS and iOS.")
+	endif()
+endif()
+
 # Joystick
 
 if(NOT (BSD OR SOLARIS OR EMSCRIPTEN))
@@ -93,22 +116,22 @@ endif()
 
 # OpenGL (ES)
 
-if(NOT ANDROID)
+if(NOT ANDROID AND NOT USE_ANGLE)
 	set(DEFAULT_OPENGL3 TRUE)
 endif()
 option(ENABLE_OPENGL3 "Enable OpenGL 3+" ${DEFAULT_OPENGL3})
 
-if(ANDROID OR EMSCRIPTEN)
+if(ANDROID OR EMSCRIPTEN OR USE_ANGLE)
 	set(ENABLE_OPENGL FALSE)
 else()
 	option(ENABLE_OPENGL "Enable legacy OpenGL" TRUE)
 endif()
 
-if(APPLE)
+if(APPLE AND NOT USE_ANGLE)
 	set(ENABLE_GLES2 FALSE)
 	set(ENABLE_WEBGL1 FALSE)
 else()
-	if(ANDROID OR EMSCRIPTEN)
+	if(ANDROID OR EMSCRIPTEN OR USE_ANGLE)
 		set(DEFAULT_GLES2 TRUE)
 	endif()
 	if(EMSCRIPTEN)
@@ -235,7 +258,10 @@ endif()
 
 # Platform-specific libs
 
-if(APPLE)
+if(APPLE_MACOS)
+	find_library(COCOA_LIB Cocoa REQUIRED)
+	find_library(IOKIT_LIB IOKit REQUIRED)
+
 	add_compile_definitions(GL_SILENCE_DEPRECATION)
 endif()
 
@@ -507,8 +533,6 @@ target_link_libraries(IrrlichtMt PRIVATE
 	${ZLIB_LIBRARY}
 	${JPEG_LIBRARY}
 	${PNG_LIBRARY}
-	"$<$<BOOL:${USE_SDL2_SHARED}>:SDL2::SDL2>"
-	"$<$<BOOL:${USE_SDL2_STATIC}>:SDL2::SDL2-static>"
 
 	"$<$<BOOL:${USE_SDL3}>:SDL3::SDL3-${SDL3_SUFFIX}>"
 
@@ -518,6 +542,33 @@ target_link_libraries(IrrlichtMt PRIVATE
 	# incl. transitive SDL2 dependencies for static linking
 	"$<$<PLATFORM_ID:Android>:-landroid -llog -lGLESv2 -lGLESv1_CM -lOpenSLES>"
 )
+
+if(APPLE_IOS)
+	target_link_libraries(IrrlichtMt PRIVATE
+		"-framework UIKit"
+		"-framework Foundation"
+		"-framework CoreGraphics"
+		"-framework QuartzCore"
+		"-framework AudioToolbox"
+		"-framework AVFoundation"
+		"-framework CoreAudio"
+		"-framework CoreMotion"
+		${OPENGLES2_LIBRARY}
+		${SDL2_LIBRARIES}
+	)
+else()
+	target_link_libraries(IrrlichtMt PRIVATE
+		"$<$<BOOL:${USE_SDL2_SHARED}>:SDL2::SDL2>"
+		"$<$<BOOL:${USE_SDL2_STATIC}>:SDL2::SDL2-static>"
+	)
+endif()
+
+if(APPLE AND USE_ANGLE)
+	target_link_libraries(IrrlichtMt PRIVATE
+		"-framework IOSurface"
+		${OPENGLES2_LIBRARY}
+	)
+endif()
 
 if(WIN32)
 	target_compile_definitions(IrrlichtMt INTERFACE _IRR_WINDOWS_API_)

--- a/irr/src/COSOperator.cpp
+++ b/irr/src/COSOperator.cpp
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #ifndef _IRR_ANDROID_PLATFORM_
 #include <sys/types.h>
-#ifdef _IRR_OSX_PLATFORM_
+#if defined(_IRR_OSX_PLATFORM_) || defined(_IRR_IOS_PLATFORM_)
 #include <sys/sysctl.h>
 #endif
 #endif

--- a/irr/src/CSDLManager.cpp
+++ b/irr/src/CSDLManager.cpp
@@ -42,7 +42,11 @@ bool CSDLManager::activateContext(const SExposedVideoData &videoData, bool resto
 
 void *CSDLManager::getProcAddress(const std::string &procName)
 {
+#ifndef _IRR_COMPILE_WITH_ANGLE_ON_APPLE_
 	return (void *)SDL_GL_GetProcAddress(procName.c_str());
+#else
+	return (void *)eglGetProcAddress(procName.c_str());
+#endif
 }
 
 bool CSDLManager::swapBuffers()

--- a/irr/src/OpenGL/Common.h
+++ b/irr/src/OpenGL/Common.h
@@ -7,13 +7,13 @@
 
 #include "irrTypes.h"
 // even though we have mt_opengl.h our driver code still uses GL_* constants
-#if defined(_IRR_COMPILE_WITH_SDL_DEVICE_)
+#if defined(_IRR_COMPILE_WITH_SDL_DEVICE_) && !defined(_IRR_COMPILE_WITH_ANGLE_ON_APPLE_)
 #ifdef _IRR_USE_SDL3_
 	#include <SDL3/SDL_opengl.h>
-#else
+#else // _IRR_USE_SDL3_
 	#include <SDL_video.h>
 	#include <SDL_opengl.h>
-#endif
+#endif // _IRR_USE_SDL3_
 #else
 #include "vendor/gl.h"
 #endif

--- a/lib/sha256/CMakeLists.txt
+++ b/lib/sha256/CMakeLists.txt
@@ -5,7 +5,6 @@ add_library(sha256 STATIC sha256.c my_sha256.h)
 target_include_directories(sha256 INTERFACE .)
 
 INCLUDE(CheckIncludeFiles)
-check_include_files(endian.h HAVE_ENDIAN_H)
 
 configure_file(
 	"${PROJECT_SOURCE_DIR}/cmake_config.h.in"

--- a/lib/sha256/sha256.c
+++ b/lib/sha256/sha256.c
@@ -111,7 +111,7 @@
 #endif
 #endif
 
-#if defined(__APPLE__) && !defined(HAVE_ENDIAN_H)
+#if defined(__APPLE__)
 #include <libkern/OSByteOrder.h>
 #define be16toh(x) OSSwapBigToHostInt16((x))
 #define htobe16(x) OSSwapHostToBigInt16((x))
@@ -119,7 +119,7 @@
 #define be32toh(x) OSSwapBigToHostInt32((x))
 #define htole32(x) OSSwapHostToLittleInt32(x)
 #define htobe32(x) OSSwapHostToBigInt32(x)
-#endif /* __APPLE__ && !HAVE_ENDIAN_H */
+#endif /* __APPLE__ */
 
 #if defined(_WIN32) && !defined(HAVE_ENDIAN_H)
 #include <winsock2.h>

--- a/misc/ios/Info.plist.in
+++ b/misc/ios/Info.plist.in
@@ -23,6 +23,8 @@
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.games</string>
 	<key>NSHighResolutionCapable</key>
+	<false/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 </dict>
 </plist>

--- a/misc/ios/entitlements/release.entitlements
+++ b/misc/ios/entitlements/release.entitlements
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,15 @@
 project(luanti)
 
+if (APPLE)
+	if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+		set(APPLE_MACOS TRUE)
+	elseif(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+		set(APPLE_IOS TRUE)
+	else()
+		message(FATAL_ERROR "Unrecognized Apple device: ${CMAKE_SYSTEM_NAME}")
+	endif()
+endif()
+
 INCLUDE(CheckTypeSize)
 INCLUDE(CheckIncludeFiles)
 INCLUDE(CheckLibraryExists)
@@ -374,8 +384,6 @@ else()
 	set(HAVE_MALLOC_TRIM FALSE)
 endif()
 
-check_include_files(endian.h HAVE_ENDIAN_H)
-
 if((NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR) AND EXISTS "${PROJECT_SOURCE_DIR}/cmake_config.h")
 	message(FATAL_ERROR "You are doing an out-of-tree build, but build artifacts are left in-tree. This will break the build!")
 endif()
@@ -527,6 +535,10 @@ if(ANDROID)
 	list(APPEND common_SRCS porting_android.cpp)
 endif()
 
+if(APPLE_IOS)
+	list(APPEND common_SRCS porting_ios.mm)
+endif()
+
 if(BUILD_UNITTESTS OR BUILD_BENCHMARKS)
 	list(APPEND common_SRCS catch.cpp)
 endif()
@@ -646,10 +658,17 @@ endif()
 
 if(APPLE)
 	# Configure the Info.plist file
-	configure_file(
-		"${CMAKE_SOURCE_DIR}/misc/macos/Info.plist.in"
-		"${CMAKE_BINARY_DIR}/Info.plist"
-	)
+	if(APPLE_MACOS)
+		configure_file(
+			"${CMAKE_SOURCE_DIR}/misc/macos/Info.plist.in"
+			"${CMAKE_BINARY_DIR}/Info.plist"
+		)
+	else()
+		configure_file(
+			"${CMAKE_SOURCE_DIR}/misc/ios/Info.plist.in"
+			"${CMAKE_BINARY_DIR}/Info.plist"
+		)
+	endif()
 endif()
 
 if(BUILD_CLIENT)
@@ -725,6 +744,10 @@ if(BUILD_CLIENT)
 		# on Android, Luanti depends on SDL2 directly
 		# on other platforms, only IrrlichtMt depends on SDL2
 		"$<$<PLATFORM_ID:Android>:${SDL2_LIBRARIES}>"
+		# extra libraries needed on iOS
+		"$<$<PLATFORM_ID:iOS>:-framework Security -framework CoreHaptics -framework CoreBluetooth>"
+		"$<$<PLATFORM_ID:iOS>:-framework GameController -framework Metal -framework Foundation>"
+		"$<$<PLATFORM_ID:iOS>:${OPENGLES2_LIBRARY}>"
 	)
 	target_compile_definitions(${PROJECT_NAME} PRIVATE "MT_BUILDTARGET=1")
 	if(NOT USE_LUAJIT)

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -31,6 +31,7 @@
 #cmakedefine01 USE_REDIS
 #cmakedefine01 USE_OPENSSL
 #cmakedefine01 HAVE_ENDIAN_H
+#cmakedefine01 HAVE_ENDIAN_FUNCS
 #cmakedefine01 HAVE_STRLCPY
 #cmakedefine01 HAVE_MALLOC_TRIM
 #cmakedefine01 CURSES_HAVE_CURSES_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,6 +52,11 @@ extern "C" {
 #endif
 }
 
+// Use SDLmain.a to load, initialize and call SDL_main after on iOS
+#if TARGET_OS_IPHONE
+#include <SDL2/SDL.h>
+#endif
+
 #if !defined(__cpp_rtti) || !defined(__cpp_exceptions)
 #error Luanti cannot be built without exceptions or RTTI
 #endif

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -38,6 +38,7 @@
 	#include <android/api-level.h>
 #endif
 #if defined(__APPLE__)
+	#include <TargetConditionals.h>
 	#include <mach-o/dyld.h>
 	#include <CoreFoundation/CoreFoundation.h>
 	#include <sys/types.h>
@@ -45,6 +46,9 @@
 	// For _NSGetEnviron()
 	// Related: https://gitlab.haskell.org/ghc/ghc/issues/2458
 	#include <crt_externs.h>
+	#if TARGET_OS_IPHONE
+	#include "porting_ios.h"
+	#endif
 #endif
 
 #if defined(__HAIKU__)
@@ -607,6 +611,10 @@ bool setSystemPaths()
 	}
 	CFRelease(resources_url);
 
+	// for iPhoneSimulator, TARGET_OS_IPHONE=1 and TARGET_OS_MAC=1
+#if TARGET_OS_IPHONE
+	path_user = getAppleDocumentsDirectory();
+#elif TARGET_OS_MAC
 	auto user_path_env = getUserPathEnvVar();
 	if (user_path_env) {
 		path_user = std::move(user_path_env.value());
@@ -615,6 +623,9 @@ bool setSystemPaths()
 		path_user = std::string(getHomeOrFail())
 			+ "/Library/Application Support/" "minetest";
 	}
+#else
+	#error "Not supported Apple OS."
+#endif
 	return true;
 }
 
@@ -732,6 +743,8 @@ void initializePaths()
 	sanity_check(!path_cache.empty());
 #  elif defined(_WIN32)
 	path_cache = path_user + DIR_DELIM "cache";
+#  elif TARGET_OS_IOS
+	path_cache = getAppleCacheDirectory();
 #  else
 	// First try $XDG_CACHE_HOME/PROJECT_NAME
 	const char *cache_dir = getenv("XDG_CACHE_HOME");

--- a/src/porting_ios.h
+++ b/src/porting_ios.h
@@ -1,0 +1,14 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 SFENCE <sfence.software@gmail.com>
+
+#include <string>
+
+namespace porting
+{
+
+std::string getAppleDocumentsDirectory();
+std::string getAppleLibraryDirectory();
+std::string getAppleCacheDirectory();
+
+}

--- a/src/porting_ios.mm
+++ b/src/porting_ios.mm
@@ -1,0 +1,41 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 SFENCE <sfence.software@gmail.com>
+
+#include "porting_ios.h"
+
+#import <Foundation/Foundation.h>
+
+namespace porting
+{
+
+std::string getAppleDocumentsDirectory() {
+    @autoreleasepool {
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+        return std::string([[paths firstObject] UTF8String]);
+    }
+}
+
+std::string getAppleLibraryDirectory() {
+    @autoreleasepool {
+        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+        return std::string([[paths firstObject] UTF8String]);
+    }
+}
+
+std::string getAppleCacheDirectory()
+{
+    @autoreleasepool {
+        NSURL *url = [[NSFileManager defaultManager]
+            URLForDirectory:NSCachesDirectory
+            inDomain:NSUserDomainMask
+            appropriateForURL:nil
+            create:YES
+            error:nil];
+
+        return std::string([[url path] UTF8String]);
+    }
+}
+
+// namespace porting
+}

--- a/src/util/serialize.h
+++ b/src/util/serialize.h
@@ -59,7 +59,7 @@ static constexpr float F1000_MAX = (s32)((float)(S32_MAX) / FIXEDPOINT_FACTOR);
 
 extern FloatType g_serialize_f32_type;
 
-#if HAVE_ENDIAN_H
+#if HAVE_ENDIAN_FUNCS
 // use machine native byte swapping routines
 // Note: memcpy below is optimized out by modern compilers
 

--- a/util/ci/build_ios.sh
+++ b/util/ci/build_ios.sh
@@ -1,0 +1,62 @@
+#!/bin/bash -e
+
+sudo xcode-select -s /Applications/Xcode_${xcodever}.app/Contents/Developer
+sdkroot="$(realpath $(xcrun --sdk iphonesimulator --show-sdk-path)/../iPhoneSimulator${osver}.sdk)"
+export CMAKE_PREFIX_PATH=${DEPS_DIR}
+export SDKROOT="$sdkroot"
+
+# common args
+cmake_args=(
+	-DCMAKE_SYSTEM_NAME=iOS
+	-DCMAKE_OSX_DEPLOYMENT_TARGET=$osver
+	-DCMAKE_FIND_FRAMEWORK=LAST
+	-DCMAKE_OSX_ARCHITECTURES=arm64
+	-DCMAKE_INSTALL_PREFIX=../build/ios/
+	-DRUN_IN_PLACE=FALSE
+	-DENABLE_GETTEXT=TRUE
+	-DCMAKE_BUILD_TYPE=Release
+	-DCMAKE_PREFIX_PATH=${DEPS_DIR}
+	-DENABLE_OPENGL=OFF
+	-DENABLE_OPENGL3=OFF
+	-DENABLE_GLES2=ON
+	-DUSE_SDL2_STATIC=ON
+	-DSDL2_DIR=${DEPS_DIR}/lib/cmake/SDL2
+	-DOPENGLES2_LIBRARY=${DEPS_DIR}/lib/libGLESv2_static.a
+	-DOPENGL_INCLUDE_DIR=${DEPS_DIR}/include/ANGLE
+	-DCURL_LIBRARY=${DEPS_DIR}/lib/libcurl.a
+	-DCURL_INCLUDE_DIR=${DEPS_DIR}/include
+	-DFREETYPE_LIBRARY=${DEPS_DIR}/lib/libfreetype.a
+	-DFREETYPE_INCLUDE_DIRS=${DEPS_DIR}/include/freetype2
+	-DGETTEXT_INCLUDE_DIR=${DEPS_DIR}/include
+	-DGETTEXT_LIBRARY=${DEPS_DIR}/lib/libintl.a
+	-DLUA_LIBRARY=${DEPS_DIR}/lib/libluajit-5.1.a
+	-DLUA_INCLUDE_DIR=${DEPS_DIR}/include/luajit-2.1
+	-DOGG_LIBRARY=${DEPS_DIR}/lib/libogg.a
+	-DOGG_INCLUDE_DIR=${DEPS_DIR}/include
+	-DVORBIS_LIBRARY=${DEPS_DIR}/lib/libvorbis.a
+	-DVORBISFILE_LIBRARY=${DEPS_DIR}/lib/libvorbisfile.a
+	-DVORBIS_INCLUDE_DIR=${DEPS_DIR}/include
+	-DZSTD_LIBRARY=${DEPS_DIR}/lib/libzstd.a
+	-DZSTD_INCLUDE_DIR=${DEPS_DIR}/include
+	-DGMP_LIBRARY=${DEPS_DIR}/lib/libgmp.a
+	-DGMP_INCLUDE_DIR=${DEPS_DIR}/include
+	-DJSON_LIBRARY=${DEPS_DIR}/lib/libjsoncpp.a
+	-DJSON_INCLUDE_DIR=${DEPS_DIR}/include
+	-DENABLE_LEVELDB=OFF
+	-DENABLE_POSTGRESQL=OFF
+	-DENABLE_REDIS=OFF
+	-DJPEG_LIBRARY=${DEPS_DIR}/lib/libjpeg.a
+	-DJPEG_INCLUDE_DIR=${DEPS_DIR}/include
+	-DPNG_LIBRARY=${DEPS_DIR}/lib/libpng.a
+	-DPNG_PNG_INCLUDE_DIR=${DEPS_DIR}/include
+	-DCMAKE_EXE_LINKER_FLAGS="-lbz2 ${DEPS_DIR}/lib/libANGLE_static.a ${DEPS_DIR}/lib/libEGL_static.a"
+	-DXCODE_CODE_SIGN_ENTITLEMENTS=${REPDIR}/misc/ios/entitlements/release.entitlements
+	-GXcode
+)
+cmake .. "${cmake_args[@]}"
+
+xcodebuild 	-project luanti.xcodeproj \
+	-target luanti \
+	-configuration Release \
+	-sdk iphonesimulator \
+	build

--- a/util/ci/build_macos.sh
+++ b/util/ci/build_macos.sh
@@ -16,6 +16,7 @@ cmake_args=(
 	-DCMAKE_BUILD_TYPE=${build_type}
 	-DCMAKE_FIND_FRAMEWORK=LAST
 	-DRUN_IN_PLACE=FALSE
+	-DUSE_SDL2_STATIC=TRUE
 	-DENABLE_GETTEXT=TRUE
 	-DJPEG_LIBRARY=${DEPS_DIR}/lib/libjpeg.a
 	-DJPEG_INCLUDE_DIR=${DEPS_DIR}/include
@@ -43,8 +44,18 @@ cmake_args=(
 	-DENABLE_LEVELDB=OFF
 	-DENABLE_POSTGRESQL=OFF
 	-DENABLE_REDIS=OFF
-	-DCMAKE_EXE_LINKER_FLAGS=-lbz2
 )
+if [ "$angle" == "yes" ]; then
+	cmake_args+=(-DENABLE_OPENGL3=OFF)
+	cmake_args+=(-DENABLE_GLES2=ON)
+	cmake_args+=(-DUSE_ANGLE=ON)
+	cmake_args+=(-DENABLE_OPENGL3=OFF)
+	cmake_args+=(-DOPENGLES2_LIBRARY=${DEPS_DIR}/lib/libGLESv2_static.a)
+	cmake_args+=(-DOPENGL_INCLUDE_DIR=${DEPS_DIR}/include/ANGLE)
+	cmake_args+=(-DCMAKE_EXE_LINKER_FLAGS="-lbz2 ${DEPS_DIR}/lib/libANGLE_static.a ${DEPS_DIR}/lib/libEGL_static.a -framework IOSurface")
+else
+	cmake_args+=(-DCMAKE_EXE_LINKER_FLAGS=-lbz2)
+fi
 if [ "$USE_XCODE" == "yes" ]; then
 	cmake_args+=(-GXcode)
 fi

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -82,3 +82,28 @@ install_macos_precompiled_deps() {
 	tar -xf macos${osver}_${arch}_deps.tar.gz
 	cd ~
 }
+
+# iOS build only
+install_ios_deps() {
+	osver=$1
+
+	# Uninstall the bundled cmake, it is outdated, and brew does not want to install the newest version with this one present since they are from different taps.
+	brew uninstall cmake || :
+
+	local pkgs=(
+		cmake gettext wget
+	)
+	export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+	export HOMEBREW_NO_INSTALL_CLEANUP=1
+	# contrary to how it may look --auto-update makes brew do *less*
+	brew update --auto-update
+	brew install --display-times "${pkgs[@]}"
+	brew unlink $(brew ls --formula)
+	brew link "${pkgs[@]}"
+
+	DIR=$(pwd)
+	cd /Users/Shared
+	wget -O ios${osver}_deps.tar.gz https://github.com/luanti-org/luanti_ios_deps/releases/download/latest/ios${osver}_deps.tar.gz
+	tar -xf ios${osver}_deps.tar.gz
+	cd ${DIR}
+}

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -65,6 +65,7 @@ install_macos_brew_deps() {
 install_macos_precompiled_deps() {
 	local osver=$1
 	local arch=$2
+	local angle=$3
 
 	local pkgs=(
 		cmake wget
@@ -77,9 +78,15 @@ install_macos_precompiled_deps() {
 	brew unlink $(brew ls --formula)
 	brew link "${pkgs[@]}"
 
+	if [[ "$angle" == "yes" ]]; then
+		angle="_angle"
+	else
+		angle=""
+	fi
+
 	cd /Users/Shared
-	wget -O macos${osver}_${arch}_deps.tar.gz https://github.com/luanti-org/luanti_macos_deps/releases/download/latest/macos${osver}_${arch}_deps.tar.gz
-	tar -xf macos${osver}_${arch}_deps.tar.gz
+	wget -O macos${osver}_${arch}${angle}_deps.tar.gz https://github.com/luanti-org/luanti_macos_deps/releases/download/latest/macos${osver}_${arch}${angle}_deps.tar.gz
+	tar -xf macos${osver}_${arch}${angle}_deps.tar.gz
 	cd ~
 }
 

--- a/util/ci/run_ios.sh
+++ b/util/ci/run_ios.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+DEVICE_NAME=$1
+TIMEOUT=$2
+
+sudo xcode-select -s /Applications/Xcode_${xcodever}.app/Contents/Developer
+
+xcrun simctl boot "$DEVICE_NAME"
+xcrun simctl install booted build/build/Release-iphonesimulator/luanti.app
+
+# Run the iOS app in the background
+xcrun simctl launch --console booted org.luanti.luanti --run-unittests 2> log.txt &
+APP_PID=$!
+
+# Initialize variables
+CHECK_INTERVAL=15
+ELAPSED_TIME=0
+FOUND_RESULT=false
+
+# Monitor the log file
+while [ $ELAPSED_TIME -lt $TIMEOUT ]; do
+    if grep -q "Unit Test Results:" log.txt; then
+        FOUND_RESULT=true
+        break
+    fi
+    sleep $CHECK_INTERVAL
+    ELAPSED_TIME=$((ELAPSED_TIME + CHECK_INTERVAL))
+done
+
+# Terminate the app
+if $FOUND_RESULT; then
+    echo "Unit test results found. Terminating the app."
+else
+    echo "Timeout reached. Terminating the app."
+fi
+xcrun simctl terminate booted org.luanti.luanti
+xcrun simctl shutdown booted
+


### PR DESCRIPTION
This PR is about adding basic support for compiling with ANGLE as an OpenGL ES translator to Metal. It allows users to use ogles2 driver on macOS and iOS via iPhoneSimulator SDK.

## To do

This PR is a Ready for Review.

## How to test

Download dependencies from https://github.com/luanti-org/luanti_ios_deps/releases/tag/latest and/or https://github.com/luanti-org/luanti_macos_deps/releases/tag/latest.

Generate Xcode project against dependencies and build. You can use or find inspiration in scripts https://github.com/sfence/sfence_luanti_scripts/blob/master/ios/ios_build_with_deps.sh and/or https://github.com/sfence/sfence_luanti_scripts/blob/master/macos/macos_build_with_deps_angle.sh.

Tested with XCode 26.2

Actual state:

Luanti is runnable in iPhoneSimulator. It can connect to the server, install a game and play it.
Some issues are still common.
Luanti is runnable with the ogles2 driver under macOS.

<img width="739" alt="Screenshot 2025-02-22 at 17 11 19" src="https://github.com/user-attachments/assets/b4af5589-3936-4daa-8cf5-ad5ad1e78a9a" />

<img width="1425" alt="Screenshot 2025-02-24 at 17 06 51" src="https://github.com/user-attachments/assets/c7244589-044d-4853-92e0-ac7ff22cee34" />

<img width="915" alt="Screenshot 2025-02-24 at 17 18 57" src="https://github.com/user-attachments/assets/2a6902ae-4ca6-4841-a477-1defabed96ee" />
