### PR TITLE
filesys: replace goto by #else to omit compile warning

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -506,15 +506,10 @@ bool CopyFileContents(const std::string &source, const std::string &target)
 	// fallback to normal copy, but no need to reopen the files
 	sourcefile.reset(fdopen(srcfd, "rb"));
 	targetfile.reset(fdopen(tgtfd, "wb"));
-	goto fallback;
-
+#else
+    sourcefile.reset(fopen(source.c_str(), "rb"));
+    targetfile.reset(fopen(target.c_str(), "wb"));
 #endif
-
-	sourcefile.reset(fopen(source.c_str(), "rb"));
-	targetfile.reset(fopen(target.c_str(), "wb"));
-
-fallback:
-
 	if (!sourcefile) {
 		errorstream << source << ": can't open for reading: "
 			<< strerror(errno) << std::endl;

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -507,8 +507,8 @@ bool CopyFileContents(const std::string &source, const std::string &target)
 	sourcefile.reset(fdopen(srcfd, "rb"));
 	targetfile.reset(fdopen(tgtfd, "wb"));
 #else
-    sourcefile.reset(fopen(source.c_str(), "rb"));
-    targetfile.reset(fopen(target.c_str(), "wb"));
+	sourcefile.reset(fopen(source.c_str(), "rb"));
+	targetfile.reset(fopen(target.c_str(), "wb"));
 #endif
 	if (!sourcefile) {
 		errorstream << source << ": can't open for reading: "


### PR DESCRIPTION
When compiling on a system other than Linux, you get the warning:
```
[ 72%] Building CXX object src/CMakeFiles/luanti.dir/filesys.cpp.o
.../luanti/src/filesys.cpp:516:1: warning: unused label 'fallback' [-Wunused-label]
  516 | fallback:
```

Fix this by using an `#else` instead of a goto.

Add compact, short information about your PR for easier understanding:

- Goal: reduce compiler warnings
- How does the PR work?: recompiled without issue 

I was unsure if I should have guarded the goto label with another `#ifdef` instead as I recall back in the day the `#else` not being as supported as the standard `#ifdef`. However I think it is a non-issue these days.

## To do

This PR is  Ready for Review.
