### PR TITLE
[no squash] CAO 'node' visual

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1522,7 +1522,7 @@ There are a bunch of different looking node types.
 * `allfaces`
     * Often used for partially-transparent nodes.
     * External sides of textures, and unlike other drawtypes, the external sides
-      of other blocks, are visible from the inside.
+      of other nodes, are visible from the inside.
 * `allfaces_optional`
     * Often used for leaves nodes.
     * This switches between `normal`, `glasslike` and `allfaces` according to
@@ -9229,7 +9229,7 @@ Player properties need to be saved manually.
     -- Clients older than 5.9.0 interpret `pointable = "blocking"` as `pointable = true`.
     -- Can be overridden by the `pointabilities` of the held item.
 
-    visual = "cube" / "sprite" / "upright_sprite" / "mesh" / "wielditem" / "item",
+    visual = "",
     -- "cube" is a node-sized cube.
     -- "sprite" is a flat texture always facing the player.
     -- "upright_sprite" is a vertical flat texture.
@@ -9251,6 +9251,8 @@ Player properties need to be saved manually.
     --   Wielditems are scaled a bit. If you want a wielditem to appear
     --   to be as large as a node, use `0.667` in `visual_size`
     -- "item" is similar to "wielditem" but ignores the 'wield_image' parameter.
+    -- "node" looks exactly like a node in-world (supported since 5.12.0)
+    --   Note that visual effects like waving or liquid reflections will not work.
 
     visual_size = {x = 1, y = 1, z = 1},
     -- Multipliers for the visual size. If `z` is not specified, `x` will be used
@@ -9260,7 +9262,7 @@ Player properties need to be saved manually.
     -- File name of mesh when using "mesh" visual
 
     textures = {},
-    -- Number of required textures depends on visual.
+    -- Number of required textures depends on visual:
     -- "cube" uses 6 textures just like a node, but all 6 must be defined.
     -- "sprite" uses 1 texture.
     -- "upright_sprite" uses 2 textures: {front, back}.
@@ -9270,11 +9272,14 @@ Player properties need to be saved manually.
     colors = {},
     -- Currently unused.
 
+    node = {name = "ignore", param1=0, param2=0},
+    -- Node to show when using the "node" visual
+
     use_texture_alpha = false,
-    -- Use texture's alpha channel.
-    -- Excludes "upright_sprite" and "wielditem".
+    -- Use texture's alpha channel for transparency blending.
     -- Note: currently causes visual issues when viewed through other
     -- semi-transparent materials such as water.
+    -- Note: ignored for "item", "wielditem" and "node" visual.
 
     spritediv = {x = 1, y = 1},
     -- Used with spritesheet textures for animation and/or frame selection
@@ -9291,7 +9296,7 @@ Player properties need to be saved manually.
     -- If false, object is invisible and can't be pointed.
 
     makes_footstep_sound = false,
-    -- If true, is able to make footstep sounds of nodes
+    -- If true, object is able to make footstep sounds of nodes
     -- (see node sound definition for details).
 
     automatic_rotate = 0,
@@ -9314,6 +9319,7 @@ Player properties need to be saved manually.
 
     backface_culling = true,
     -- Set to false to disable backface_culling for model
+    -- Note: only used by "mesh" and "cube" visual
 
     glow = 0,
     -- Add this much extra lighting when calculating texture color.
@@ -9349,6 +9355,7 @@ Player properties need to be saved manually.
 
     shaded = true,
     -- Setting this to 'false' disables diffuse lighting of entity
+    -- Note: ignored for "item", "wielditem" and "node" visual
 
     show_on_minimap = false,
     -- Defaults to true for players, false for other entities.

--- a/games/devtest/mods/testentities/visuals.lua
+++ b/games/devtest/mods/testentities/visuals.lua
@@ -66,6 +66,15 @@ core.register_entity("testentities:mesh_unshaded", {
 	},
 })
 
