### PR TITLE
Fix documentation for the official Docker image after project rename

### DIFF
--- a/doc/docker_server.md
+++ b/doc/docker_server.md
@@ -4,22 +4,25 @@ We provide Luanti server Docker images using the GitHub container registry.
 
 Images are built on each commit and available using the following tag scheme:
 
-* `ghcr.io/minetest/minetest:master` (latest build)
-* `ghcr.io/minetest/minetest:<tag>` (specific Git tag)
-* `ghcr.io/minetest/minetest:latest` (latest Git tag, which is the stable release)
+* `ghcr.io/luanti-org/luanti:master` (latest build)
+* `ghcr.io/luanti-org/luanti:<tag>` (specific Git tag)
+* `ghcr.io/luanti-org/luanti:latest` (latest Git tag, which is the stable release)
 
-See [here](https://github.com/minetest/minetest/pkgs/container/minetest) for all available tags.
+See [here](https://github.com/luanti-org/luanti/pkgs/container/luanti) for all available tags.
+
+Versions released before the project was renamed are available with the same tag scheme at `ghcr.io/minetest/minetest`.
+See [here](https://github.com/orgs/minetest/packages/container/package/minetest) for all available tags.
 
 For a quick test you can easily run:
 
 ```shell
-docker run ghcr.io/minetest/minetest:master
+docker run ghcr.io/luanti-org/luanti:master
 ```
 
 To use it in a production environment, you should use volumes bound to the Docker host to persist data and modify the configuration:
 
 ```shell
-docker create -v /home/minetest/data/:/var/lib/minetest/ -v /home/minetest/conf/:/etc/minetest/ ghcr.io/minetest/minetest:master
+docker create -v /home/minetest/data/:/var/lib/minetest/ -v /home/minetest/conf/:/etc/minetest/ ghcr.io/luanti-org/luanti:master
 ```
 
 You may also want to use [Docker Compose](https://docs.docker.com/compose):
@@ -29,7 +32,7 @@ You may also want to use [Docker Compose](https://docs.docker.com/compose):
 version: "2"
 services:
   minetest_server:
-    image: ghcr.io/minetest/minetest:master
+    image: ghcr.io/luanti-org/luanti:master
     restart: always
     networks:
       - default


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Update the official Docker image documentation after the rename

## To do

This PR is a Ready for Review.

- [x] Reference `ghcr.io/luanti-org/luanti` instead of `ghcr.io/minetest/minetest` in commands.
- [x] Mention the older versions of the image at `ghcr.io/minetest/minetest`
- [x] Fix the link to available tags for `ghcr.io/minetest/minetest`, was broken since the repository no longer lives in the minetest org.

## How to test

Read, check no links are dead unlike previously.