### PR TITLE
Tweak main menu server list behavior

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -109,7 +109,7 @@ local function load()
 	local change_keys = {
 		query_text = "Controls",
 		requires = {
-			touch_controls = false,
+			keyboard_mouse = true,
 		},
 		get_formspec = function(self, avail_w)
 			local btn_w = math.min(avail_w, 3)
@@ -377,6 +377,9 @@ local function check_requirements(name, requires)
 			local required_setting = get_setting_info(req_key)
 			if required_setting == nil then
 				core.log("warning", "Unknown setting " .. req_key .. " required by " .. (name or "???"))
+			elseif required_setting.type ~= "bool" then
+				core.log("warning", "Setting " .. req_key .. " of type " .. required_setting.type ..
+					" used as requirement by " .. (name or "???") .. ", only bool is allowed")
 			end
 			local actual_value = core.settings:get_bool(req_key,
 				required_setting and core.is_yes(required_setting.default))

--- a/builtin/mainmenu/dlg_clients_list.lua
+++ b/builtin/mainmenu/dlg_clients_list.lua
@@ -21,7 +21,7 @@ local function clients_list_formspec(dialogdata)
 		"size[6,9.5]",
 		TOUCH_GUI and "padding[0.01,0.01]" or "",
 		"hypertext[0,0;6,1.5;;<global margin=5 halign=center valign=middle>",
-			fgettext("This is the list of clients connected to\n$1",
+			fgettext("Players connected to\n$1",
 				"<b>" .. core.hypertext_escape(servername) .. "</b>") .. "]",
 		"textlist[0.5,1.5;5,6.8;;" .. fmt_formspec_list(clients_list) .. "]",
 		"button[1.5,8.5;3,0.8;quit;OK]"

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -419,20 +419,37 @@ local function search_server_list(input)
 		return
 	end
 
+	local current_server = find_selected_server()
+
 	table.sort(search_result, function(a, b)
 		return a.points > b.points
 	end)
 	menudata.search_result = search_result
 
-	-- Find first compatible server (favorite or public)
-	for _, server in ipairs(search_result) do
-		if is_server_protocol_compat(server.proto_min, server.proto_max) then
-			set_selected_server(server)
-			return
-		end
-	end
-	-- If no compatible server found, clear selection
-	set_selected_server(nil)
+	-- Keep current selection if it's in search results
+    local found_current = false
+    if current_server then
+        for _, server in ipairs(search_result) do
+            if server.address == current_server.address and
+               server.port == current_server.port then
+                found_current = true
+                break
+            end
+        end
+    end
+
+    -- If current selection isn't in results, select first compatible server
+    if not found_current then
+        -- Find first compatible server (favorite or public)
+        for _, server in ipairs(search_result) do
+            if is_server_protocol_compat(server.proto_min, server.proto_max) then
+                set_selected_server(server)
+                return
+            end
+        end
+        -- If no compatible server found, clear selection
+        set_selected_server(nil)
+    end
 end
 local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.te_name then

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -391,15 +391,14 @@ local function matches_query(server, query)
 	return name_matches and 50 or description_matches and 0
 end
 
-local pre_search_selection = nil
-
-local function search_server_list(input)
+local function search_server_list(input, tabdata)
 	menudata.search_result = nil
 	if #serverlistmgr.servers < 2 then
 		return
 	end
 
-	pre_search_selection = pre_search_selection or find_selected_server()
+
+	tabdata.pre_search_selection = tabdata.pre_search_selection or find_selected_server()
 
 	-- setup the search query
 	local query = parse_search_input(input)
@@ -450,6 +449,7 @@ local function search_server_list(input)
 	-- If no compatible server found, clear selection
 	set_selected_server(nil)
 end
+
 local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.te_name then
 		gamedata.playername = fields.te_name
@@ -487,7 +487,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			end
 			if event.type == "CHG" then
 				set_selected_server(server)
-				pre_search_selection = nil
+				tabdata.pre_search_selection = nil
 				return true
 			end
 		end
@@ -531,16 +531,16 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.btn_mp_clear then
 		tabdata.search_for = ""
 		menudata.search_result = nil
-		if pre_search_selection then
-			set_selected_server(pre_search_selection)
-			pre_search_selection = nil
+		if tabdata.pre_search_selection then
+			set_selected_server(tabdata.pre_search_selection)
+			tabdata.pre_search_selection = nil
 		end
 		return true
 	end
 
 	if fields.btn_mp_search or fields.key_enter_field == "te_search" then
 		tabdata.search_for = fields.te_search
-		search_server_list(fields.te_search)
+		search_server_list(fields.te_search, tabdata)
 		return true
 	end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -391,10 +391,16 @@ local function matches_query(server, query)
 	return name_matches and 50 or description_matches and 0
 end
 
+local pre_search_selection = nil
+
 local function search_server_list(input)
 	menudata.search_result = nil
 	if #serverlistmgr.servers < 2 then
 		return
+	end
+
+	if not pre_search_selection then
+		pre_search_selection = find_selected_server()
 	end
 
 	-- setup the search query
@@ -427,29 +433,29 @@ local function search_server_list(input)
 	menudata.search_result = search_result
 
 	-- Keep current selection if it's in search results
-    local found_current = false
-    if current_server then
-        for _, server in ipairs(search_result) do
-            if server.address == current_server.address and
-               server.port == current_server.port then
-                found_current = true
-                break
-            end
-        end
-    end
+	local found_current = false
+	if current_server then
+	    for _, server in ipairs(search_result) do
+			if server.address == current_server.address and
+				server.port == current_server.port then
+				found_current = true
+				break
+			end
+		end
+	end
 
-    -- If current selection isn't in results, select first compatible server
-    if not found_current then
-        -- Find first compatible server (favorite or public)
-        for _, server in ipairs(search_result) do
-            if is_server_protocol_compat(server.proto_min, server.proto_max) then
-                set_selected_server(server)
-                return
-            end
-        end
-        -- If no compatible server found, clear selection
-        set_selected_server(nil)
-    end
+	-- If current selection isn't in results, select first compatible server
+	if not found_current then
+		-- Find first compatible server (favorite or public)
+		for _, server in ipairs(search_result) do
+			if is_server_protocol_compat(server.proto_min, server.proto_max) then
+				set_selected_server(server)
+				return
+			end
+		end
+		-- If no compatible server found, clear selection
+		set_selected_server(nil)
+	end
 end
 local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.te_name then
@@ -531,7 +537,10 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.btn_mp_clear then
 		tabdata.search_for = ""
 		menudata.search_result = nil
-		set_selected_server(nil)
+		if pre_search_selection then
+			set_selected_server(pre_search_selection)
+			pre_search_selection = nil
+		end
 		return true
 	end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -399,9 +399,7 @@ local function search_server_list(input)
 		return
 	end
 
-	if not pre_search_selection then
-		pre_search_selection = find_selected_server()
-	end
+	pre_search_selection = pre_search_selection or find_selected_server()
 
 	-- setup the search query
 	local query = parse_search_input(input)
@@ -433,29 +431,24 @@ local function search_server_list(input)
 	menudata.search_result = search_result
 
 	-- Keep current selection if it's in search results
-	local found_current = false
 	if current_server then
 	    for _, server in ipairs(search_result) do
 			if server.address == current_server.address and
-				server.port == current_server.port then
-				found_current = true
-				break
+					server.port == current_server.port then
+				return
 			end
 		end
 	end
 
-	-- If current selection isn't in results, select first compatible server
-	if not found_current then
-		-- Find first compatible server (favorite or public)
-		for _, server in ipairs(search_result) do
-			if is_server_protocol_compat(server.proto_min, server.proto_max) then
-				set_selected_server(server)
-				return
-			end
+	-- Find first compatible server (favorite or public)
+	for _, server in ipairs(search_result) do
+		if is_server_protocol_compat(server.proto_min, server.proto_max) then
+			set_selected_server(server)
+			return
 		end
-		-- If no compatible server found, clear selection
-		set_selected_server(nil)
 	end
+	-- If no compatible server found, clear selection
+	set_selected_server(nil)
 end
 local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.te_name then

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -484,11 +484,9 @@ local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.btn_delete_favorite then
 		local idx = core.get_table_index("servers")
 		if not idx then return end
-		local server = tabdata.lookup[idx]
-		if not server then return end
 
-		serverlistmgr.delete_favorite(server)
-		set_selected_server(server)
+		serverlistmgr.delete_favorite(tabdata.lookup[idx])
+		set_selected_server(tabdata.lookup[idx+1])
 		return true
 	end
 

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -487,6 +487,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 			end
 			if event.type == "CHG" then
 				set_selected_server(server)
+				pre_search_selection = nil
 				return true
 			end
 		end

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -190,10 +190,10 @@ local function get_formspec(tabview, name, tabdata)
 			local max_clients = 5
 			if #clients_list > max_clients then
 				retval = retval .. "tooltip[btn_view_clients;" ..
-						fgettext("Clients:\n$1", table.concat(clients_list, "\n", 1, max_clients)) .. "\n..." .. "]"
+						fgettext("Players:\n$1", table.concat(clients_list, "\n", 1, max_clients)) .. "\n..." .. "]"
 			else
 				retval = retval .. "tooltip[btn_view_clients;" ..
-						fgettext("Clients:\n$1", table.concat(clients_list, "\n")) .. "]"
+						fgettext("Players:\n$1", table.concat(clients_list, "\n")) .. "]"
 			end
 			retval = retval .. "style[btn_view_clients;padding=6]"
 			retval = retval .. "image_button[4.5,1.3;0.5,0.5;" .. core.formspec_escape(defaulttexturedir ..


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

This PR resolves some buggy behavior when searching or removing favorites.

- Goal of the PR
Provide a more intuitive user experience when searching or deleting favorites. 
- How does the PR work?
It saves the current selection before searching so that it can be reused if a user should clear the search bar.
When searching, it now also checks if the selected server is among the search results; if not, it will select the first compatible.
Instead of keeping the selection when removing a server from favorites, now the selection will be moved to the server below.
- Does it resolve any reported issue?
Fixes #15545
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
2.3 hopefully

## Preview
This PR:
![image](https://github.com/user-attachments/assets/204349a4-3243-4697-925e-32c7430c8d1f)
Current Master:
![image](https://github.com/user-attachments/assets/f9cfe908-d4f6-4171-ab3a-20556b11b13b)

## How to test

Search servers (maybe the same as in the issue), remove favorites.
Notice how the selection is kept when clearing the search.