+core.register_entity("testentities:node", {
+	initial_properties = {
+		visual = "node",
+		node = { name = "stairs:stair_stone" },
+	},
+})
+
+-- More complex meshes
+
 core.register_entity("testentities:sam", {
 	initial_properties = {
 		visual = "mesh",

--- a/irr/include/IMeshSceneNode.h
+++ b/irr/include/IMeshSceneNode.h
@@ -34,16 +34,16 @@ public:
 	/** \return Pointer to mesh which is displayed by this node. */
 	virtual IMesh *getMesh(void) = 0;
 
-	//! Sets if the scene node should not copy the materials of the mesh but use them in a read only style.
+	//! Sets if the scene node should not copy the materials of the mesh but use them directly.
 	/** In this way it is possible to change the materials of a mesh
 	causing all mesh scene nodes referencing this mesh to change, too.
-	\param readonly Flag if the materials shall be read-only. */
-	virtual void setReadOnlyMaterials(bool readonly) = 0;
+	\param shared Flag if the materials shall be shared. */
+	virtual void setSharedMaterials(bool shared) = 0;
 
-	//! Check if the scene node should not copy the materials of the mesh but use them in a read only style
-	/** This flag can be set by setReadOnlyMaterials().
-	\return Whether the materials are read-only. */
-	virtual bool isReadOnlyMaterials() const = 0;
+	//! Check if the scene node does not copy the materials of the mesh but uses them directly.
+	/** This flag can be set by setSharedMaterials().
+	\return Whether the materials are shared. */
+	virtual bool isSharedMaterials() const = 0;
 };
 
 } // end namespace scene

--- a/irr/src/CMeshSceneNode.h
+++ b/irr/src/CMeshSceneNode.h
@@ -52,13 +52,16 @@ public:
 	//! Returns the current mesh
 	IMesh *getMesh(void) override { return Mesh; }
 
-	//! Sets if the scene node should not copy the materials of the mesh but use them in a read only style.
-	/* In this way it is possible to change the materials a mesh causing all mesh scene nodes
-	referencing this mesh to change too. */
-	void setReadOnlyMaterials(bool readonly) override;
+	//! Sets if the scene node should not copy the materials of the mesh but use them directly.
+	/** In this way it is possible to change the materials of a mesh
+	causing all mesh scene nodes referencing this mesh to change, too.
+	\param shared Flag if the materials shall be shared. */
+	void setSharedMaterials(bool shared) override;
 
-	//! Returns if the scene node should not copy the materials of the mesh but use them in a read only style
-	bool isReadOnlyMaterials() const override;
+	//! Check if the scene node does not copy the materials of the mesh but uses them directly.
+	/** This flag can be set by setSharedMaterials().
+	\return Whether the materials are shared. */
+	bool isSharedMaterials() const override;
 
 	//! Creates a clone of this scene node and its children.
 	ISceneNode *clone(ISceneNode *newParent = 0, ISceneManager *newManager = 0) override;
@@ -71,14 +74,13 @@ public:
 protected:
 	void copyMaterials();
 
-	core::array<video::SMaterial> Materials;
+	std::vector<video::SMaterial> Materials;
 	core::aabbox3d<f32> Box{{0, 0, 0}};
-	video::SMaterial ReadOnlyMaterial;
 
 	IMesh *Mesh;
 
 	s32 PassCount;
-	bool ReadOnlyMaterials;
+	bool SharedMaterials;
 };
 
 } // end namespace scene

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -220,14 +220,9 @@ static scene::SMesh *generateNodeMesh(Client *client, MapNode n,
 
 			// Set up material
 			auto &mat = buf->Material;
-			mat.setTexture(0, p.layer.texture);
 			u32 shader_id = shdsrc->getShader("object_shader", p.layer.material_type, NDT_NORMAL);
 			mat.MaterialType = shdsrc->getShaderInfo(shader_id).material;
-			if (layer == 1) {
-				mat.PolygonOffsetSlopeScale = -1;
-				mat.PolygonOffsetDepthBias = -1;
-			}
-			p.layer.applyMaterialOptionsWithShaders(mat);
+			p.layer.applyMaterialOptions(mat, layer);
 
 			mesh->addMeshBuffer(buf.get());
 		}

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -691,26 +691,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		node->forEachMaterial(setMaterial);
 	};
 
