### PR TITLE
Implement secondary keybindings

### DIFF
--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -42,7 +42,7 @@ struct KeyCache
 	// Keys that are not settings dependent
 	void populate_nonchanging();
 
-	KeyPress key[KeyType::INTERNAL_ENUM_COUNT];
+	std::vector<KeyPress> key[KeyType::INTERNAL_ENUM_COUNT];
 	InputHandler *handler;
 };
 
@@ -117,6 +117,14 @@ public:
 	}
 
 	bool operator[](const KeyPress &key) const { return find(key) != end(); }
+
+	bool operator[](const std::vector<KeyPress> &keylist) const
+	{
+		for (const auto &key: keylist)
+			if (find(key) != end())
+				return true;
+		return false;
+	}
 };
 
 class MyEventReceiver : public IEventReceiver
@@ -126,23 +134,28 @@ public:
 	virtual bool OnEvent(const SEvent &event);
 
 	bool IsKeyDown(const KeyPress &keyCode) const { return keyIsDown[keyCode]; }
+	bool IsKeyDown(const std::vector<KeyPress> &keyCode) const { return keyIsDown[keyCode]; }
 
 	// Checks whether a key was down and resets the state
-	bool WasKeyDown(const KeyPress &keyCode)
+	bool WasKeyDown(const std::vector<KeyPress> &keylist)
 	{
-		bool b = keyWasDown[keyCode];
-		if (b)
-			keyWasDown.unset(keyCode);
+		bool b = false;
+		for (const auto &key: keylist) {
+			if (keyWasDown[key]) {
+				b = true;
+				keyWasDown.unset(key);
+			}
+		}
 		return b;
 	}
 
 	// Checks whether a key was just pressed. State will be cleared
 	// in the subsequent iteration of Game::processPlayerInteraction
-	bool WasKeyPressed(const KeyPress &keycode) const { return keyWasPressed[keycode]; }
+	bool WasKeyPressed(const std::vector<KeyPress> &keycode) const { return keyWasPressed[keycode]; }
 
 	// Checks whether a key was just released. State will be cleared
 	// in the subsequent iteration of Game::processPlayerInteraction
-	bool WasKeyReleased(const KeyPress &keycode) const { return keyWasReleased[keycode]; }
+	bool WasKeyReleased(const std::vector<KeyPress> &keycode) const { return keyWasReleased[keycode]; }
 
 	void listenForKey(const KeyPress &keyCode)
 	{
@@ -359,7 +372,7 @@ public:
 		return true;
 	}
 
-	virtual bool isKeyDown(GameKeyType k) { return keydown[keycache.key[k]]; }
+	virtual bool isKeyDown(GameKeyType k) { return keydown[k]; }
 	virtual bool wasKeyDown(GameKeyType k) { return false; }
 	virtual bool wasKeyPressed(GameKeyType k) { return false; }
 	virtual bool wasKeyReleased(GameKeyType k) { return false; }
@@ -376,7 +389,7 @@ public:
 	s32 Rand(s32 min, s32 max);
 
 private:
-	KeyList keydown;
+	std::bitset<KeyType::INTERNAL_ENUM_COUNT> keydown;
 	v2s32 mousepos;
 	v2s32 mousespeed;
 	float joystickSpeed;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -9,6 +9,7 @@
 #include <Keycodes.h>
 #include <IEventReceiver.h>
 #include <string>
+#include <vector>
 
 class UnknownKeycode : public BaseException
 {
@@ -57,7 +58,8 @@ extern const KeyPress MMBKey; // Middle Mouse Button
 extern const KeyPress RMBKey;
 
 // Key configuration getter
-const KeyPress &getKeySetting(const char *settingname);
+const std::vector<KeyPress> &getKeySetting(const std::string &settingname);
+bool inKeySetting(const std::string &settingname, const KeyPress &kp);
 
 // Clear fast lookup cache
 void clearKeyCache();

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -415,7 +415,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		}
 
 		// Key input
-		if (KeyPress(event.KeyInput) == getKeySetting("keymap_console")) {
+		if (inKeySetting("keymap_console", event.KeyInput)) {
 			closeConsole();
 
 			// inhibit open so the_game doesn't reopen immediately

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3953,7 +3953,7 @@ bool GUIFormSpecMenu::preprocessEvent(const SEvent& event)
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 			KeyPress kp(event.KeyInput);
 		if (kp == EscapeKey
-				|| kp == getKeySetting("keymap_inventory")
+				|| inKeySetting("keymap_inventory", kp)
 				|| event.KeyInput.Key==KEY_RETURN) {
 			gui::IGUIElement *focused = Environment->getFocus();
 			if (focused && isMyChild(focused) &&
@@ -4020,17 +4020,17 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		KeyPress kp(event.KeyInput);
 		if (event.KeyInput.PressedDown && (
 				(kp == EscapeKey) ||
-				((m_client != NULL) && (kp == getKeySetting("keymap_inventory"))))) {
+				((m_client != NULL) && (inKeySetting("keymap_inventory", kp))))) {
 			tryClose();
 			return true;
 		}
 
 		if (m_client != NULL && event.KeyInput.PressedDown &&
-				(kp == getKeySetting("keymap_screenshot"))) {
+				(inKeySetting("keymap_screenshot", kp))) {
 			m_client->makeScreenshot();
 		}
 
-		if (event.KeyInput.PressedDown && kp == getKeySetting("keymap_toggle_debug")) {
+		if (event.KeyInput.PressedDown && inKeySetting("keymap_toggle_debug", kp)) {
 			if (!m_client || m_client->checkPrivilege("debug"))
 				m_show_debug = !m_show_debug;
 		}

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -359,7 +359,8 @@ void GUIKeyChangeMenu::add_key(int id, std::wstring button_name, const std::stri
 
 	k->button_name = std::move(button_name);
 	k->setting_name = setting_name;
-	k->key = getKeySetting(k->setting_name.c_str());
+	if (const auto &keylist = getKeySetting(k->setting_name.c_str()); keylist.size() > 0)
+		k->key = keylist.front();
 	key_settings.push_back(k);
 }
 


### PR DESCRIPTION
This PR allows players to define secondary keybindings, e.g. using left or right shift for sneaking in the SDL build.

This PR depends on #15152.
Note that this PR had some minor conflicts with #14964. IMO we should merge that PR first and then this one.

- Goal of the PR
  Allow defining secondary keybindings (see description above).
- How does the PR work?
  - Key settings are represented `std::vector<KeyPress>`. This allows keeping an order for keypresses (e.g. when saving the settings); it should not be problematic in terms of performance as the list of keybindings for a single setting will likely be very short (containing at most 2 entries) in most real-world cases.
  - Each entry in the string representation is delimited by the `|` character. It is not possible to escape `|`. This keep things simple at the cost of not allowing the `|` key in a key list if the key cannot be represented with a `EKEY_CODE`, but it should not be problematic as #14964 implements a new keycode syntax that is used by default (and does not involve the `|` character). Note that a special case is created if the setting string includes _only_ the `|` character, in which case it is parsed as a key instead of a list of keys.
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/minetest/minetest/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  https://github.com/minetest/minetest/pull/14964#issuecomment-2335180342

## To do
This PR is a Work in Progress.

- [x] Implement handling secondary keybindings
- [ ] Update keybinding GUI. (Waiting for #15791)

## How to test
Change a key setting to have the form of (e.g.) `KEY_KEY_Z|KEY_KEY_Y` and observe that pressing (in this case) the `Z` or `Y` key performs the relevant action. Note that it is currently not possible to specify secondary keybindings in the "Controls" form/GUI (see To-Do).