### PR TITLE
[NO SQUASH] Server: Correct client inventory prediction for IDropAction and IMoveAction

### DIFF
--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -96,37 +96,36 @@ int InvRef::l_set_size(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
+	Inventory *inv;
+	InventoryList *list;
 
 	int newsize = luaL_checknumber(L, 3);
-	if (newsize < 0) {
-		lua_pushboolean(L, false);
-		return 1;
+	if (newsize < 0)
+		goto fail;
+
+	inv = getinv(L, ref);
+	if (!inv)
+		goto fail;
+
+	if (newsize == 0) {
+		inv->deleteList(listname);
+		goto done;
 	}
 
-	Inventory *inv = getinv(L, ref);
-	if(inv == NULL){
-		lua_pushboolean(L, false);
-		return 1;
-	}
-	if(newsize == 0){
-		inv->deleteList(listname);
-		reportInventoryChange(L, ref);
-		lua_pushboolean(L, true);
-		return 1;
-	}
-	InventoryList *list = inv->getList(listname);
-	if(list){
+	list = inv->getList(listname);
+	if (list) {
 		list->setSize(newsize);
 	} else {
 		list = inv->addList(listname, newsize);
 		if (!list)
-		{
-			lua_pushboolean(L, false);
-			return 1;
-		}
+			goto fail;
 	}
+done:
 	reportInventoryChange(L, ref);
 	lua_pushboolean(L, true);
+	return 1;
+fail:
+	lua_pushboolean(L, false);
 	return 1;
 }
 
@@ -136,27 +135,27 @@ int InvRef::l_set_width(lua_State *L)
 	NO_MAP_LOCK_REQUIRED;
 	InvRef *ref = checkObject<InvRef>(L, 1);
 	const char *listname = luaL_checkstring(L, 2);
+	Inventory *inv;
+	InventoryList *list;
 
 	int newwidth = luaL_checknumber(L, 3);
-	if (newwidth < 0) {
-		lua_pushboolean(L, false);
-		return 1;
-	}
+	if (newwidth < 0)
+		goto fail;
 
-	Inventory *inv = getinv(L, ref);
-	if(inv == NULL){
-		lua_pushboolean(L, false);
-		return 1;
-	}
-	InventoryList *list = inv->getList(listname);
-	if(list){
-		list->setWidth(newwidth);
-	} else {
-		lua_pushboolean(L, false);
-		return 1;
-	}
+	inv = getinv(L, ref);
+	if (!inv)
+		goto fail;
+
+	list = inv->getList(listname);
+	if (!list)
+		goto fail;
+
+	list->setWidth(newwidth);
 	reportInventoryChange(L, ref);
 	lua_pushboolean(L, true);
+	return 1;
+fail:
+	lua_pushboolean(L, false);
 	return 1;
 }
 


### PR DESCRIPTION
Fixes the root cause of #15728.
The first commit is a cleanup of messy code that I encountered.

Details (same issue): https://github.com/luanti-org/luanti/issues/15728#issuecomment-2628859482


## To do

This PR is Ready for Review.

## How to test

1. 
```diff
diff --git a/src/network/serverpackethandler.cpp b/src/network/serverpackethandler.cpp
index 86c18725f..45fa8fa13 100644
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -711,7 +711,8 @@ void Server::handleCommand_InventoryAction(NetworkPacket* pkt)
 		da->from_inv.applyCurrentPlayer(player->getName());
 
 		m_inventory_mgr->setInventoryModified(da->from_inv);
-		mark_player_inv_list_dirty(da->from_inv, da->from_list);
+		//mark_player_inv_list_dirty(da->from_inv, da->from_list);
+		return;
 
 		/*
 			Disable dropping items out of craftpreview
```
2. Drop an item. The inventory remains in an outdated state.
3. Uncomment the `mark_player_inv_list_dirty` line. The client prediction is now reverted.