-	if (m_prop.visual == "sprite") {
-		m_spritenode = m_smgr->addBillboardSceneNode(
-				m_matrixnode, v2f(1, 1), v3f(0,0,0), -1);
-		m_spritenode->grab();
-		video::ITexture *tex = tsrc->getTextureForMesh("no_texture.png");
-		m_spritenode->forEachMaterial([tex] (auto &mat) {
-			mat.setTexture(0, tex);
-		});
-
-		setSceneNodeMaterials(m_spritenode);
-
-		m_spritenode->setSize(v2f(m_prop.visual_size.X,
-				m_prop.visual_size.Y) * BS);
-		{
-			const float txs = 1.0 / 1;
-			const float tys = 1.0 / 1;
-			setBillboardTextureMatrix(m_spritenode,
-					txs, tys, 0, 0);
-		}
-	} else if (m_prop.visual == "upright_sprite") {
+	if (m_prop.visual == "upright_sprite") {
 		auto mesh = make_irr<scene::SMesh>();
 		f32 dx = BS * m_prop.visual_size.X / 2;
 		f32 dy = BS * m_prop.visual_size.Y / 2;
@@ -823,8 +804,22 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 
 		setSceneNodeMaterials(m_meshnode);
 	} else {
-		infostream<<"GenericCAO::addToScene(): \""<<m_prop.visual
-				<<"\" not supported"<<std::endl;
+		m_spritenode = m_smgr->addBillboardSceneNode(m_matrixnode);
+		m_spritenode->grab();
+
+		setSceneNodeMaterials(m_spritenode);
+
+		m_spritenode->setSize(v2f(m_prop.visual_size.X,
+				m_prop.visual_size.Y) * BS);
+		setBillboardTextureMatrix(m_spritenode, 1, 1, 0, 0);
+
+		// This also serves as fallback for unknown visual types
+		if (m_prop.visual != "sprite") {
+			infostream << "GenericCAO::addToScene(): \"" << m_prop.visual
+				<< "\" not supported" << std::endl;
+			m_spritenode->getMaterial(0).setTexture(0,
+				tsrc->getTextureForMesh("unknown_object.png"));
+		}
 	}
 
 	/* Set VBO hint */

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -12,6 +12,8 @@
 #include "client/sound.h"
 #include "client/texturesource.h"
 #include "client/mapblock_mesh.h"
+#include "client/content_mapblock.h"
+#include "client/meshgen/collector.h"
 #include "util/basic_macros.h"
 #include "util/numeric.h"
 #include "util/serialize.h"
@@ -178,6 +180,60 @@ static void setColorParam(scene::ISceneNode *node, video::SColor color)
 {
 	for (u32 i = 0; i < node->getMaterialCount(); ++i)
 		node->getMaterial(i).ColorParam = color;
+}
+
+static scene::SMesh *generateNodeMesh(Client *client, MapNode n,
+	std::vector<MeshAnimationInfo> &animation)
+{
+	auto *ndef = client->ndef();
+	auto *shdsrc = client->getShaderSource();
+
+	MeshCollector collector(v3f(0), v3f());
+	{
+		MeshMakeData mmd(ndef, 1, MeshGrid{1});
+		n.setParam1(0xff);
+		mmd.fillSingleNode(n);
+		MapblockMeshGenerator(&mmd, &collector).generate();
+	}
+
+	auto mesh = make_irr<scene::SMesh>();
+	animation.clear();
+	for (int layer = 0; layer < MAX_TILE_LAYERS; layer++) {
+		for (PreMeshBuffer &p : collector.prebuffers[layer]) {
+			// reset the pre-computed light data stored in the vertex color,
+			// since we do that ourselves via updateLight().
+			for (auto &v : p.vertices)
+				v.Color.set(0xFFFFFFFF);
+			// but still apply the tile color
+			p.applyTileColor();
+
+			if (p.layer.material_flags & MATERIAL_FLAG_ANIMATION) {
+				const FrameSpec &frame = (*p.layer.frames)[0];
+				p.layer.texture = frame.texture;
+
+				animation.emplace_back(MeshAnimationInfo{mesh->getMeshBufferCount(), 0, p.layer});
+			}
+
+			auto buf = make_irr<scene::SMeshBuffer>();
+			buf->append(&p.vertices[0], p.vertices.size(),
+					&p.indices[0], p.indices.size());
+
+			// Set up material
+			auto &mat = buf->Material;
+			mat.setTexture(0, p.layer.texture);
+			u32 shader_id = shdsrc->getShader("object_shader", p.layer.material_type, NDT_NORMAL);
+			mat.MaterialType = shdsrc->getShaderInfo(shader_id).material;
+			if (layer == 1) {
+				mat.PolygonOffsetSlopeScale = -1;
+				mat.PolygonOffsetDepthBias = -1;
+			}
+			p.layer.applyMaterialOptionsWithShaders(mat);
+
+			mesh->addMeshBuffer(buf.get());
+		}
+	}
+	mesh->recalculateBoundingBox();
+	return mesh.release();
 }
 
 /*
@@ -572,6 +628,8 @@ void GenericCAO::removeFromScene(bool permanent)
 		m_spritenode = nullptr;
 	}
 
+	m_meshnode_animation.clear();
+
 	if (m_matrixnode) {
 		m_matrixnode->remove();
 		m_matrixnode->drop();
@@ -602,8 +660,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 
 	infostream << "GenericCAO::addToScene(): " << m_prop.visual << std::endl;
 
-	m_material_type_param = 0.5f; // May cut off alpha < 128 depending on m_material_type
-
+	if (m_prop.visual != "node" && m_prop.visual != "wielditem" && m_prop.visual != "item")
 	{
 		IShaderSource *shader_source = m_client->getShaderSource();
 		MaterialType material_type;
@@ -617,15 +674,17 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 
 		u32 shader_id = shader_source->getShader("object_shader", material_type, NDT_NORMAL);
 		m_material_type = shader_source->getShaderInfo(shader_id).material;
+	} else {
+		// Not used, so make sure it's not valid
+		m_material_type = EMT_INVALID;
 	}
 
-	auto grabMatrixNode = [this] {
-		m_matrixnode = m_smgr->addDummyTransformationSceneNode();
-		m_matrixnode->grab();
-	};
+	m_matrixnode = m_smgr->addDummyTransformationSceneNode();
+	m_matrixnode->grab();
 
 	auto setMaterial = [this] (video::SMaterial &mat) {
-		mat.MaterialType = m_material_type;
+		if (m_material_type != EMT_INVALID)
+			mat.MaterialType = m_material_type;
 		mat.FogEnable = true;
 		mat.forEachTexture([] (auto &tex) {
 			tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
@@ -638,7 +697,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 	};
 
 	if (m_prop.visual == "sprite") {
-		grabMatrixNode();
 		m_spritenode = m_smgr->addBillboardSceneNode(
 				m_matrixnode, v2f(1, 1), v3f(0,0,0), -1);
 		m_spritenode->grab();
@@ -658,7 +716,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 					txs, tys, 0, 0);
 		}
 	} else if (m_prop.visual == "upright_sprite") {
-		grabMatrixNode();
 		auto mesh = make_irr<scene::SMesh>();
 		f32 dx = BS * m_prop.visual_size.X / 2;
 		f32 dy = BS * m_prop.visual_size.Y / 2;
@@ -700,7 +757,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		m_meshnode = m_smgr->addMeshSceneNode(mesh.get(), m_matrixnode);
 		m_meshnode->grab();
 	} else if (m_prop.visual == "cube") {
-		grabMatrixNode();
 		scene::IMesh *mesh = createCubeMesh(v3f(BS,BS,BS));
 		m_meshnode = m_smgr->addMeshSceneNode(mesh, m_matrixnode);
 		m_meshnode->grab();
@@ -714,7 +770,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 			mat.BackfaceCulling = m_prop.backface_culling;
 		});
 	} else if (m_prop.visual == "mesh") {
-		grabMatrixNode();
 		scene::IAnimatedMesh *mesh = m_client->getMesh(m_prop.mesh, true);
 		if (mesh) {
 			if (!checkMeshNormals(mesh)) {
@@ -741,7 +796,6 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		} else
 			errorstream<<"GenericCAO::addToScene(): Could not load mesh "<<m_prop.mesh<<std::endl;
 	} else if (m_prop.visual == "wielditem" || m_prop.visual == "item") {
-		grabMatrixNode();
 		ItemStack item;
 		if (m_prop.wield_item.empty()) {
 			// Old format, only textures are specified.
@@ -761,6 +815,18 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 			(m_prop.visual == "wielditem"));
 
 		m_wield_meshnode->setScale(m_prop.visual_size / 2.0f);
+	} else if (m_prop.visual == "node") {
+		auto *mesh = generateNodeMesh(m_client, m_prop.node, m_meshnode_animation);
+		assert(mesh);
+
+		m_meshnode = m_smgr->addMeshSceneNode(mesh, m_matrixnode);
+		m_meshnode->setSharedMaterials(true);
+		m_meshnode->grab();
+		mesh->drop();
+
+		m_meshnode->setScale(m_prop.visual_size);
+
+		setSceneNodeMaterials(m_meshnode);
 	} else {
 		infostream<<"GenericCAO::addToScene(): \""<<m_prop.visual
 				<<"\" not supported"<<std::endl;
@@ -789,8 +855,7 @@ void GenericCAO::addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr)
 		updateTextures(m_current_texture_modifier);
 
 	if (scene::ISceneNode *node = getSceneNode()) {
-		if (m_matrixnode)
-			node->setParent(m_matrixnode);
+		node->setParent(m_matrixnode);
 
 		if (auto shadow = RenderingEngine::get_shadow_renderer())
 			shadow->addNodeToShadowList(node);
@@ -861,8 +926,7 @@ void GenericCAO::updateLight(u32 day_night_ratio)
 	if (!pos_ok)
 		light_at_pos = LIGHT_SUN;
 
-	// Initialize with full alpha, otherwise entity won't be visible
-	video::SColor light{0xFFFFFFFF};
+	video::SColor light;
 
 	// Encode light into color, adding a small boost
 	// based on the entity glow.
@@ -965,6 +1029,7 @@ void GenericCAO::updateNodePos()
 	scene::ISceneNode *node = getSceneNode();
 
 	if (node) {
+		assert(m_matrixnode);
 		v3s16 camera_offset = m_env->getCameraOffset();
 		v3f pos = pos_translator.val_current -
 				intToFloat(camera_offset, BS);
@@ -1153,7 +1218,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			m_anim_frame = 0;
 	}
 
-	updateTexturePos();
+	updateTextureAnim();
 
 	if(m_reset_textures_timer >= 0)
 	{
@@ -1214,7 +1279,7 @@ static void setMeshBufferTextureCoords(scene::IMeshBuffer *buf, const v2f *uv, u
 	buf->setDirty(scene::EBT_VERTEX);
 }
 
-void GenericCAO::updateTexturePos()
+void GenericCAO::updateTextureAnim()
 {
 	if(m_spritenode)
 	{
@@ -1279,6 +1344,23 @@ void GenericCAO::updateTexturePos()
 			auto mesh = m_meshnode->getMesh();
 			setMeshBufferTextureCoords(mesh->getMeshBuffer(0), t, 4);
 			setMeshBufferTextureCoords(mesh->getMeshBuffer(1), t, 4);
+		} else if (m_prop.visual == "node") {
+			// same calculation as MapBlockMesh::animate() with a global timer
+			const float time = m_client->getAnimationTime();
+			for (auto &it : m_meshnode_animation) {
+				const TileLayer &tile = it.tile;
+				int frameno = (int)(time * 1000 / tile.animation_frame_length_ms)
+					% tile.animation_frame_count;
+
+				if (frameno == it.frame)
+					continue;
+				it.frame = frameno;
+
+				auto *buf = m_meshnode->getMesh()->getMeshBuffer(it.i);
+
+				const FrameSpec &frame = (*tile.frames)[frameno];
+				buf->getMaterial().setTexture(0, frame.texture);
+			}
 		}
 	}
 }
@@ -1304,7 +1386,6 @@ void GenericCAO::updateTextures(std::string mod)
 
 			video::SMaterial &material = m_spritenode->getMaterial(0);
 			material.MaterialType = m_material_type;
-			material.MaterialTypeParam = m_material_type_param;
 			material.setTexture(0, tsrc->getTextureForMesh(texturestring));
 
 			material.forEachTexture([=] (auto &tex) {
@@ -1333,7 +1414,6 @@ void GenericCAO::updateTextures(std::string mod)
 				// Set material flags and texture
 				video::SMaterial &material = m_animated_meshnode->getMaterial(i);
 				material.MaterialType = m_material_type;
-				material.MaterialTypeParam = m_material_type_param;
 				material.TextureLayers[0].Texture = texture;
 				material.BackfaceCulling = m_prop.backface_culling;
 
@@ -1365,7 +1445,6 @@ void GenericCAO::updateTextures(std::string mod)
 				// Set material flags and texture
 				video::SMaterial &material = m_meshnode->getMaterial(i);
 				material.MaterialType = m_material_type;
-				material.MaterialTypeParam = m_material_type_param;
 				material.setTexture(0, tsrc->getTextureForMesh(texturestring));
 				material.getTextureMatrix(0).makeIdentity();
 
@@ -1532,7 +1611,7 @@ bool GenericCAO::visualExpiryRequired(const ObjectProperties &new_) const
 	/* Visuals do not need to be expired for:
 	 * - nametag props: handled by updateNametag()
 	 * - textures:      handled by updateTextures()
-	 * - sprite props:  handled by updateTexturePos()
+	 * - sprite props:  handled by updateTextureAnim()
 	 * - glow:          handled by updateLight()
 	 * - any other properties that do not change appearance
 	 */
@@ -1542,9 +1621,10 @@ bool GenericCAO::visualExpiryRequired(const ObjectProperties &new_) const
 	// Ordered to compare primitive types before std::vectors
 	return old.backface_culling != new_.backface_culling ||
 		old.is_visible != new_.is_visible ||
-		old.mesh != new_.mesh ||
 		old.shaded != new_.shaded ||
 		old.use_texture_alpha != new_.use_texture_alpha ||
+		old.node != new_.node ||
+		old.mesh != new_.mesh ||
 		old.visual != new_.visual ||
 		old.visual_size != new_.visual_size ||
 		old.wield_item != new_.wield_item ||
@@ -1655,7 +1735,7 @@ void GenericCAO::processMessage(const std::string &data)
 		m_anim_framelength = framelength;
 		m_tx_select_horiz_by_yawpitch = select_horiz_by_yawpitch;
 
-		updateTexturePos();
+		updateTextureAnim();
 	} else if (cmd == AO_CMD_SET_PHYSICS_OVERRIDE) {
 		float override_speed = readF32(is);
 		float override_jump = readF32(is);

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -12,6 +12,7 @@
 #include "clientobject.h"
 #include "constants.h"
 #include "itemgroup.h"
+#include "client/tile.h"
 #include <cassert>
 #include <map>
 #include <memory>
@@ -27,7 +28,7 @@ struct Nametag;
 struct MinimapMarker;
 
 /*
-	SmoothTranslator
+	SmoothTranslator and other helpers
 */
 
 template<typename T>
@@ -60,9 +61,21 @@ struct SmoothTranslatorWrappedv3f : SmoothTranslator<v3f>
 	void translate(f32 dtime);
 };
 
