### PR TITLE
Fix overrideable hand ToolCapabilities and range

### DIFF
--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -75,8 +75,8 @@ public:
 			Client *client, ClientEnvironment *env);
 
 	// If returns true, punch will not be sent to the server
-	virtual bool directReportPunch(v3f dir, const ItemStack *punchitem = nullptr,
-		float time_from_last_punch = 1000000) { return false; }
+	virtual bool directReportPunch(v3f dir, const ItemStack *punchitem,
+		const ItemStack *hand_item, float time_from_last_punch = 1000000) { return false; }
 
 protected:
 	// Used for creating objects based on type

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1861,11 +1861,11 @@ void GenericCAO::processMessage(const std::string &data)
 /* \pre punchitem != NULL
  */
 bool GenericCAO::directReportPunch(v3f dir, const ItemStack *punchitem,
-		float time_from_last_punch)
+	const ItemStack *hand_item, float time_from_last_punch)
 {
 	assert(punchitem);	// pre-condition
 	const ToolCapabilities *toolcap =
-			&punchitem->getToolCapabilities(m_client->idef());
+			&punchitem->getToolCapabilities(m_client->idef(), hand_item->name);
 	PunchDamageResult result = getPunchDamage(
 			m_armor_groups,
 			toolcap,

--- a/src/client/content_cao.h
+++ b/src/client/content_cao.h
@@ -269,8 +269,8 @@ public:
 
 	void processMessage(const std::string &data) override;
 
-	bool directReportPunch(v3f dir, const ItemStack *punchitem=NULL,
-			float time_from_last_punch=1000000) override;
+	bool directReportPunch(v3f dir, const ItemStack *punchitem,
+			const ItemStack *hand_item, float time_from_last_punch=1000000) override;
 
 	std::string debugInfoText() override;
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -590,7 +590,7 @@ protected:
 	void handlePointingAtNode(const PointedThing &pointed,
 			const ItemStack &selected_item, const ItemStack &hand_item, f32 dtime);
 	void handlePointingAtObject(const PointedThing &pointed, const ItemStack &playeritem,
-			const v3f &player_position, bool show_debug);
+			const ItemStack &hand_item, const v3f &player_position, bool show_debug);
 	void handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 			const ItemStack &selected_item, const ItemStack &hand_item, f32 dtime);
 	void updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
@@ -2937,14 +2937,14 @@ void Game::updateCamera(f32 dtime)
 		- Is it a usable item?
 		- Can it point to liquids?
 	*/
-	ItemStack playeritem;
+	ItemStack playeritem, hand;
 	{
-		ItemStack selected, hand;
+		ItemStack selected;
 		playeritem = player->getWieldedItem(&selected, &hand);
 	}
 
 	ToolCapabilities playeritem_toolcap =
-		playeritem.getToolCapabilities(itemdef_manager);
+		playeritem.getToolCapabilities(itemdef_manager, hand.name);
 
 	if (wasKeyPressed(KeyType::CAMERA_MODE)) {
 		GenericCAO *playercao = player->getCAO();
@@ -3047,8 +3047,8 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	ItemStack selected_item, hand_item;
 	const ItemStack &tool_item = player->getWieldedItem(&selected_item, &hand_item);
 
-	const ItemDefinition &selected_def = selected_item.getDefinition(itemdef_manager);
-	f32 d = getToolRange(selected_item, hand_item, itemdef_manager);
+	const ItemDefinition &selected_def = tool_item.getDefinition(itemdef_manager);
+	f32 d = getToolRange(tool_item, hand_item, itemdef_manager);
 
 	core::line3d<f32> shootline;
 
@@ -3162,7 +3162,7 @@ void Game::processPlayerInteraction(f32 dtime, bool show_hud)
 	} else if (pointed.type == POINTEDTHING_OBJECT) {
 		v3f player_position  = player->getPosition();
 		bool basic_debug_allowed = client->checkPrivilege("debug") || (player->hud_flags & HUD_FLAG_BASIC_DEBUG);
-		handlePointingAtObject(pointed, tool_item, player_position,
+		handlePointingAtObject(pointed, tool_item, hand_item, player_position,
 				m_game_ui->m_flags.show_basic_debug && basic_debug_allowed);
 	} else if (isKeyDown(KeyType::DIG)) {
 		// When button is held down in air, show continuous animation
@@ -3578,8 +3578,8 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	}
 }
 
