### PR TITLE
PauseMenuScripting: resolve absolute 'builtin' path before substring check

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -773,7 +773,7 @@ int ScriptApiSecurity::sl_g_loadfile(lua_State *L)
 		std::string path = readParam<std::string>(L, 1);
 		const std::string *contents = script->getClient()->getModFile(path);
 		if (!contents) {
-			std::string error_msg = "Coudln't find script called: " + path;
+			std::string error_msg = "Couldn't find script called: " + path;
 			lua_pushnil(L);
 			lua_pushstring(L, error_msg.c_str());
 			return 2;

--- a/src/script/scripting_pause_menu.cpp
+++ b/src/script/scripting_pause_menu.cpp
@@ -50,7 +50,7 @@ void PauseMenuScripting::initializeModApi(lua_State *L, int top)
 
 void PauseMenuScripting::loadBuiltin()
 {
-	loadMod(Client::getBuiltinLuaPath() + DIR_DELIM "init.lua", BUILTIN_MOD_NAME);
+	loadScript(Client::getBuiltinLuaPath() + DIR_DELIM "init.lua");
 	checkSetByBuiltin();
 }
 

--- a/src/script/scripting_pause_menu.cpp
+++ b/src/script/scripting_pause_menu.cpp
@@ -50,7 +50,7 @@ void PauseMenuScripting::initializeModApi(lua_State *L, int top)
 
 void PauseMenuScripting::loadBuiltin()
 {
-	loadMod(getClient()->getBuiltinLuaPath() + DIR_DELIM "init.lua", BUILTIN_MOD_NAME);
+	loadMod(Client::getBuiltinLuaPath() + DIR_DELIM "init.lua", BUILTIN_MOD_NAME);
 	checkSetByBuiltin();
 }
 
@@ -65,9 +65,6 @@ bool PauseMenuScripting::checkPathInternal(const std::string &abs_path, bool wri
 	if (write_required)
 		return false;
 
-	if (write_allowed)
-		*write_allowed = false;
-
-	std::string path_builtin = fs::AbsolutePathPartial(getClient()->getBuiltinLuaPath());
-	return fs::PathStartsWith(abs_path, path_builtin);
+	std::string path_builtin = fs::AbsolutePath(Client::getBuiltinLuaPath());
+	return !path_builtin.empty() && fs::PathStartsWith(abs_path, path_builtin);
 }

--- a/src/script/scripting_pause_menu.cpp
+++ b/src/script/scripting_pause_menu.cpp
@@ -50,7 +50,7 @@ void PauseMenuScripting::initializeModApi(lua_State *L, int top)
 
 void PauseMenuScripting::loadBuiltin()
 {
-	loadScript(porting::path_share + DIR_DELIM "builtin" DIR_DELIM "init.lua");
+	loadMod(getClient()->getBuiltinLuaPath() + DIR_DELIM "init.lua", BUILTIN_MOD_NAME);
 	checkSetByBuiltin();
 }
 
@@ -60,9 +60,14 @@ bool PauseMenuScripting::checkPathInternal(const std::string &abs_path, bool wri
 	// NOTE: The pause menu env is on the same level of trust as the mainmenu env.
 	// However, since it doesn't need anything else at the moment, there's no
 	// reason to give it access to anything else.
+	// See also: `MainMenuScripting::mayModifyPath` for similar, but less restricted checks.
 
 	if (write_required)
 		return false;
-	std::string path_share = fs::AbsolutePath(porting::path_share);
-	return !path_share.empty() && fs::PathStartsWith(abs_path, path_share + DIR_DELIM "builtin");
+
+	if (write_allowed)
+		*write_allowed = false;
+
+	std::string path_builtin = fs::AbsolutePathPartial(getClient()->getBuiltinLuaPath());
+	return fs::PathStartsWith(abs_path, path_builtin);
 }


### PR DESCRIPTION
In 99% of the cases, this behaviour is identical to before. With this commit, it is again possible to have 'builtin' a symlink that e.g. points to the engine source directory, which is helpful for development purposes.

This was changed in eeb6cab4c43 and immediately broke my build setup. Hence this PR.

I also think that `getClient()->getBuiltinLuaPath()` is safer, as `RUN_IN_PLACE=1` builds might have `path_user` and `path_share` in the same place, which can result in erroneously picking the wrong path [during development].

## To do

This PR is Ready for Review.

## How to test

1. Read the code
2. The settings menu must work
