### PR TITLE
Add a SSCSM controller and environment skeleton

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -53,6 +53,7 @@
 #include "translation.h"
 #include "content/mod_configuration.h"
 #include "mapnode.h"
+#include "script/sscsm/sscsm_controller.h"
 
 extern gui::IGUIEnvironment* guienv;
 
@@ -133,6 +134,8 @@ Client::Client(
 
 	m_cache_save_interval = g_settings->getU16("server_map_save_interval");
 	m_mesh_grid = { g_settings->getU16("client_mesh_chunk") };
+
+	m_sscsm_controller = SSCSMController::create();
 }
 
 void Client::migrateModStorage()
@@ -521,6 +524,8 @@ void Client::step(float dtime)
 		Handle environment
 	*/
 	LocalPlayer *player = m_env.getLocalPlayer();
+
+	m_sscsm_controller->eventOnStep(this, dtime);
 
 	// Step environment (also handles player controls)
 	m_env.step(dtime);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -55,6 +55,8 @@ struct MeshMakeData;
 struct MinimapMapblock;
 struct PlayerControl;
 struct PointedThing;
+class ClientScripting;
+class SSCSMController;
 
 namespace con {
 class IConnection;
@@ -97,8 +99,6 @@ private:
 	// command, count
 	std::map<u16, u32> m_packets;
 };
