### PR TITLE
Re-save active entities more often if they move a certain distance

### DIFF
--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -43,6 +43,8 @@
 // A number that is much smaller than the timeout for particle spawners should/could ever be
 #define PARTICLE_SPAWNER_NO_EXPIRY -1024.f
 
+#define ACTIVE_OBJECT_RESAVE_DISTANCE_SQ 2 * 2
+
 /*
 	ABMWithState
 */
@@ -2160,15 +2162,14 @@ void ServerEnvironment::deactivateFarObjects(const bool _force_delete)
 		// The block in which the object resides in
 		v3s16 blockpos_o = getNodeBlockPos(floatToInt(objectpos, BS));
 
-		// If object's static data is stored in a deactivated block and object
-		// is actually located in an active block, or if the object is actually located
-		// in an active block which is not neighboring to the block in which
-		// the object's static data is stored (there is at least one block between
-		// them), re-save to the block in which the object is actually located in.
+		// If object's static data is stored in a deactivated block or it has moved a bunch
+		// then re-save to the block in which the object is now located in.
+		// This only applies if the object is in a currently active block, since deactivating
+		// is handled by the code further below.
 		if (!force_delete && obj->isStaticAllowed() && obj->m_static_exists &&
 		   m_active_blocks.contains(blockpos_o) &&
 		   (!m_active_blocks.contains(obj->m_static_block) ||
-		   blockpos_o.getDistanceFromSQ(obj->m_static_block) >= 2 * 2)) {
+		   blockpos_o.getDistanceFromSQ(obj->m_static_block) >= ACTIVE_OBJECT_RESAVE_DISTANCE_SQ)) {
 
 			// Delete from block where object was located
 			deleteStaticFromBlock(obj, id, MOD_REASON_STATIC_DATA_REMOVED, false);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -43,7 +43,7 @@
 // A number that is much smaller than the timeout for particle spawners should/could ever be
 #define PARTICLE_SPAWNER_NO_EXPIRY -1024.f
 
-#define ACTIVE_OBJECT_RESAVE_DISTANCE_SQ 2 * 2
+static constexpr s16 ACTIVE_OBJECT_RESAVE_DISTANCE_SQ = 3 * 3;
 
 /*
 	ABMWithState

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2167,7 +2167,7 @@ void ServerEnvironment::deactivateFarObjects(const bool _force_delete)
 		if (!force_delete && obj->isStaticAllowed() && obj->m_static_exists &&
 		   m_active_blocks.contains(blockpos_o) &&
 		   (!m_active_blocks.contains(obj->m_static_block) ||
-		   blockpos_o.getDistanceFromSQ(obj->m_static_block) >= MAP_BLOCKSIZE * MAP_BLOCKSIZE)) {
+		   blockpos_o.getDistanceFromSQ(obj->m_static_block) >= 2 * 2)) {
 
 			// Delete from block where object was located
 			deleteStaticFromBlock(obj, id, MOD_REASON_STATIC_DATA_REMOVED, false);

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2161,9 +2161,10 @@ void ServerEnvironment::deactivateFarObjects(const bool _force_delete)
 		v3s16 blockpos_o = getNodeBlockPos(floatToInt(objectpos, BS));
 
 		// If object's static data is stored in a deactivated block and object
-		// is actually located in an active block, or the distance between stored
-		// and actual location of the object, re-save to the block in which
-		// the object is actually located in.
+		// is actually located in an active block, or if the object is actually located
+		// in an active block which is not neighboring to the block in which
+		// the object's static data is stored (there is at least one block between
+		// them), re-save to the block in which the object is actually located in.
 		if (!force_delete && obj->isStaticAllowed() && obj->m_static_exists &&
 		   m_active_blocks.contains(blockpos_o) &&
 		   (!m_active_blocks.contains(obj->m_static_block) ||

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -2161,11 +2161,13 @@ void ServerEnvironment::deactivateFarObjects(const bool _force_delete)
 		v3s16 blockpos_o = getNodeBlockPos(floatToInt(objectpos, BS));
 
 		// If object's static data is stored in a deactivated block and object
-		// is actually located in an active block, re-save to the block in
-		// which the object is actually located in.
+		// is actually located in an active block, or the distance between stored
+		// and actual location of the object, re-save to the block in which
+		// the object is actually located in.
 		if (!force_delete && obj->isStaticAllowed() && obj->m_static_exists &&
-		   !m_active_blocks.contains(obj->m_static_block) &&
-		   m_active_blocks.contains(blockpos_o)) {
+		   m_active_blocks.contains(blockpos_o) &&
+		   (!m_active_blocks.contains(obj->m_static_block) ||
+		   blockpos_o.getDistanceFromSQ(obj->m_static_block) >= MAP_BLOCKSIZE * MAP_BLOCKSIZE)) {
 
 			// Delete from block where object was located
 			deleteStaticFromBlock(obj, id, MOD_REASON_STATIC_DATA_REMOVED, false);


### PR DESCRIPTION
This patch should fix a bug when location in the database might be not updated in case of server crash, if the location in the database belongs to a block which wasn't unloaded up until the crash. The bug was fixed by adding a check of the distance between the two locations, and updating the data in case if it reached some threshold (`MAP_BLOCKSIZE` was used but it could be reconsidered.

## To do

This PR is Ready for Review.

## How to test

- Create a server with the `paleotest` mod installed (https://content.luanti.org/packages/ElCeejo/paleotest/)
- Run the server in the multiplayer mode, log in as two separate players
- One player places "Spawn Quetzatcoatlus" very close to the second one, it should spawn an adult Quetzalcoatlus
- The first player mounts the Quetzalcoatlus by right-clicking it with "Whip", and flies away ("Space" to ascend, "S" to descend, mouse to turn). The second player should remain in the same place to keep the area loaded
- The first players flies away on a large distance (I tested with the distance of 2000 blocks but in theory it could be even two opposite ends of the world)
- The server is killed with `SIGKILL` (`pkill -9 luanti`)

With this patch, after next log in the position of the mob should be near the position of the first player (as expected by users). Without this patch, the mob will be at the place where it was initially spawned, i.e. near the second player.
Remark: the latest version of the mod is buggy, and the mob might die for no reason during descend, but in other aspects it seems to work OK, and it's one of the easiest way to test the scenario I'm aware of.