### PR TITLE
Fix sounds playing for objects not sent to the client

### DIFF
--- a/rebuild
+++ b/rebuild
@@ -1,0 +1,5 @@
+#!/bin/bash
+touch src/version.cpp
+git update-index --refresh
+cmake -B build -DRUN_IN_PLACE=TRUE -DUSE_SDL2=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja #-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld"
+cmake --build build --parallel $(($(nproc) + 1))

--- a/rebuild
+++ b/rebuild
@@ -1,5 +1,0 @@
-#!/bin/bash
-touch src/version.cpp
-git update-index --refresh
-cmake -B build -DRUN_IN_PLACE=TRUE -DUSE_SDL2=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja #-DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld"
-cmake --build build --parallel $(($(nproc) + 1))

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -852,6 +852,7 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 			m_sound->playSoundAt(client_id, spec, pos, vel);
 			break;
 		}
+		[[fallthrough]];
 	}
 	default:
 		// Unknown SoundLocation, instantly remove sound

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -846,13 +846,12 @@ void Client::handleCommand_PlaySound(NetworkPacket* pkt)
 		break;
 	case SoundLocation::Object: {
 		ClientActiveObject *cao = m_env.getActiveObject(object_id);
-		v3f vel(0.0f);
 		if (cao) {
 			pos = cao->getPosition() * (1.0f/BS);
-			vel = cao->getVelocity() * (1.0f/BS);
+			v3f vel = cao->getVelocity() * (1.0f/BS);
+			m_sound->playSoundAt(client_id, spec, pos, vel);
+			break;
 		}
-		m_sound->playSoundAt(client_id, spec, pos, vel);
-		break;
 	}
 	default:
 		// Unknown SoundLocation, instantly remove sound


### PR DESCRIPTION
~~This PR fixes sounds playing for objects not sent to the client.~~ Does not fix, but make sense anyways.

## To do

This PR is Ready for Review.

## How to test

1. Try to reproduce the bug[^1] without this patch. Sounds from nonexistent objects should be played at full volume.
2. Apply this patch and try again. This should not happen again.
3. Confirm that normal object sounds aren't affected by this patch.

[^1]: I don't know how to reproduce this bug reliably. However, if you're a regular player of LinuxForks, 1F616EMO Survival Server, or any servers with extensive Advtrains network, you should have encountered this at least once.
