### PR TITLE
Restrict relative mouse mode to Wayland users

### DIFF
--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -198,6 +198,9 @@ public:
 	or similar. */
 	virtual bool supportsTouchEvents() const { return false; }
 
+	//! Checks whether windowing uses the Wayland protocol.
+	virtual bool isUsingWayland() const { return false; }
+
 	//! Get the current color format of the window
 	/** \return Color format of the window. */
 	virtual video::ECOLOR_FORMAT getColorFormat() const = 0;

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -1248,6 +1248,15 @@ bool CIrrDeviceSDL::supportsTouchEvents() const
 	return true;
 }
 
+//! Checks whether windowing uses the Wayland protocol.
+bool CIrrDeviceSDL::isUsingWayland() const
+{
+	if (!Window)
+		return false;
+	auto *name = SDL_GetCurrentVideoDriver();
+	return name && !strcmp(name, "wayland");
+}
+
 //! returns if window is active. if not, nothing need to be drawn
 bool CIrrDeviceSDL::isWindowActive() const
 {

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -96,6 +96,9 @@ public:
 	//! Checks if the Irrlicht device supports touch events.
 	bool supportsTouchEvents() const override;
 
+	//! Checks whether windowing uses the Wayland protocol.
+	bool isUsingWayland() const override;
+
 	//! Get the position of this window on screen
 	core::position2di getWindowPosition() override;
 


### PR DESCRIPTION
fixes #14932

## To do

This PR is Ready for Review.

## How to test

nobody could reproduce the original issue but you can confirm that:
1. Luanti on wayland uses relative mouse mode
2. it doesn't on other platforms