### PR TITLE
Change main website domain to `www.luanti.org`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Contributions are welcome! Here's how you can help:
    the work, to avoid disappointment.
 
    You may also benefit from discussing on our IRC development channel
-   [#minetest-dev](http://www.minetest.net/irc/). Note that a proper IRC client
+   [#minetest-dev](http://www.luanti.org/irc/). Note that a proper IRC client
    is required to speak on this channel.
 
 3. Start coding!
@@ -77,7 +77,7 @@ a stable release is on the way.
 
 1. Do a quick search on GitHub to check if the issue has already been reported.
 2. Is it an issue with the Minetest *engine*? If not, report it
-   [elsewhere](http://www.minetest.net/development/#reporting-issues).
+   [elsewhere](http://www.luanti.org/development/#reporting-issues).
 3. [Open an issue](https://github.com/luanti-org/luanti/issues/new) and describe
    the issue you are having - you could include:
      - Error logs (check the bottom of the `debug.txt` file).
@@ -111,7 +111,7 @@ translated by editing a `.tr` text file. See
 ## Donations
 
 If you'd like to monetarily support Luanti development, you can find donation
-methods on [our website](http://www.minetest.net/development/#donate).
+methods on [our website](http://www.luanti.org/development/#donate).
 
 # Maintaining
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -766,7 +766,7 @@ enable_split_login_register (Enable split login/register) bool true
 
 #    URL to JSON file which provides information about the newest Luanti release.
 #    If this is empty the engine will never check for updates.
-update_information_url (Update information URL) string https://www.minetest.net/release_info.json
+update_information_url (Update information URL) string https://www.luanti.org/release_info.json
 
 [*Server]
 

--- a/doc/client_lua_api.md
+++ b/doc/client_lua_api.md
@@ -5,7 +5,7 @@ Luanti Lua Client Modding API Reference 5.11.0
 it's now called `core` due to the renaming of Luanti (formerly Minetest).
 `minetest` will keep existing as an alias, so that old code won't break.
 
-* More information at <http://www.minetest.net/>
+* More information at <http://www.luanti.org/>
 * Developer Wiki: <https://dev.luanti.org/>
 
 Introduction

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -751,7 +751,7 @@
 #    URL to JSON file which provides information about the newest Luanti release.
 #    If this is empty the engine will never check for updates.
 #    type: string
-# update_information_url = https://www.minetest.net/release_info.json
+# update_information_url = https://www.luanti.org/release_info.json
 
 ## Server
 

--- a/misc/net.minetest.minetest.metainfo.xml
+++ b/misc/net.minetest.minetest.metainfo.xml
@@ -103,13 +103,13 @@
     <launchable type="desktop-id">net.minetest.minetest.desktop</launchable>
     <screenshots>
         <screenshot type="default">
-            <image>https://www.minetest.net/media/gallery/1.jpg</image>
+            <image>https://www.luanti.org/media/gallery/1.jpg</image>
         </screenshot>
         <screenshot>
-            <image>https://www.minetest.net/media/gallery/3.jpg</image>
+            <image>https://www.luanti.org/media/gallery/3.jpg</image>
         </screenshot>
         <screenshot>
-            <image>https://www.minetest.net/media/gallery/5.jpg</image>
+            <image>https://www.luanti.org/media/gallery/5.jpg</image>
         </screenshot>
     </screenshots>
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -404,7 +404,7 @@ void set_default_settings()
 #endif
 
 #if ENABLE_UPDATE_CHECKER
-	settings->setDefault("update_information_url", "https://www.minetest.net/release_info.json");
+	settings->setDefault("update_information_url", "https://www.luanti.org/release_info.json");
 #else
 	settings->setDefault("update_information_url", "");
 #endif


### PR DESCRIPTION
The server automatically redirects to the new name, so why not move it on the engine side too?

This seems like a natural checklist item for the renaming. Presumably the old domain was left in for 5.10's release, at an earlier stage of the renaming; but 5.11 does not need to do the same.

## How to test

Backdate to 5.9.1, remove common.conf (or the relevant lines `update_last_known`) from your cache directory, and replace the setting in builtin/settingtypes.conf. It will still find there is an update.

Alternatively, remove the last checked date from common.conf as in method 1, then use wireshark to verify the HTTP request goes through. I just didn't get wireshark working today.