+struct MeshAnimationInfo {
+	u32 i; /// index of mesh buffer
+	int frame; /// last animation frame
+	TileLayer tile;
+};
+
+/*
+	GenericCAO
+*/
+
 class GenericCAO : public ClientActiveObject
 {
 private:
+	static constexpr auto EMT_INVALID = video::EMT_FORCE_32BIT;
+
 	// Only set at initialization
 	std::string m_name = "";
 	bool m_is_player = false;
@@ -73,6 +86,8 @@ private:
 	scene::ISceneManager *m_smgr = nullptr;
 	Client *m_client = nullptr;
 	aabb3f m_selection_box = aabb3f(-BS/3.,-BS/3.,-BS/3., BS/3.,BS/3.,BS/3.);
+
+	// Visuals
 	scene::IMeshSceneNode *m_meshnode = nullptr;
 	scene::IAnimatedMeshSceneNode *m_animated_meshnode = nullptr;
 	WieldMeshSceneNode *m_wield_meshnode = nullptr;
@@ -80,6 +95,15 @@ private:
 	scene::IDummyTransformationSceneNode *m_matrixnode = nullptr;
 	Nametag *m_nametag = nullptr;
 	MinimapMarker *m_marker = nullptr;
+	bool m_visuals_expired = false;
+	video::SColor m_last_light = video::SColor(0xFFFFFFFF);
+	bool m_is_visible = false;
+	std::vector<MeshAnimationInfo> m_meshnode_animation;
+
+	// Material
+	video::E_MATERIAL_TYPE m_material_type = EMT_INVALID;
+
+	// Movement
 	v3f m_position = v3f(0.0f, 10.0f * BS, 0);
 	v3f m_velocity;
 	v3f m_acceleration;
@@ -87,18 +111,25 @@ private:
 	u16 m_hp = 1;
 	SmoothTranslator<v3f> pos_translator;
 	SmoothTranslatorWrappedv3f rot_translator;
-	// Spritesheet/animation stuff
+
+	// Spritesheet stuff
 	v2f m_tx_size = v2f(1,1);
 	v2s16 m_tx_basepos;
 	bool m_initial_tx_basepos_set = false;
 	bool m_tx_select_horiz_by_yawpitch = false;
+	bool m_animation_loop = true;
 	v2f m_animation_range;
 	float m_animation_speed = 15.0f;
 	float m_animation_blend = 0.0f;
-	bool m_animation_loop = true;
+	int m_anim_frame = 0;
+	int m_anim_num_frames = 1;
+	float m_anim_framelength = 0.2f;
+	float m_anim_timer = 0.0f;
+
 	// stores position and rotation for each bone name
 	BoneOverrideMap m_bone_override;
 
+	// Attachments
 	object_t m_attachment_parent_id = 0;
 	std::unordered_set<object_t> m_attachment_child_ids;
 	std::string m_attachment_bone = "";
@@ -107,23 +138,13 @@ private:
 	bool m_attached_to_local = false;
 	bool m_force_visible = false;
 
-	int m_anim_frame = 0;
-	int m_anim_num_frames = 1;
-	float m_anim_framelength = 0.2f;
-	float m_anim_timer = 0.0f;
 	ItemGroupList m_armor_groups;
 	float m_reset_textures_timer = -1.0f;
 	// stores texture modifier before punch update
 	std::string m_previous_texture_modifier = "";
 	// last applied texture modifier
 	std::string m_current_texture_modifier = "";
-	bool m_visuals_expired = false;
 	float m_step_distance_counter = 0.0f;
-	video::SColor m_last_light = video::SColor(0xFFFFFFFF);
-	bool m_is_visible = false;
-	// Material
-	video::E_MATERIAL_TYPE m_material_type;
-	f32 m_material_type_param;
 
 	bool visualExpiryRequired(const ObjectProperties &newprops) const;
 
@@ -255,7 +276,7 @@ public:
 
 	void step(float dtime, ClientEnvironment *env) override;
 
-	void updateTexturePos();
+	void updateTextureAnim();
 
 	// ffs this HAS TO BE a string copy! See #5739 if you think otherwise
 	// Reason: updateTextures(m_previous_texture_modifier);

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -426,20 +426,6 @@ void getNodeTile(MapNode mn, const v3s16 &p, const v3s16 &dir, MeshMakeData *dat
 	tile.rotation = tile.world_aligned ? TileRotation::None : dir_to_tile[facedir][dir_i].rotation;
 }
 
-static void applyTileColor(PreMeshBuffer &pmb)
-{
-	video::SColor tc = pmb.layer.color;
-	if (tc == video::SColor(0xFFFFFFFF))
-		return;
-	for (video::S3DVertex &vertex : pmb.vertices) {
-		video::SColor *c = &vertex.Color;
-		c->set(c->getAlpha(),
-			c->getRed() * tc.getRed() / 255,
-			c->getGreen() * tc.getGreen() / 255,
-			c->getBlue() * tc.getBlue() / 255);
-	}
-}
-
 /*
 	MapBlockBspTree
 */
@@ -668,7 +654,7 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data):
 		{
 			PreMeshBuffer &p = collector.prebuffers[layer][i];
 
-			applyTileColor(p);
+			p.applyTileColor();
 
 			// Generate animation data
 			// - Cracks

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -687,28 +687,16 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data):
 
 			// Create material
 			video::SMaterial material;
