### PR TITLE
Add an enable_relative_mouse_mode setting

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -141,6 +141,12 @@ invert_mouse (Invert mouse) bool false
 #    Requires: keyboard_mouse
 mouse_sensitivity (Mouse sensitivity) float 0.2 0.001 10.0
 
+#    Use relative mouse mode for camera mouse movement.
+#    This is generally preferable, but on some setups it causes issues.
+#
+#    Requires: keyboard_mouse
+enable_relative_mouse_mode (Enable relative mouse mode) bool true
+
 #    Enable mouse wheel (scroll) for item selection in hotbar.
 #
 #    Requires: keyboard_mouse

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -289,6 +289,10 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 		SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 		SDL_SetHint(SDL_HINT_MOUSE_TOUCH_EVENTS, "0");
 
+		// For sdl2-compat. We have a setting enable_relative_mouse_mode, so
+		// we wan't SDL to interfere here.
+		SDL_SetHint("SDL_MOUSE_EMULATE_WARP_WITH_RELATIVE", "0");
+
 #if defined(SDL_HINT_APP_NAME)
 		SDL_SetHint(SDL_HINT_APP_NAME, "Luanti");
 #endif

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -754,7 +754,6 @@ private:
 	f32  m_repeat_dig_time;
 	f32  m_cache_cam_smoothing;
 
-	bool m_enable_relative_mode = false;
 	bool m_invert_mouse;
 	bool m_enable_hotbar_mouse_wheel;
 	bool m_invert_hotbar_mouse_wheel;
@@ -898,15 +897,6 @@ bool Game::startup(bool *kill,
 	}
 
 	m_first_loop_after_window_activation = true;
-
-	// In principle we could always enable relative mouse mode, but it causes weird
-	// bugs on some setups (e.g. #14932), so we enable it only when it's required.
-	// That is: on Wayland or Android, because it does not support mouse repositioning
-#ifdef __ANDROID__
-	m_enable_relative_mode = true;
-#else
-	m_enable_relative_mode = device->isUsingWayland();
-#endif
 
 	g_client_translations->clear();
 
@@ -2360,7 +2350,7 @@ void Game::updateCameraDirection(CameraOrientation *cam, float dtime)
 	this results in duplicated input. To avoid that, we don't enable relative
 	mouse mode if we're in touchscreen mode. */
 	if (cur_control) {
-		cur_control->setRelativeMode(m_enable_relative_mode &&
+		cur_control->setRelativeMode(g_settings->getBool("enable_relative_mouse_mode") &&
 			!g_touchcontrols && !isMenuActive());
 	}
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -350,6 +350,7 @@ void set_default_settings()
 	settings->setDefault("enable_hotbar_mouse_wheel", "true");
 	settings->setDefault("invert_hotbar_mouse_wheel", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");
+	settings->setDefault("enable_relative_mouse_mode", "true");
 	settings->setDefault("repeat_place_time", "0.25");
 	settings->setDefault("repeat_dig_time", "0.0");
 	settings->setDefault("safe_dig_and_place", "false");


### PR DESCRIPTION
Fixes #15761.

Users who are affected by #14932 (cc @Elysian-dev) can just change the setting.

This also has the advantage that users with exotic input devices can try out different modes. (E.g. using a graphics tablet, it spins violently for me when using SDL and relative mode.)

(Should I remove the `isUsingWayland()`?)

## To do

This PR is a Ready for Review.

## How to test

See #15761.

I've tested on sdl2, and on sdl2-compat.
