### PR TITLE
Restore proper rollback database indexing

### DIFF
--- a/src/server/rollback.cpp
+++ b/src/server/rollback.cpp
@@ -224,7 +224,12 @@ bool RollbackManager::createTables()
 		"	FOREIGN KEY (`oldNode`)   REFERENCES `node`(`id`),\n"
 		"	FOREIGN KEY (`newNode`)   REFERENCES `node`(`id`)\n"
 		");\n"
-		"CREATE INDEX IF NOT EXISTS `actionIndex` ON `action`(`x`,`y`,`z`,`timestamp`,`actor`);\n",
+		// We run queries with the following filters:
+		// - `timestamp` >= ? AND `actor` = ?
+		// - `timestamp` >= ?
+		// - `timestamp` >= ? AND <range query on X, Y, Z>
+		"CREATE INDEX IF NOT EXISTS `actionIndex` ON `action`(`x`,`y`,`z`,`timestamp`,`actor`);\n"
+		"CREATE INDEX IF NOT EXISTS `actionTimestampActorIndex` ON `action`(`timestamp`,`actor`);\n",
 		NULL, NULL, NULL));
 	verbosestream << "SQL Rollback: SQLite3 database structure was created" << std::endl;
 


### PR DESCRIPTION
Messages sent recently by cheapie on #minetest:

> TIL that rollback bug I inadvertently created like 6 years ago is still there
...I should probably fix that one
Eek, even more than that, 10 years ago apparently
https://github.com/luanti-org/luanti/commit/380e1504eb2445fd43c03c87d23b8e41e85a7871 - it's the result of me coming across code written by someone who didn't seem to really understand indexing, and then trying to fix it while I also didn't really understand indexing :P

> Really should probably be an index on action(x,y,z,timestamp) and a second one on action(timestamp,actor) or maybe action(actor,timestamp), to match the sorts of queries /rollback_check and /rollback do, respectively

> The one I had ended up putting in there actually isn't too terrible for /rollback_check (but I don't think the coverage of the actor column is doing anything for that) but /rollback is pretty awful like this.

I simply looked at the queries and it's pretty obvious what index is missing. The index perfectly covers both remaining queries.

## How to test

This is one of those things where testing is probably a waste of time. Just look at the code carefully.