### PR TITLE
Clamp client-sent movement speed control

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -30,6 +30,8 @@
 #include "util/srp.h"
 #include "clientdynamicinfo.h"
 
+#include <algorithm>
+
 void Server::handleCommand_Deprecated(NetworkPacket* pkt)
 {
 	infostream << "Server: " << toServerCommandTable[pkt->getCommand()].name
@@ -468,7 +470,9 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 		*pkt >> bits;
 
 	if (pkt->getRemainingBytes() >= 8) {
-		*pkt >> player->control.movement_speed;
+		f32 movement_speed;
+		*pkt >> movement_speed;
+		player->control.movement_speed = std::clamp(movement_speed, 0.0f, 1.0f);
 		*pkt >> player->control.movement_direction;
 	} else {
 		player->control.movement_speed = 0.0f;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -472,6 +472,8 @@ void Server::process_PlayerPos(RemotePlayer *player, PlayerSAO *playersao,
 	if (pkt->getRemainingBytes() >= 8) {
 		f32 movement_speed;
 		*pkt >> movement_speed;
+		if (movement_speed != movement_speed) // NaN
+			movement_speed = 0.0f;
 		player->control.movement_speed = std::clamp(movement_speed, 0.0f, 1.0f);
 		*pkt >> player->control.movement_direction;
 	} else {


### PR DESCRIPTION
Results in the `movement_x` and `movement_y` fields of `player:get_player_control()` being safe to use (otherwise users would need to compute the length as `(x^2 + y^2)^0.5` and clamp that to 1 themselves).

Prompted by https://github.com/luanti-org/luanti/pull/14348#issuecomment-2614840171.
