### PR TITLE
COSOperator: Use NSPasteboardTypeString instead of NSStringPboardType

### DIFF
--- a/irr/src/COSOperator.cpp
+++ b/irr/src/COSOperator.cpp
@@ -97,8 +97,8 @@ void COSOperator::copyToClipboard(const c8 *text) const
 	if ((text != NULL) && (strlen(text) > 0)) {
 		str = [NSString stringWithCString:text encoding:NSUTF8StringEncoding];
 		board = [NSPasteboard generalPasteboard];
-		[board declareTypes:[NSArray arrayWithObject:NSStringPboardType] owner:NSApp];
-		[board setString:str forType:NSStringPboardType];
+		[board declareTypes:[NSArray arrayWithObject:NSPasteboardTypeString] owner:NSApp];
+		[board setString:str forType:NSPasteboardTypeString];
 	}
 
 #elif defined(_IRR_COMPILE_WITH_X11_DEVICE_)
@@ -155,7 +155,7 @@ const c8 *COSOperator::getTextFromClipboard() const
 	char *result = 0;
 
 	board = [NSPasteboard generalPasteboard];
-	str = [board stringForType:NSStringPboardType];
+	str = [board stringForType:NSPasteboardTypeString];
 
 	if (str != nil)
 		result = (char *)[str cStringUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
According to https://developer.apple.com/documentation/appkit/nsstringpboardtype?language=objc we can replace it with NSPasteboardTypeString:

> In apps that adopt App Sandbox, use an NSURL object, a bookmark, or a
> filename pasteboard type instead. In a nonsandboxed app, you can also
> use the NSPasteboardTypeString pasteboard type.

Add compact, short information about your PR for easier understanding:

- Goal of the PR: remove a deprecation warning 
- How does the PR work? use newer type; test if pasting text into chat console still works (as expected)

<img width="1259" alt="Screenshot 2025-01-25 at 1 10 51 PM" src="https://github.com/user-attachments/assets/2921370f-9c54-4970-8215-529b484f0f60" />


This PR is Ready for Review.

## How to test

I assume just pasting text from the OS clipboard anywhere would be a sufficient test.
