### PR TITLE
Document that object properties `colors` field is unused

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9236,7 +9236,7 @@ Player properties need to be saved manually.
     -- Deprecated usage of "wielditem" expects 'textures = {itemname}' (see 'visual' above).
 
     colors = {},
-    -- Number of required colors depends on visual
+    -- Currently unused.
 
     use_texture_alpha = false,
     -- Use texture's alpha channel.

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1404,8 +1404,8 @@ void GenericCAO::updateTextures(std::string mod)
 				});
 			}
 			// Set mesh color (only if lighting is disabled)
-			if (!m_prop.colors.empty() && m_prop.glow < 0)
-				setMeshColor(mesh, m_prop.colors[0]);
+			if (m_prop.glow < 0)
+				setMeshColor(mesh, {255, 255, 255, 255});
 		}
 	}
 	// Prevent showing the player after changing texture

--- a/src/object_properties.cpp
+++ b/src/object_properties.cpp
@@ -16,7 +16,6 @@ static const video::SColor NULL_BGCOLOR{0, 1, 1, 1};
 ObjectProperties::ObjectProperties()
 {
 	textures.emplace_back("no_texture.png");
-	colors.emplace_back(255,255,255,255);
 }
 
 std::string ObjectProperties::dump() const

--- a/src/object_properties.h
+++ b/src/object_properties.h
@@ -16,7 +16,7 @@ struct ObjectProperties
 	/* member variables ordered roughly by size */
 
 	std::vector<std::string> textures;
-	std::vector<video::SColor> colors;
+	std::vector<video::SColor> colors; // Currently unused
 	// Values are BS=1
 	aabb3f collisionbox = aabb3f(-0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f);
 	// Values are BS=1

--- a/src/server/player_sao.cpp
+++ b/src/server/player_sao.cpp
@@ -32,7 +32,6 @@ PlayerSAO::PlayerSAO(ServerEnvironment *env_, RemotePlayer *player_, session_t p
 	m_prop.textures.emplace_back("player.png");
 	m_prop.textures.emplace_back("player_back.png");
 	m_prop.colors.clear();
-	m_prop.colors.emplace_back(255, 255, 255, 255);
 	m_prop.spritediv = v2s16(1,1);
 	m_prop.eye_height = 1.625f;
 	// End of default appearance


### PR DESCRIPTION
This PR documents that the object property colors field is unused and removes the one case where it was used.


<details> 
  <summary>Old </summary>
   


This PR removes the `colors` field from object properties.

It is not (sufficiently) documented, quite useless and takes up space.

This is the only place where it gets used, so only for `upright_sprite` with `glow < 0`, and the default color is white, ~but I didn't notice any difference, so I completely removed it instead of defaulting it to white.~, readded it, but I'm not sure if is needed.
https://github.com/minetest/minetest/blob/c8b5e3b741390fb98bfa9cdbae56930239ea271a/src/client/content_cao.cpp#L1406-L1408


The documentation for `glow` says `Value < 0 disables light's effect on texture color.` and this sill works.

## To do

This PR is Ready for Review.

## How to test

``` lua
core.register_entity("testentities:upright_sprite2", {
	glow = -5,
	initial_properties = {
		visual = "upright_sprite",
		textures = {
			"testentities_upright_sprite1.png",
			"testentities_upright_sprite2.png",
		},
	},
})
```
</details>