### PR TITLE
Optimize add_area_node_boxes in collision code

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -234,6 +234,15 @@ static bool add_area_node_boxes(const v3s16 min, const v3s16 max, IGameDef *game
 			block = last_block;
 		}
 
+		if (!block) {
+			aabb3f box = getNodeBox(p, BS);
+			v3s16 p2(bp.X * MAP_BLOCKSIZE + MAP_BLOCKSIZE - 1, p.Y, p.Z);
+			box.addInternalBox(getNodeBox(p2, BS));
+			cinfo.emplace_back(true, 0, p, box);
+			p.X = p2.X; // skip ahead
+			continue;
+		}
+
 		bool is_position_valid = !!block;
 		MapNode n = block ? block->getNodeNoCheck(relpos) : MapNode(CONTENT_IGNORE);
 
@@ -268,6 +277,7 @@ static bool add_area_node_boxes(const v3s16 min, const v3s16 max, IGameDef *game
 			cinfo.emplace_back(true, 0, p, box);
 		}
 	}
+
 	return any_position_valid;
 }
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -243,10 +243,16 @@ static bool add_area_node_boxes(const v3s16 min, const v3s16 max, IGameDef *game
 			continue;
 		}
 
-		bool is_position_valid = !!block;
-		MapNode n = block ? block->getNodeNoCheck(relpos) : MapNode(CONTENT_IGNORE);
+		if (block->isAir() && !nodedef->get(CONTENT_AIR).walkable) {
+			any_position_valid = true;
+			v3s16 p2(bp.X * MAP_BLOCKSIZE + MAP_BLOCKSIZE - 1, p.Y, p.Z);
+			p.X = p2.X; // skip ahead
+			continue;
+		}
 
-		if (is_position_valid && n.getContent() != CONTENT_IGNORE) {
+		MapNode n = block->getNodeNoCheck(relpos);
+
+		if (n.getContent() != CONTENT_IGNORE) {
 			// Object collides into walkable nodes
 
 			any_position_valid = true;


### PR DESCRIPTION
probably(?) nobody has a perf problem with collision in the real world but I did this anyway

this PR is essentially just three simple optimizations. nothing complex.

## References

relates to #15227

somewhat addresses the root cause of #15208: the "load" is now 16² not 16³

## To do

This PR is Ready for Review.

## How to test

I used a very unscientific benchmark by letting the client perform collisions in any direction:
```diff
diff --git a/src/client/client.cpp b/src/client/client.cpp
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -22,6 +22,8 @@
 #include "client/mesh_generator_thread.h"
 #include "client/particles.h"
 #include "client/localplayer.h"
+#include "collision.h"
+#include "content_cao.h"
 #include "util/auth.h"
 #include "util/directiontables.h"
 #include "util/pointedthing.h"
@@ -550,6 +552,16 @@ void Client::step(float dtime)
 		{
 			counter = 0.0;
 			sendPlayerPos();
+
+			ScopeProfiler sp(g_profiler, "collide test", SPT_AVG, PRECISION_MICRO);
+			v3f pos = player->getPosition();
+			for (auto dir : g_6dirs) {
+				v3f speed;
+				collisionMoveSimple(&m_env, this,
+					player->getCollisionbox(), 0, 0.25f,
+					&pos, &speed, v3f(dir.X, dir.Y, dir.Z) * 200 * BS,
+					player->getCAO());
+			}
 		}
 	}
 
```
(keep position and world the same ofc)
this showed 0-60% faster times