### PR TITLE
[no sq]  Enable ipv6_server by default 

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -835,11 +835,12 @@ protocol_version_min (Protocol version minimum) int 1 1 65535
 #    Files that are not present will be fetched the usual way.
 remote_media (Remote media) string
 
-#    Enable/disable running an IPv6 server.
+#    Enable IPv6 support for server.
+#    Note that clients will be able to connect with both IPv4 and IPv6.
 #    Ignored if bind_address is set.
 #
 #    Requires: enable_ipv6
-ipv6_server (IPv6 server) bool false
+ipv6_server (IPv6 server) bool true
 
 [*Server Security]
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -422,7 +422,7 @@ void set_default_settings()
 
 	// Network
 	settings->setDefault("enable_ipv6", "true");
-	settings->setDefault("ipv6_server", "false");
+	settings->setDefault("ipv6_server", "true");
 	settings->setDefault("max_packets_per_iteration", "1024");
 	settings->setDefault("port", "30000");
 	settings->setDefault("strict_protocol_version_checking", "false");

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -128,7 +128,8 @@ void UDPSocket::Bind(Address addr)
 		if (setsockopt(m_handle, IPPROTO_IPV6, IPV6_V6ONLY,
 				reinterpret_cast<char *>(&value), sizeof(value)) != 0) {
 			auto errmsg = SOCKET_ERR_STR(LAST_SOCKET_ERR());
-			errorstream << "Failed to disable V6ONLY: " << errmsg << std::endl;
+			errorstream << "Failed to disable V6ONLY: " << errmsg
+				<< "\nTry disabling ipv6_server to fix this." << std::endl;
 			throw SocketException(errmsg);
 		}
 	}

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -87,24 +87,15 @@ bool UDPSocket::init(bool ipv6, bool noExceptions)
 	m_handle = socket(m_addr_family, SOCK_DGRAM, IPPROTO_UDP);
 
 	if (m_handle < 0) {
-		if (noExceptions) {
+		auto msg = std::string("Failed to create socket: ") +
+			SOCKET_ERR_STR(LAST_SOCKET_ERR());
+		verbosestream << msg << std::endl;
+		if (noExceptions)
 			return false;
-		}
-
-		throw SocketException(std::string("Failed to create socket: error ") +
-				      SOCKET_ERR_STR(LAST_SOCKET_ERR()));
+		throw SocketException(msg);
 	}
 
 	setTimeoutMs(0);
-
-	if (m_addr_family == AF_INET6) {
-		// Allow our socket to accept both IPv4 and IPv6 connections
-		// required on Windows:
-		// https://msdn.microsoft.com/en-us/library/windows/desktop/bb513665(v=vs.85).aspx
-		int value = 0;
-		setsockopt(m_handle, IPPROTO_IPV6, IPV6_V6ONLY,
-				reinterpret_cast<char *>(&value), sizeof(value));
-	}
 
 	return true;
 }
@@ -127,6 +118,19 @@ void UDPSocket::Bind(Address addr)
 				"Socket and bind address families do not match";
 		errorstream << "Bind failed: " << errmsg << std::endl;
 		throw SocketException(errmsg);
+	}
+
+	if (m_addr_family == AF_INET6) {
+		// Allow our socket to accept both IPv4 and IPv6 connections
+		// required on Windows:
+		// <https://msdn.microsoft.com/en-us/library/windows/desktop/bb513665(v=vs.85).aspx>
+		int value = 0;
+		if (setsockopt(m_handle, IPPROTO_IPV6, IPV6_V6ONLY,
+				reinterpret_cast<char *>(&value), sizeof(value)) != 0) {
+			auto errmsg = SOCKET_ERR_STR(LAST_SOCKET_ERR());
+			errorstream << "Failed to disable V6ONLY: " << errmsg << std::endl;
+			throw SocketException(errmsg);
+		}
 	}
 
 	int ret = 0;


### PR DESCRIPTION
This makes it so that if you have IPv6 and enable server announcements you automatically arrive at a configuration that actually works (domain or not).
Previously if you had IPv6 configured on your server and maybe even a domain, the server list would reject you because the server can't actually be reached over IPv6 *by default*.

Implications:
* the IP returned in `get_player_information` will look like `::ffff:1.2.3.4` by default. I think most mods handle this. 

Note: this PR was written on a train.

## To do

This PR is a Ready for Review.

