### PR TITLE
GUI inventory list: Do not render clipped slots at all

### DIFF
--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -85,6 +85,10 @@ void GUIInventoryList::draw()
 		v2s32 p((i % m_geom.X) * m_slot_spacing.X,
 				(i / m_geom.X) * m_slot_spacing.Y);
 		core::rect<s32> rect = imgrect + base_pos + p;
+
+		if (!getAbsoluteClippingRect().isRectCollided(rect))
+			continue; // out of (parent) clip area
+
 		const ItemStack &orig_item = ilist->getItem(item_i);
 		ItemStack item = orig_item;
 


### PR DESCRIPTION
~~Fixes~~ degrades #6905 to low priority.

You can apply the following diff to stress test "inventory in scroll container" (warning: murders your inventory):

```diff
diff --git a/games/devtest/mods/testformspec/formspec.lua b/games/devtest/mods/testformspec/formspec.lua
index 29014f1f2..759dfcea9 100644
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -264,7 +264,16 @@ local style_fs = [[
 	container_end[]
 ]]
 
+local n = 4000
+core.register_on_joinplayer(function(player)
+	player:get_inventory():set_size("main", 8 * n)
+	for i = 1, 8 * n do
+		player:get_inventory():set_stack("main", i, "basenodes:dirt")
+	end
+end)
+
 local scroll_fs =
+	--[[
 	"button[8.5,1;4,1;outside;Outside of container]"..
 	"box[1,1;8,6;#00aa]"..
 	"scroll_container[1,1;8,6;scrbar;vertical]"..
@@ -300,9 +309,10 @@ local scroll_fs =
 	"scrollbar[7.5,0;0.3,4;vertical;scrbar;0]"..
 	"scrollbar[8,0;0.3,4;vertical;scrbarhmmm;0]"..
 	"dropdown[0,6;2;hmdrpdwnnn;Outside,of,container;1]"..
+	--]]
 	"scroll_container[0,8;10,4;scrbar420;vertical;0.1;2]"..
 		"button[0.5,0.5;10,1;;Container with padding=2]"..
-		"list[current_player;main;0,5;8,4;]"..
+		"list[current_player;main;0,5;8," .. n .. ";]"..
 	"scroll_container_end[]"..
 	"scrollbar[10.1,8;0.5,4;vertical;scrbar420;0]"..
 	-- Buttons for scale comparison
```

then `/test_formspec` and go on the `ScrollC` tab.

Now compile a release / relwithdebinfo build (ideally without LTO to save yourself some time).
Without the fix, scrolling should be choppy. If scrolling isn't choppy, try increasing `n`.
With the fix, scrolling should be smooth no matter the `n`.