-void Game::handlePointingAtObject(const PointedThing &pointed,
-		const ItemStack &tool_item, const v3f &player_position, bool show_debug)
+void Game::handlePointingAtObject(const PointedThing &pointed, const ItemStack &tool_item,
+		const ItemStack &hand_item, const v3f &player_position, bool show_debug)
 {
 	std::wstring infotext = unescape_translate(
 		utf8_to_wide(runData.selected_object->infoText()));
@@ -3617,7 +3617,7 @@ void Game::handlePointingAtObject(const PointedThing &pointed,
 			v3f dir = (objpos - player_position).normalize();
 
 			bool disable_send = runData.selected_object->directReportPunch(
-					dir, &tool_item, runData.time_from_last_punch);
+					dir, &tool_item, &hand_item, runData.time_from_last_punch);
 			runData.time_from_last_punch = 0;
 
 			if (!disable_send)
@@ -3638,18 +3638,19 @@ void Game::handleDigging(const PointedThing &pointed, const v3s16 &nodepos,
 	ClientMap &map = client->getEnv().getClientMap();
 	MapNode n = map.getNode(nodepos);
 	const auto &features = nodedef_manager->get(n);
+	const ItemStack &tool_item = selected_item.name.empty() ? hand_item : selected_item;
 
 	// NOTE: Similar piece of code exists on the server side for
 	// cheat detection.
 	// Get digging parameters
 	DigParams params = getDigParams(features.groups,
-			&selected_item.getToolCapabilities(itemdef_manager),
-			selected_item.wear);
+			&tool_item.getToolCapabilities(itemdef_manager, hand_item.name),
+			tool_item.wear);
 
 	// If can't dig, try hand
 	if (!params.diggable) {
 		params = getDigParams(features.groups,
-				&hand_item.getToolCapabilities(itemdef_manager));
+				&hand_item.getToolCapabilities(itemdef_manager, hand_item.name));
 	}
 
 	if (!params.diggable) {

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -103,16 +103,18 @@ struct ItemStack
 
 	// Get tool digging properties, or those of the hand if not a tool
 	const ToolCapabilities& getToolCapabilities(
-			const IItemDefManager *itemdef) const
+			const IItemDefManager *itemdef, const std::string &hand) const
 	{
 		const ToolCapabilities *item_cap =
 			itemdef->get(name).tool_capabilities;
 
-		if (item_cap == NULL)
-			// Fall back to the hand's tool capabilities
+		// Fall back to the hand's tool capabilities
+		if (item_cap == nullptr)
+			item_cap = itemdef->get(hand).tool_capabilities;
+		if (item_cap == nullptr)
 			item_cap = itemdef->get("").tool_capabilities;
 
-		assert(item_cap != NULL);
+		assert(item_cap != nullptr);
 		return metadata.getToolCapabilities(*item_cap); // Check for override
 	}
 

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -852,8 +852,8 @@ void Server::handleCommand_PlayerItem(NetworkPacket* pkt)
 bool Server::checkInteractDistance(RemotePlayer *player, const f32 d, const std::string &what)
 {
 	ItemStack selected_item, hand_item;
-	player->getWieldedItem(&selected_item, &hand_item);
-	f32 max_d = BS * getToolRange(selected_item, hand_item, m_itemdef);
+	const ItemStack &tool_item = player->getWieldedItem(&selected_item, &hand_item);
+	f32 max_d = BS * getToolRange(tool_item, hand_item, m_itemdef);
 
 	// Cube diagonal * 1.5 for maximal supported node extents:
 	// sqrt(3) * 1.5 ≅ 2.6
@@ -1061,7 +1061,7 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 		ItemStack selected_item, hand_item;
 		ItemStack tool_item = playersao->getWieldedItem(&selected_item, &hand_item);
 		ToolCapabilities toolcap =
-				tool_item.getToolCapabilities(m_itemdef);
+				tool_item.getToolCapabilities(m_itemdef, hand_item.name);
 		v3f dir = (pointed_object->getBasePosition() -
 				(playersao->getBasePosition() + playersao->getEyeOffset())
 					).normalize();
@@ -1118,16 +1118,16 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 			// Get player's wielded item
 			// See also: Game::handleDigging
 			ItemStack selected_item, hand_item;
-			player->getWieldedItem(&selected_item, &hand_item);
+			ItemStack &tool_item = player->getWieldedItem(&selected_item, &hand_item);
 
 			// Get diggability and expected digging time
 			DigParams params = getDigParams(m_nodedef->get(n).groups,
-					&selected_item.getToolCapabilities(m_itemdef),
-					selected_item.wear);
+					&tool_item.getToolCapabilities(m_itemdef, hand_item.name),
+					tool_item.wear);
 			// If can't dig, try hand
 			if (!params.diggable) {
 				params = getDigParams(m_nodedef->get(n).groups,
-					&hand_item.getToolCapabilities(m_itemdef));
+					&hand_item.getToolCapabilities(m_itemdef, hand_item.name));
 			}
 			// If can't dig, ignore dig
 			if (!params.diggable) {

--- a/src/script/lua_api/l_item.cpp
+++ b/src/script/lua_api/l_item.cpp
@@ -327,7 +327,7 @@ int LuaItemStack::l_get_tool_capabilities(lua_State *L)
 	LuaItemStack *o = checkObject<LuaItemStack>(L, 1);
 	ItemStack &item = o->m_stack;
 	const ToolCapabilities &prop =
-		item.getToolCapabilities(getGameDef(L)->idef());
+		item.getToolCapabilities(getGameDef(L)->idef(), "");
 	push_tool_capabilities(L, prop);
 	return 1;
 }


### PR DESCRIPTION
Solves #15740

To avoid confusion, notice:
`selected_item` is the item selected in the hotbar, (`""` if empty)
`hand_item` is the overwritten hand (`""` by default).
`tool_item`/`playeritem`/`punchitem` is what should be used for `getToolCapabilities` (`getWieldedItem` returns this)

`getToolCapabilities`  needs both `tool_item` and `hand_item` as a fallback.


## To do

Ready for Review.

## How to test

- Like explained in the issue, try e.g.
``` lua

core.register_item("default:hand", {
	type = "none",
	range = 20,
	tool_capabilities = {
		groupcaps = {
			crumbly = {times={[1] = 0.1, [2] = 0.1, [3] = 0.1}, uses = 0, maxlevel = 1},
			cracky = {times={[1] = 0.1, [2] = 0.1, [3] = 0.1}, uses = 0, maxlevel = 1},
		}
	}
})

core.register_chatcommand('hand', {
	func = function(name, param)
		local player = core.get_player_by_name(name)

		local handitem
		if param == 'reset' then
			handitem = ''
		else
			handitem = 'default:hand'
		end

		local inv = player:get_inventory()
		inv:set_size('hand', 1)
		inv:set_stack('hand', 1, ItemStack(handitem))
	end
})

```
- See that it works while wleiding nothinig, and while e.g. a node
