### PR TITLE
Lua get_biome_data: calc heat and humidity only once

### DIFF
--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -552,24 +552,33 @@ int ModApiMapgen::l_get_biome_data(lua_State *L)
 	if (!biomegen)
 		return 0;
 
-	const Biome *biome = biomegen->calcBiomeAtPoint(pos);
-	if (!biome || biome->index == OBJDEF_INVALID_INDEX)
-		return 0;
-
-	lua_newtable(L);
-
-	lua_pushinteger(L, biome->index);
-	lua_setfield(L, -2, "biome");
-
 	if (biomegen->getType() == BIOMEGEN_ORIGINAL) {
 		float heat = ((BiomeGenOriginal*) biomegen)->calcHeatAtPoint(pos);
 		float humidity = ((BiomeGenOriginal*) biomegen)->calcHumidityAtPoint(pos);
+		const Biome *biome = ((BiomeGenOriginal*) biomegen)->calcBiomeFromNoise(heat, humidity, pos);
+		if (!biome || biome->index == OBJDEF_INVALID_INDEX)
+			return 0;
+
+		lua_newtable(L);
+
+		lua_pushinteger(L, biome->index);
+		lua_setfield(L, -2, "biome");
 
 		lua_pushnumber(L, heat);
 		lua_setfield(L, -2, "heat");
 
 		lua_pushnumber(L, humidity);
 		lua_setfield(L, -2, "humidity");
+
+	} else {
+		const Biome *biome = biomegen->calcBiomeAtPoint(pos);
+		if (!biome || biome->index == OBJDEF_INVALID_INDEX)
+			return 0;
+
+		lua_newtable(L);
+
+		lua_pushinteger(L, biome->index);
+		lua_setfield(L, -2, "biome");
 	}
 
 	return 1;


### PR DESCRIPTION
At every call to `l_get_biome_data()`, the lua API for getting the biome at a position, heat and humidity are computed twice: once inside `calcBiomeAtPoint`, and then again below to return exact heat and humidity.

Because of the perlin noises, this function is fairly expensive, and shows up in flamegraphs.

See, e.g., <https://codeberg.org/mineclonia/mineclonia/pulls/2681#issuecomment-2650068>
> have you any idea whether it is possible to cache the results of biome tests (core.get_biome_data) when it is likely to be called repetitively with closely adjacent positions? core.get_biome_data is suboptimal and evaluates biome noise four times per call, and currently occupies multiple milliseconds of a globalstep with thousands of loaded Minecraft chunks.

Computing them once each is enough. It makes the function roughly twice as fast (well, there is also a y blending noise additionally, it could potentially even be left out. For example with the valley mapgen, biomes are not exact anyway.