### PR TITLE
Don't save `load_mod_* = false` lines in `world.mt`

### DIFF
--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -299,7 +299,7 @@ local function handle_buttons(this, fields)
 						worldfile:set("load_mod_" .. mod.name, mod.virtual_path)
 						was_set[mod.name] = true
 					elseif not was_set[mod.name] then
-						worldfile:set("load_mod_" .. mod.name, "false")
+						worldfile:remove("load_mod_" .. mod.name)
 					end
 				elseif mod.enabled then
 					gamedata.errormessage = fgettext_ne("Failed to enable mo" ..

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -154,7 +154,7 @@ void ModConfiguration::addModsFromConfig(
 					candidates[pair->first].emplace_back(mod.virtual_path);
 				}
 			} else {
-				conf.setBool("load_mod_" + mod.name, false);
+				conf.remove("load_mod_" + mod.name);
 			}
 		}
 	}

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -140,8 +140,6 @@ void ModConfiguration::addModsFromConfig(
 	 *
 	 * Alternative candidates for a modname are stored in `candidates`,
 	 * and used in an error message later.
-	 *
-	 * If not enabled, add `load_mod_modname = false` to world.mt
 	 */
 	for (const auto &modPath : modPaths) {
 		std::vector<ModSpec> addon_mods_in_path = flattenMods(getModsInPath(modPath.second, modPath.first));


### PR DESCRIPTION
Fixes #11423.

## How to test

Look at `world.mt` after configuring a world.