-
-class ClientScripting;
 
 class Client : public con::PeerHandler, public InventoryManager, public IGameDef
 {
@@ -570,6 +570,9 @@ private:
 	float m_mod_storage_save_timer = 10.0f;
 	std::vector<ModSpec> m_mods;
 	StringMap m_mod_vfs;
+
+	// SSCSM
+	std::unique_ptr<SSCSMController> m_sscsm_controller;
 
 	bool m_shutdown = false;
 

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(common)
 add_subdirectory(cpp_api)
 add_subdirectory(lua_api)
+add_subdirectory(sscsm)
 
 # Used by server and client
 set(common_SCRIPT_SRCS
@@ -19,5 +20,6 @@ set(client_SCRIPT_SRCS
 	${client_SCRIPT_COMMON_SRCS}
 	${client_SCRIPT_CPP_API_SRCS}
 	${client_SCRIPT_LUA_API_SRCS}
+	${client_SCRIPT_SSCSM_SRCS}
 	PARENT_SCOPE)
 

--- a/src/script/sscsm/CMakeLists.txt
+++ b/src/script/sscsm/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(client_SCRIPT_SSCSM_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/sscsm_controller.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/sscsm_environment.cpp
+	PARENT_SCOPE)

--- a/src/script/sscsm/sscsm_controller.cpp
+++ b/src/script/sscsm/sscsm_controller.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "sscsm_controller.h"
+#include "sscsm_environment.h"
+#include "sscsm_requests.h"
+#include "sscsm_events.h"
+#include "sscsm_stupid_channel.h"
+
+std::unique_ptr<SSCSMController> SSCSMController::create()
+{
+	auto channel = std::make_shared<StupidChannel>();
+	auto thread = std::make_unique<SSCSMEnvironment>(channel);
+	thread->start();
+
+	// Wait for thread to finish initializing.
+	auto req0 = deserializeSSCSMRequest(channel->recvB());
+	FATAL_ERROR_IF(!dynamic_cast<SSCSMRequestPollNextEvent *>(req0.get()),
+			"First request must be pollEvent.");
+
+	return std::make_unique<SSCSMController>(std::move(thread), channel);
+}
+
+SSCSMController::SSCSMController(std::unique_ptr<SSCSMEnvironment> thread,
+		std::shared_ptr<StupidChannel> channel) :
+	m_thread(std::move(thread)), m_channel(std::move(channel))
+{
+}
+
+SSCSMController::~SSCSMController()
+{
+	// send tear-down
+	auto answer = SSCSMRequestPollNextEvent::Answer{};
+	answer.next_event = std::make_unique<SSCSMEventTearDown>();
+	m_channel->sendB(serializeSSCSMAnswer(std::move(answer)));
+	// wait for death
+	m_thread->stop();
+	m_thread->wait();
+}
+
+SerializedSSCSMAnswer SSCSMController::handleRequest(Client *client, ISSCSMRequest *req)
+{
+	return req->exec(client);
+}
+
+void SSCSMController::runEvent(Client *client, std::unique_ptr<ISSCSMEvent> event)
+{
+	auto answer0 = SSCSMRequestPollNextEvent::Answer{};
+	answer0.next_event = std::move(event);
+	auto answer = serializeSSCSMAnswer(std::move(answer0));
+
+	while (true) {
+		auto request = deserializeSSCSMRequest(m_channel->exchangeB(std::move(answer)));
+
+		if (dynamic_cast<SSCSMRequestPollNextEvent *>(request.get()) != nullptr) {
+			break;
+		}
+
+		answer = handleRequest(client, request.get());
+	}
+}
+
+void SSCSMController::eventOnStep(Client *client, f32 dtime)
+{
+	auto event = std::make_unique<SSCSMEventOnStep>();
+	event->dtime = dtime;
+	runEvent(client, std::move(event));
+}

--- a/src/script/sscsm/sscsm_controller.h
+++ b/src/script/sscsm/sscsm_controller.h
@@ -13,6 +13,14 @@
 class SSCSMEnvironment;
 class StupidChannel;
 
+/**
+ * The purpose of this class is to:
+ * * Be the RAII owner of the SSCSM process.
+ * * Send events to SSCSM process, and process requests. (`runEvent`)
+ * * Hide details (e.g. that it is a separate process, or that it has to do IPC calls).
+ *
+ * See also SSCSMEnvironment for other side.
+ */
 class SSCSMController
 {
 	std::unique_ptr<SSCSMEnvironment> m_thread;

--- a/src/script/sscsm/sscsm_controller.h
+++ b/src/script/sscsm/sscsm_controller.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include "irrlichttypes.h"
+#include "sscsm_irequest.h"
+#include "sscsm_ievent.h"
+#include "util/basic_macros.h"
+
+class SSCSMEnvironment;
+class StupidChannel;
+
+class SSCSMController
+{
+	std::unique_ptr<SSCSMEnvironment> m_thread;
+	std::shared_ptr<StupidChannel> m_channel;
+
+	SerializedSSCSMAnswer handleRequest(Client *client, ISSCSMRequest *req);
+
+public:
+	static std::unique_ptr<SSCSMController> create();
+
+	SSCSMController(std::unique_ptr<SSCSMEnvironment> thread,
+			std::shared_ptr<StupidChannel> channel);
+
+	~SSCSMController();
+
+	DISABLE_CLASS_COPY(SSCSMController);
+
+	// Handles requests until the next event is polled
+	void runEvent(Client *client, std::unique_ptr<ISSCSMEvent> event);
+
+	void eventOnStep(Client *client, f32 dtime);
+};

--- a/src/script/sscsm/sscsm_environment.cpp
+++ b/src/script/sscsm/sscsm_environment.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "sscsm_environment.h"
+#include "sscsm_requests.h"
+#include "sscsm_events.h"
+#include "sscsm_stupid_channel.h"
+
+
+void *SSCSMEnvironment::run()
+{
+	while (true) {
+		auto next_event = requestPollNextEvent();
+
+		if (dynamic_cast<SSCSMEventTearDown *>(next_event.get())) {
+			break;
+		}
+
+		next_event->exec(this);
+	}
+
+	return nullptr;
+}
+
+SerializedSSCSMAnswer SSCSMEnvironment::exchange(SerializedSSCSMRequest req)
+{
+	return m_channel->exchangeA(std::move(req));
+}
+
+std::unique_ptr<ISSCSMEvent> SSCSMEnvironment::requestPollNextEvent()
+{
+	auto request = SSCSMRequestPollNextEvent{};
+	auto answer = deserializeSSCSMAnswer<SSCSMRequestPollNextEvent::Answer>(
+			exchange(serializeSSCSMRequest(request))
+		);
+	return std::move(answer.next_event);
+}
+
+MapNode SSCSMEnvironment::requestGetNode(v3s16 pos)
+{
+	auto request = SSCSMRequestGetNode{};
+	request.pos = pos;
+	auto answer = deserializeSSCSMAnswer<SSCSMRequestGetNode::Answer>(
+			exchange(serializeSSCSMRequest(request))
+		);
+	return answer.node;
+}

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include "client/client.h"
+#include "threading/thread.h"
+#include "sscsm_controller.h"
+#include "sscsm_irequest.h"
+
+// The thread that runs SSCSM code.
+// Meant to be replaced by a sandboxed process.
+class SSCSMEnvironment : public Thread
+{
+	std::shared_ptr<StupidChannel> m_channel;
+
+	void *run() override;
+
+	SerializedSSCSMAnswer exchange(SerializedSSCSMRequest req);
+
+public:
+	SSCSMEnvironment(std::shared_ptr<StupidChannel> channel) :
+		Thread("SSCSMEnvironment-thread"),
+		m_channel(std::move(channel))
+	{
+	}
+
+	std::unique_ptr<ISSCSMEvent> requestPollNextEvent();
+	MapNode requestGetNode(v3s16 pos);
+};

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -10,8 +10,14 @@
 #include "sscsm_controller.h"
 #include "sscsm_irequest.h"
 
-// The thread that runs SSCSM code.
-// Meant to be replaced by a sandboxed process.
+/** The thread that runs SSCSM code.
+ *
+ * Meant to be replaced by a sandboxed process.
+ *
+ * RAII-owns and abstracts away resources to communicate to the main process / thread.
+ *
+ * See also SSCSMController for other side.
+ */
 class SSCSMEnvironment : public Thread
 {
 	std::shared_ptr<StupidChannel> m_channel;

--- a/src/script/sscsm/sscsm_events.h
+++ b/src/script/sscsm/sscsm_events.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "sscsm_ievent.h"
+#include "debug.h"
+#include "irrlichttypes.h"
+#include "irr_v3d.h"
+#include "sscsm_environment.h"
+#include "mapnode.h"
+
+struct SSCSMEventTearDown : public ISSCSMEvent
+{
+	void exec(SSCSMEnvironment *env) override
+	{
+		FATAL_ERROR("SSCSMEventTearDown needs to be handled by SSCSMEnvironment::run()");
+	}
+};
+
+struct SSCSMEventOnStep final : public ISSCSMEvent
+{
+	f32 dtime;
+
+	void exec(SSCSMEnvironment *env) override
+	{
+		// example
+		env->requestGetNode(v3s16(0, 0, 0));
+	}
+};
+

--- a/src/script/sscsm/sscsm_ievent.h
+++ b/src/script/sscsm/sscsm_ievent.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+class SSCSMEnvironment;
+
+// Event triggered from the main env for the SSCSM env.
+struct ISSCSMEvent
+{
+	virtual ~ISSCSMEvent() = default;
+
+	// Note: No return value (difference to ISSCSMRequest). These are not callbacks
+	// that you can run at arbitrary locations, because the untrusted code could
+	// then clobber your local variables.
+	virtual void exec(SSCSMEnvironment *cntrl) = 0;
+};
+
+// FIXME: actually serialize, and replace this with a string
+using SerializedSSCSMEvent = std::unique_ptr<ISSCSMEvent>;
+
+template <typename T>
+inline SerializedSSCSMEvent serializeSSCSMEvent(const T &event)
+{
+	static_assert(std::is_base_of_v<ISSCSMEvent, T>);
+
+	return std::make_unique<T>(event);
+}
+
+inline std::unique_ptr<ISSCSMEvent> deserializeSSCSMEvent(SerializedSSCSMEvent event_serialized)
+{
+	// The actual deserialization will have to use a type tag, and then choose
+	// the appropriate deserializer.
+	return event_serialized;
+}

--- a/src/script/sscsm/sscsm_irequest.h
+++ b/src/script/sscsm/sscsm_irequest.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "exceptions.h"
+#include <memory>
+#include <type_traits>
+
+class SSCSMController;
+class Client;
+
+struct ISSCSMAnswer
+{
+	virtual ~ISSCSMAnswer() = default;
+};
+
+// FIXME: actually serialize, and replace this with a string
+using SerializedSSCSMAnswer = std::unique_ptr<ISSCSMAnswer>;
+
+// Request made by the sscsm env to the main env.
+struct ISSCSMRequest
+{
+	virtual ~ISSCSMRequest() = default;
+
+	virtual SerializedSSCSMAnswer exec(Client *client) = 0;
+};
+
+// FIXME: actually serialize, and replace this with a string
+using SerializedSSCSMRequest = std::unique_ptr<ISSCSMRequest>;
+
+template <typename T>
+inline SerializedSSCSMRequest serializeSSCSMRequest(const T &request)
+{
+	static_assert(std::is_base_of_v<ISSCSMRequest, T>);
+
+	return std::make_unique<T>(request);
+}
+
+template <typename T>
+inline T deserializeSSCSMAnswer(SerializedSSCSMAnswer answer_serialized)
+{
+	static_assert(std::is_base_of_v<ISSCSMAnswer, T>);
+
+	// dynamic cast in place of actual deserialization
+	auto ptr = dynamic_cast<T *>(answer_serialized.get());
+	if (!ptr) {
+		throw SerializationError("deserializeSSCSMAnswer failed");
+	}
+	return std::move(*ptr);
+}
+
+template <typename T>
+inline SerializedSSCSMAnswer serializeSSCSMAnswer(T &&answer)
+{
+	static_assert(std::is_base_of_v<ISSCSMAnswer, T>);
+
+	return std::make_unique<T>(std::move(answer));
+}
+
+inline std::unique_ptr<ISSCSMRequest> deserializeSSCSMRequest(SerializedSSCSMRequest request_serialized)
+{
+	// The actual deserialization will have to use a type tag, and then choose
+	// the appropriate deserializer.
+	return request_serialized;
+}

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "sscsm_irequest.h"
+#include "sscsm_ievent.h"
+#include "mapnode.h"
+#include "map.h"
+#include "client/client.h"
+
+struct SSCSMRequestPollNextEvent : public ISSCSMRequest
+{
+	struct Answer : public ISSCSMAnswer
+	{
+		std::unique_ptr<ISSCSMEvent> next_event;
+	};
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		FATAL_ERROR("SSCSMRequestPollNextEvent needs to be handled by SSCSMControler::runEvent()");
+	}
+};
+
+struct SSCSMRequestGetNode : public ISSCSMRequest
+{
+	struct Answer : public ISSCSMAnswer
+	{
+		MapNode node;
+	};
+
+	v3s16 pos;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		MapNode node = client->getEnv().getMap().getNode(pos);
+
+		Answer answer{};
+		answer.node = node;
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};

--- a/src/script/sscsm/sscsm_stupid_channel.h
+++ b/src/script/sscsm/sscsm_stupid_channel.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <condition_variable>
+#include "sscsm_irequest.h"
+
+// FIXME: replace this with an ipc channel
+class StupidChannel
+{
+	std::mutex m_mutex;
+	std::condition_variable m_condvar;
+	SerializedSSCSMRequest m_request;
+	SerializedSSCSMAnswer m_answer;
+
+public:
+	void sendA(SerializedSSCSMRequest request)
+	{
+		{
+			auto lock = std::lock_guard(m_mutex);
+
+			m_request = std::move(request);
+		}
+
+		m_condvar.notify_one();
+	}
+
+	SerializedSSCSMAnswer recvA()
+	{
+		auto lock = std::unique_lock(m_mutex);
+
+		while (!m_answer) {
+			m_condvar.wait(lock);
+		}
+
+		auto answer = std::move(m_answer);
+		m_answer = nullptr;
+
+		return answer;
+	}
+
+	SerializedSSCSMAnswer exchangeA(SerializedSSCSMRequest request)
+	{
+		sendA(std::move(request));
+
+		return recvA();
+	}
+
+	void sendB(SerializedSSCSMAnswer answer)
+	{
+		{
+			auto lock = std::lock_guard(m_mutex);
+
+			m_answer = std::move(answer);
+		}
+
+		m_condvar.notify_one();
+	}
+
+	SerializedSSCSMRequest recvB()
+	{
+		auto lock = std::unique_lock(m_mutex);
+
+		while (!m_request) {
+			m_condvar.wait(lock);
+		}
+
+		auto request = std::move(m_request);
+		m_request = nullptr;
+
+		return request;
+	}
+
+	SerializedSSCSMRequest exchangeB(SerializedSSCSMAnswer answer)
+	{
+		sendB(std::move(answer));
+
+		return recvB();
+	}
+};


### PR DESCRIPTION
A small step towards SSCSM.

### Overview

SSCSMs run in a separate `SSCSMEnvironment` thread, so we get the same control flow as later with a sandboxed process.
The client interacts with it via the `SSCSMController`.

**Terminology:**
* Request: A sort of API call from the SSCSM thread to the main thread.
* Answer: The return value of this call.
* Event: Something offered from the main thread to the SSCSM thread. (Has no return value, see also note below.)

### Details

From the SSCSM thread's perspective, it always processes events from the main thread. To get the next event, it does a request to pull the next event. => It's a pull-style API, events are just a special case of answer.

If the main thread wants to trigger an event, it "returns" the event ("return", because the SSCSM thread is currently in a state where it waits for the next event), and then handles requests until the next event is requested (which marks the end of this event's handling).

**Note:** Events are not meant to be triggered from arbitrary places. When you trigger an event, you have to handle all the requests, which may be arbitrary, because they come from untrusted code. So if you have local state (e.g. a pointer to a node meta), it will be invalidated. (Triggering an event from within a request handling code also doesn't work at all, because the SSCSM is not in the state where it waits for the next event.)
Hence, triggering an even from deep within a function is inherently unsafe. It should be safe to trigger events from `step()` and from client packet handlers. (If you need to, I guess you can delay an event trigger to the next step, i.e. as an asynchronous event.)
This restriction is an important part of SSCSM security, because if we only trigger events from such places, handling SSCSM API calls is pretty much as secure as handling network packages (assuming a working sandbox).


### Quick guide

To add a new event (e.g. `on_chat_message`):
* Add a struct `SSCSMEventOnChatMessage` in `sscsm_events.h`.
* PCall the lua function in this struct's `exec()` member function.
* In the future: Add de-/serialization functions for this struct. (Can look as simple as [this](https://github.com/Desour/minetest/blob/bd8ed931038ee336289fb5c013ab9faadb118a40/src/unittest/test_sscsm_ipc_serialization.cpp#L88-L93).)
* ~~Add a `SSCSMController::eventOnChatMessage()` member function. (Could maybe remove this part, and instead call `runEvent()` directly.)~~
* ~~Call this function.~~ Call `runEvent()` with client and an event.

To add a new request (e.g. `core.get_timeofday()`):
* Add a struct `SSCSMRequestGetTimeOfDay` in `sscsm_requests.h`, as well as a ~~`SSCSMAnswerGetTimeOfDay`~~ `SSCSMRequestGetTimeOfDay::Answer`.
* In the struct's `exec()` member function, get do the stuff you want to do with this request, and return the result in the answer.
* In the future: Add de-/serialization functions for these structs.
* ~~Add a `SSCSMEnvironment::getTimeOfDay()` member function.~~
* Add a `l_get_time_of_day`, where you can now ~~call this function~~ call `doRequest()` with a `SSCSMRequestGetTimeOfDay`.

### What comes next?

As next steps I suggest (concurrently):
* Replace the dynamic cast stuff with serialization (see turkeymcmac's PR). (And after that, use the IPC channel from my PR. (And then replace the thread with a process. (And then do the process sandbox.)))
  * I have something here: https://github.com/Desour/minetest/tree/sscsm_serialize
  * #13046 also has serialization (see `src/util/struct_serialize.h`), but I found it weird how it did the template specialization with `enable_if`. Also I wanted to try out an idea how to get fewer size checks, and semi-automatic serializer generation. c:
* Load client-provided builtin code.
  (E.g. add an event for adding a file to a virtual filesystem (hashtable virtual path to file data), and an event to then load mods.)
  * #15818

## To do

This PR is a Ready for Review.

Edit: I have to cherry pick some little changes from #15818, or drop this in-between step. So TODO.

## How to test

* Start a game and exit.
