### PR TITLE
Rename Minetest to Luanti in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -76,7 +76,7 @@ If you experience an issue, we would like to know the details - especially when
 a stable release is on the way.
 
 1. Do a quick search on GitHub to check if the issue has already been reported.
-2. Is it an issue with the Minetest *engine*? If not, report it
+2. Is it an issue with the Luanti *engine*? If not, report it
    [elsewhere](http://www.luanti.org/development/#reporting-issues).
 3. [Open an issue](https://github.com/luanti-org/luanti/issues/new) and describe
    the issue you are having - you could include:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Contributions are welcome! Here's how you can help:
    the work, to avoid disappointment.
 
    You may also benefit from discussing on our IRC development channel
-   [#minetest-dev](http://www.luanti.org/irc/). Note that a proper IRC client
+   [#luanti-dev](http://www.luanti.org/irc/). Note that a proper IRC client
    is required to speak on this channel.
 
 3. Start coding!


### PR DESCRIPTION
- Rename Minetest to Luanti in CONTRIBUTING.md #15322 
- Simple edits in CONTRIBUTING.md
- Does it resolve any reported issue? No, Just help rename Minetest to Luanti #15322 
- The minetest.conf.example stays with the same name since in Github it has that name it is also a template that is used in Luanti Games, and on Weblate (on the link) they still do not update project and component to the new name Luanti
This PR is a Ready for Review.

(Finished status)