-			material.BackfaceCulling = true;
 			material.FogEnable = true;
-			material.setTexture(0, p.layer.texture);
 			material.forEachTexture([] (auto &tex) {
 				tex.MinFilter = video::ETMINF_NEAREST_MIPMAP_NEAREST;
 				tex.MagFilter = video::ETMAGF_NEAREST;
 			});
-			/*
-			 * The second layer is for overlays, but uses the same vertex positions
-			 * as the first, which quickly leads to z-fighting.
-			 * To fix this we can offset the polygons in the direction of the camera.
-			 * This only affects the depth buffer and leads to no visual gaps in geometry.
-			 */
-			if (layer == 1) {
-				material.PolygonOffsetSlopeScale = -1;
-				material.PolygonOffsetDepthBias = -1;
-			}
 
 			{
 				material.MaterialType = m_shdrsrc->getShaderInfo(
 						p.layer.shader_id).material;
-				p.layer.applyMaterialOptionsWithShaders(material);
+				p.layer.applyMaterialOptions(material, layer);
 			}
 
 			scene::SMeshBuffer *buf = new scene::SMeshBuffer();

--- a/src/client/meshgen/collector.h
+++ b/src/client/meshgen/collector.h
@@ -18,6 +18,21 @@ struct PreMeshBuffer
 
 	PreMeshBuffer() = default;
 	explicit PreMeshBuffer(const TileLayer &layer) : layer(layer) {}
