### PR TITLE
Reduce the number of GameGlobal shader uniform calculations

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -411,38 +411,25 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 		"exposure_compensation",
 	};
 
-public:
-	void onSettingsChange(const std::string &name)
+	/// Set texture-related shader uniforms
+	void setMaterialConstants(video::IMaterialRendererServices *services)
 	{
-		if (name == "exposure_compensation")
-			m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
+		SamplerLayer_t tex_id;
+		tex_id = 0;
+		m_texture0.set(&tex_id, services);
+		tex_id = 1;
+		m_texture1.set(&tex_id, services);
+		tex_id = 2;
+		m_texture2.set(&tex_id, services);
+		tex_id = 3;
+		m_texture3.set(&tex_id, services);
+
+		m_texel_size0_vertex.set(m_texel_size0, services);
+		m_texel_size0_pixel.set(m_texel_size0, services);
 	}
 
-	static void settingsCallback(const std::string &name, void *userdata)
-	{
-		reinterpret_cast<GameGlobalShaderConstantSetter*>(userdata)->onSettingsChange(name);
-	}
-
-	void setSky(Sky *sky) { m_sky = sky; }
-
-	GameGlobalShaderConstantSetter(Sky *sky, Client *client) :
-		m_sky(sky),
-		m_client(client)
-	{
-		for (auto &name : SETTING_CALLBACKS)
-			g_settings->registerChangedCallback(name, settingsCallback, this);
-
-		m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
-		m_bloom_enabled = g_settings->getBool("enable_bloom");
-		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
-	}
-
-	~GameGlobalShaderConstantSetter()
-	{
-		g_settings->deregisterAllChangedCallbacks(this);
-	}
-
-	void onSetConstants(video::IMaterialRendererServices *services) override
+	/// Set shader uniforms whose values change between frames
+	void setFrameConstants(video::IMaterialRendererServices *services)
 	{
 		u32 daynight_ratio = (float)m_client->getEnv().getDayNightRatio();
 		video::SColorf sunlight;
@@ -470,19 +457,6 @@ public:
 		v3f camera_position = m_client->getCamera()->getPosition();
 		m_camera_position_pixel.set(camera_position, services);
 		m_camera_position_pixel.set(camera_position, services);
-
-		SamplerLayer_t tex_id;
-		tex_id = 0;
-		m_texture0.set(&tex_id, services);
-		tex_id = 1;
-		m_texture1.set(&tex_id, services);
-		tex_id = 2;
-		m_texture2.set(&tex_id, services);
-		tex_id = 3;
-		m_texture3.set(&tex_id, services);
-
-		m_texel_size0_vertex.set(m_texel_size0, services);
-		m_texel_size0_pixel.set(m_texel_size0, services);
 
 		const auto &lighting = m_client->getEnv().getLocalPlayer()->getLighting();
 
@@ -553,6 +527,43 @@ public:
 			float volumetric_light_strength = lighting.volumetric_light_strength;
 			m_volumetric_light_strength_pixel.set(&volumetric_light_strength, services);
 		}
+	}
+
+public:
+	void onSettingsChange(const std::string &name)
+	{
+		if (name == "exposure_compensation")
+			m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
+	}
+
+	static void settingsCallback(const std::string &name, void *userdata)
+	{
+		reinterpret_cast<GameGlobalShaderConstantSetter*>(userdata)->onSettingsChange(name);
+	}
+
+	void setSky(Sky *sky) { m_sky = sky; }
+
+	GameGlobalShaderConstantSetter(Sky *sky, Client *client) :
+		m_sky(sky),
+		m_client(client)
+	{
+		for (auto &name : SETTING_CALLBACKS)
+			g_settings->registerChangedCallback(name, settingsCallback, this);
+
+		m_user_exposure_compensation = g_settings->getFloat("exposure_compensation", -1.0f, 1.0f);
+		m_bloom_enabled = g_settings->getBool("enable_bloom");
+		m_volumetric_light_enabled = g_settings->getBool("enable_volumetric_lighting") && m_bloom_enabled;
+	}
+
+	~GameGlobalShaderConstantSetter()
+	{
+		g_settings->deregisterAllChangedCallbacks(this);
+	}
+
+	void onSetConstants(video::IMaterialRendererServices *services) override
+	{
+		setMaterialConstants(services);
+		setFrameConstants(services);
 	}
 
 	void onSetMaterial(const video::SMaterial &material) override

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -365,6 +365,8 @@ class GameGlobalShaderConstantSetter : public IShaderConstantSetter
 {
 	Sky *m_sky;
 	Client *m_client;
+	// Used to check if the frame or only the material has changed
+	u64 m_frame_time_prev = -1u;
 	CachedVertexShaderSetting<float> m_animation_timer_vertex{"animationTimer"};
 	CachedPixelShaderSetting<float> m_animation_timer_pixel{"animationTimer"};
 	CachedVertexShaderSetting<float>
@@ -563,7 +565,11 @@ public:
 	void onSetConstants(video::IMaterialRendererServices *services) override
 	{
 		setMaterialConstants(services);
-		setFrameConstants(services);
+		u64 frame_time = m_client->getEnv().getFrameTime();
+		if (frame_time != m_frame_time_prev) {
+			m_frame_time_prev = frame_time;
+			setFrameConstants(services);
+		}
 	}
 
 	void onSetMaterial(const video::SMaterial &material) override


### PR DESCRIPTION
Setting shader uniforms is implemented in the onSetConstants() methods of shader constant setters. In every frame, these methods are executed for every shader instance whenever the material changes. Material (texture) changes happen multiple times per frame but most shader uniform values, e.g. camera position and lighting information, change only once per frame.
By omitting the redundant calculations the reader of the code may more easily see which uniforms are texure-dependent.

This PR changes GameGlobalShaderConstantSetter::onSetConstants() such that it sets only texture-dependent uniforms if the frame time is unchanged since the previous call.

I have generated flame graphs with Hotspot to visualise the difference.

master (b6eaf7b5a):
![master whole game loop](https://github.com/user-attachments/assets/7f9b8af1-ec12-4068-9d18-8eff352813a3)
![master](https://github.com/user-attachments/assets/28bdfd70-d5ca-4bf9-b252-d0c7493551c0)

reduced GameGlobal shader uniform calculations:
![gamesetter changed](https://github.com/user-attachments/assets/828e4b8d-c390-4893-9a41-b821e18e60d6)

It shows that `GameGlobalShaderConstantSetter::onSetConstants()` probably takes less time now. I couldn't figure out if it slightly increases the overall rendering performance a bit or not since I don't know how to test it accurately and I don't fully trust estimations about performance changes from flamegraphs. When I've tested it by toggling the behaviour with the fast key, I didn't notice a difference in the number of FPS.

Roadmap goal: 2.1 Rendering/Graphics improvements

## To do

This PR is a Ready for Review.

Using the frame time is a workaround to determine if a new frame is rendered. In my opinion, a cleaner solution would be adding a `new_frame` boolean to the `onSetConstants()` method parameters, but I haven't figured out how to implement this in Irrlicht. 
Other shader constant setters also redundantly calculate shader uniform values; I didn't apply the workaround for them since they don't have a member variable to get the `ClientEnvironment` object.

The long bar for `irr::video::COpenGLSLMaterialRenderer::getVertexShaderConstantID()` for the MainShaderConstantSetter in the flame graphs may indicate that the caching of all shader settings does not work correctly; I haven't investigated this further and it's out of scope for this PR.

## How to test

Read the code and play the game to check that not too few or too many shader uniform changes happen