+
+	/// @brief Colorizes vertices as indicated by tile layer
+	void applyTileColor()
+	{
+		video::SColor tc = layer.color;
+		if (tc == video::SColor(0xFFFFFFFF))
+			return;
+		for (auto &vertex : vertices) {
+			video::SColor *c = &vertex.Color;
+			c->set(c->getAlpha(),
+				c->getRed() * tc.getRed() / 255U,
+				c->getGreen() * tc.getGreen() / 255U,
+				c->getBlue() * tc.getBlue() / 255U);
+		}
+	}
 };
 
 struct MeshCollector

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -4,41 +4,10 @@
 
 #include "tile.h"
 
-// Sets everything else except the texture in the material
-void TileLayer::applyMaterialOptions(video::SMaterial &material) const
+void TileLayer::applyMaterialOptions(video::SMaterial &material, int layer) const
 {
-	switch (material_type) {
-	case TILE_MATERIAL_OPAQUE:
-	case TILE_MATERIAL_LIQUID_OPAQUE:
-	case TILE_MATERIAL_WAVING_LIQUID_OPAQUE:
-		material.MaterialType = video::EMT_SOLID;
-		break;
-	case TILE_MATERIAL_BASIC:
-	case TILE_MATERIAL_WAVING_LEAVES:
-	case TILE_MATERIAL_WAVING_PLANTS:
-	case TILE_MATERIAL_WAVING_LIQUID_BASIC:
-		material.MaterialTypeParam = 0.5;
-		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
-		break;
-	case TILE_MATERIAL_ALPHA:
-	case TILE_MATERIAL_LIQUID_TRANSPARENT:
-	case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
-		material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-		break;
-	default:
-		break;
-	}
-	material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
-	if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
-		material.TextureLayers[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
-	}
-	if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
-		material.TextureLayers[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
-	}
-}
+	material.setTexture(0, texture);
 
-void TileLayer::applyMaterialOptionsWithShaders(video::SMaterial &material) const
-{
 	material.BackfaceCulling = (material_flags & MATERIAL_FLAG_BACKFACE_CULLING) != 0;
 	if (!(material_flags & MATERIAL_FLAG_TILEABLE_HORIZONTAL)) {
 		material.TextureLayers[0].TextureWrapU = video::ETC_CLAMP_TO_EDGE;
@@ -47,5 +16,16 @@ void TileLayer::applyMaterialOptionsWithShaders(video::SMaterial &material) cons
 	if (!(material_flags & MATERIAL_FLAG_TILEABLE_VERTICAL)) {
 		material.TextureLayers[0].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
 		material.TextureLayers[1].TextureWrapV = video::ETC_CLAMP_TO_EDGE;
+	}
+
+	/*
+	 * The second layer is for overlays, but uses the same vertex positions
+	 * as the first, which easily leads to Z-fighting.
+	 * To fix this we can offset the polygons in the direction of the camera.
+	 * This only affects the depth buffer and leads to no visual gaps in geometry.
+	 */
+	if (layer == 1) {
+		material.PolygonOffsetSlopeScale = -1;
+		material.PolygonOffsetDepthBias = -1;
 	}
 }

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -84,9 +84,13 @@ struct TileLayer
 		return !(*this == other);
 	}
 
-	void applyMaterialOptions(video::SMaterial &material) const;
-
-	void applyMaterialOptionsWithShaders(video::SMaterial &material) const;
+	/**
+	 * Set some material parameters accordingly.
+	 * @note does not set `MaterialType`
+	 * @param material material to mody
+	 * @param layer index of this layer in the `TileSpec`
+	 */
+	void applyMaterialOptions(video::SMaterial &material, int layer) const;
 
 	/// @return is this layer semi-transparent?
 	bool isTransparent() const

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -9,7 +9,7 @@
 #include <vector>
 #include <SMaterial.h>
 
-enum MaterialType{
+enum MaterialType : u8 {
 	TILE_MATERIAL_BASIC,
 	TILE_MATERIAL_ALPHA,
 	TILE_MATERIAL_LIQUID_TRANSPARENT,
@@ -98,8 +98,9 @@ struct TileLayer
 		case TILE_MATERIAL_LIQUID_TRANSPARENT:
 		case TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT:
 			return true;
+		default:
+			return false;
 		}
-		return false;
 	}
 
 	// Ordered for size, please do not reorder
@@ -113,13 +114,14 @@ struct TileLayer
 	u16 animation_frame_length_ms = 0;
 	u16 animation_frame_count = 1;
 
-	u8 material_type = TILE_MATERIAL_BASIC;
+	MaterialType material_type = TILE_MATERIAL_BASIC;
 	u8 material_flags =
 		//0 // <- DEBUG, Use the one below
 		MATERIAL_FLAG_BACKFACE_CULLING |
 		MATERIAL_FLAG_TILEABLE_HORIZONTAL|
 		MATERIAL_FLAG_TILEABLE_VERTICAL;
 
+	/// @note not owned by this struct
 	std::vector<FrameSpec> *frames = nullptr;
 
 	/*!

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -326,13 +326,8 @@ static scene::SMesh *createGenericNodeMesh(Client *client, MapNode n,
 			buf->append(&p.vertices[0], p.vertices.size(),
 					&p.indices[0], p.indices.size());
 
-			// Set up material
-			buf->Material.setTexture(0, p.layer.texture);
-			if (layer == 1) {
-				buf->Material.PolygonOffsetSlopeScale = -1;
-				buf->Material.PolygonOffsetDepthBias = -1;
-			}
-			p.layer.applyMaterialOptions(buf->Material);
+			// note: material type is left unset, overriden later
+			p.layer.applyMaterialOptions(buf->Material, layer);
 
 			mesh->addMeshBuffer(buf.get());
 			colors->emplace_back(p.layer.has_color, p.layer.color);
@@ -432,7 +427,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 		u32 material_count = m_meshnode->getMaterialCount();
 		for (u32 i = 0; i < material_count; ++i) {
 			video::SMaterial &material = m_meshnode->getMaterial(i);
-			// FIXME: overriding this breaks different alpha modes the mesh may have
+			// FIXME: we should take different alpha modes of the mesh into account here
 			material.MaterialType = m_material_type;
 			material.MaterialTypeParam = 0.5f;
 			material.forEachTexture([this] (auto &tex) {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -204,7 +204,6 @@ WieldMeshSceneNode::WieldMeshSceneNode(scene::ISceneManager *mgr, s32 id):
 	// Create the child scene node
 	scene::IMesh *dummymesh = g_extrusion_mesh_cache->createCube();
 	m_meshnode = SceneManager->addMeshSceneNode(dummymesh, this, -1);
-	m_meshnode->setReadOnlyMaterials(false);
 	m_meshnode->setVisible(false);
 	dummymesh->drop(); // m_meshnode grabbed it
 

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -145,7 +145,7 @@ struct alignas(u32) MapNode
 
 	MapNode() = default;
 
-	MapNode(content_t content, u8 a_param1=0, u8 a_param2=0) noexcept
+	constexpr MapNode(content_t content, u8 a_param1=0, u8 a_param2=0) noexcept
 		: param0(content),
 		  param1(a_param1),
 		  param2(a_param2)
@@ -156,6 +156,10 @@ struct alignas(u32) MapNode
 		return (param0 == other.param0
 				&& param1 == other.param1
 				&& param2 == other.param2);
+	}
+	bool operator!=(const MapNode &other) const noexcept
+	{
+		return !(*this == other);
 	}
 
 	// To be used everywhere

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -669,7 +669,7 @@ void ContentFeatures::deSerialize(std::istream &is, u16 protocol_version)
 #if CHECK_CLIENT_BUILD()
 static void fillTileAttribs(ITextureSource *tsrc, TileLayer *layer,
 		const TileSpec &tile, const TileDef &tiledef, video::SColor color,
-		u8 material_type, u32 shader_id, bool backface_culling,
+		MaterialType material_type, u32 shader_id, bool backface_culling,
 		const TextureSettings &tsettings)
 {
 	layer->shader_id     = shader_id;

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <vector>
 #include "util/pointabilities.h"
+#include "mapnode.h"
 
 struct ObjectProperties
 {
@@ -39,6 +40,7 @@ struct ObjectProperties
 	f32 automatic_face_movement_max_rotation_per_sec = -1.0f;
 	float eye_height = 1.625f;
 	float zoom_fov = 0.0f;
+	MapNode node = MapNode(CONTENT_IGNORE);
 	u16 hp_max = 1;
 	u16 breath_max = 0;
 	s8 glow = 0;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -294,11 +294,13 @@ const std::array<const char *, 33> object_property_keys = {
 	"shaded",
 	"damage_texture_modifier",
 	"show_on_minimap",
+	// "node" is intentionally not here as it's gated behind `fallback` below!
 };
 
 /******************************************************************************/
 void read_object_properties(lua_State *L, int index,
-		ServerActiveObject *sao, ObjectProperties *prop, IItemDefManager *idef)
+		ServerActiveObject *sao, ObjectProperties *prop, IItemDefManager *idef,
+		bool fallback)
 {
 	if(index < 0)
 		index = lua_gettop(L) + 1 + index;
@@ -398,6 +400,16 @@ void read_object_properties(lua_State *L, int index,
 		}
 	}
 	lua_pop(L, 1);
+
+	// This hack exists because the name 'node' easily collides with mods own
+	// usage (or in this case literally builtin/game/falling.lua).
+	if (!fallback) {
+		lua_getfield(L, -1, "node");
+		if (lua_istable(L, -1)) {
+			prop->node = readnode(L, -1);
+		}
+		lua_pop(L, 1);
+	}
 
 	lua_getfield(L, -1, "spritediv");
 	if(lua_istable(L, -1))
@@ -513,6 +525,8 @@ void push_object_properties(lua_State *L, const ObjectProperties *prop)
 	}
 	lua_setfield(L, -2, "colors");
 
+	pushnode(L, prop->node);
+	lua_setfield(L, -2, "node");
 	push_v2s16(L, prop->spritediv);
 	lua_setfield(L, -2, "spritediv");
 	push_v2s16(L, prop->initial_sprite_basepos);

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -99,10 +99,10 @@ void read_item_definition(lua_State *L, int index,
 void push_item_definition(lua_State *L, const ItemDefinition &i);
 void push_item_definition_full(lua_State *L, const ItemDefinition &i);
 
+/// @param fallback set to true if reading from bare entity table (not initial_properties)
 void read_object_properties(lua_State *L, int index,
-		ServerActiveObject *sao,
-		ObjectProperties *prop,
-		IItemDefManager *idef);
+		ServerActiveObject *sao, ObjectProperties *prop,
+		IItemDefManager *idef, bool fallback = false);
 
 void push_object_properties(lua_State *L, const ObjectProperties *prop);
 

--- a/src/script/cpp_api/s_entity.cpp
+++ b/src/script/cpp_api/s_entity.cpp
@@ -197,13 +197,17 @@ void ScriptApiEntity::luaentity_GetProperties(u16 id,
 	// Set default values that differ from ObjectProperties defaults
 	prop->hp_max = 10;
 
+	auto *idef = getServer()->idef();
+
 	// Deprecated: read object properties directly
+	// TODO: this should be changed to not read the legacy place
+	// if `initial_properties` exists!
 	logDeprecationForExistingProperties(L, -1, entity_name);
-	read_object_properties(L, -1, self, prop, getServer()->idef());
+	read_object_properties(L, -1, self, prop, idef, true);
 
 	// Read initial_properties
 	lua_getfield(L, -1, "initial_properties");
-	read_object_properties(L, -1, self, prop, getServer()->idef());
+	read_object_properties(L, -1, self, prop, idef);
 	lua_pop(L, 1);
 }
 


### PR DESCRIPTION
implements, closes #10722

## To do

This PR is Ready for Review.


## How to test

This code gives you a tool that duplicates an arbitrary node as entity:
```lua
minetest.register_entity("test2:cloned", {
	initial_properties = {
		physical = true,
		collide_with_objects = false,
		collisionbox = {-0.5, -0.5, -0.5, 0.5, 0.5, 0.5},
		static_save = false,
	},
})

minetest.register_tool("test2:clone_tool", {
	description = "Clone Node",
	inventory_image = "plus.png",
	liquids_pointable = true,

	on_use = function(itemstack, placer, pt)
		if placer == nil or pt == nil or pt.type ~= "node" then
			return
		end
		local pos = vector.offset(pt.under, 0, 1.25, 0)
		local entity = minetest.add_entity(pos, "test2:cloned")
		if entity then
			entity:set_properties({
				visual = "node",
				node = core.get_node(pt.under),
			})
		end
		return itemstack
	end,
})
```

And this one gives you a tool that can make any node fall:
```lua
core.register_tool(core.get_current_modname() .. ":fall_tool", {
	description = "Falling Tool",
	inventory_image = "end_icon.png^[transform3",
	liquids_pointable = true,

	on_use = function(itemstack, placer, pt)
		if placer == nil or pt == nil or pt.type ~= "node" then
			return
		end
		local node = core.get_node(pt.under)
		local def = core.registered_nodes[node.name]
		if def and def.drawtype ~= "airlike" then
			local was = def.groups.falling_node
			def.groups.falling_node = 1
			core.check_for_falling(pt.under)
			def.groups.falling_node = was
		end
		return itemstack
	end,
})
```