### PR TITLE
Implement metadata-aware version of InvRef:remove_item()

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -45,6 +45,7 @@ core.features = {
 	abm_without_neighbors = true,
 	biome_weights = true,
 	particle_blend_clip = true,
+	remove_item_match_meta = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7850,12 +7850,15 @@ An `InvRef` is a reference to an inventory.
   can be fully added to the list
 * `contains_item(listname, stack, [match_meta])`: returns `true` if
   the stack of items can be fully taken from the list.
-  If `match_meta` is `true`, the stack's metadata should also match
-  (default: `false`). The method ignores wear.
+    * If `match_meta` is `true`, item metadata is also considered when comparing
+      items. Otherwise, only the items' names are compared. Default: `false`
+    * The method ignores wear.
 * `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
   list, returns the items that were actually removed (as an `ItemStack`).
-  If `match_meta` is `true`, an item is only taken when the metadata also matches
-  (available since feature `remove_item_match_meta`). The method ignores wear.
+    * If `match_meta` is `true` (available since feature `remove_item_match_meta`),
+      item metadata is also considered when comparing items. Otherwise, only the
+      items' names are compared. Default: `false`
+    * The method ignores wear.
 * `get_location()`: returns a location compatible to
   `core.get_inventory(location)`.
     * returns `{type="undefined"}` in case location is not known

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5689,6 +5689,8 @@ Utilities
       biome_weights = true,
       -- Particles can specify a "clip" blend mode (5.11.0)
       particle_blend_clip = true,
+      -- The `match_meta` optional parameter is available for `InvRef:remove_item()` (5.12.0)
+      remove_item_match_meta = true,
   }
   ```
 
@@ -7853,7 +7855,7 @@ An `InvRef` is a reference to an inventory.
 * `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
   list, returns the items that were actually removed (as an `ItemStack`).
   If `match_meta` is `true`, an item is only taken when the metadata also matches
-  (since version `5.12.0`).
+  (available since feature `remove_item_match_meta`).
 * `get_location()`: returns a location compatible to
   `core.get_inventory(location)`.
     * returns `{type="undefined"}` in case location is not known

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7852,8 +7852,8 @@ An `InvRef` is a reference to an inventory.
   (default: `false`).
 * `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
   list, returns the items that were actually removed (as an `ItemStack`).
-  If `match_meta` is `true`, the function also takes metadata into account
-  (since version `5.11.0`).
+  If `match_meta` is `true`, an item is only taken when the metadata also matches
+  (since version `5.12.0`).
 * `get_location()`: returns a location compatible to
   `core.get_inventory(location)`.
     * returns `{type="undefined"}` in case location is not known

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7851,11 +7851,11 @@ An `InvRef` is a reference to an inventory.
 * `contains_item(listname, stack, [match_meta])`: returns `true` if
   the stack of items can be fully taken from the list.
   If `match_meta` is false, only the items' names are compared
-  (default: `false`).
+  (default: `false`). The function ignores wear.
 * `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
   list, returns the items that were actually removed (as an `ItemStack`).
   If `match_meta` is `true`, an item is only taken when the metadata also matches
-  (available since feature `remove_item_match_meta`).
+  (available since feature `remove_item_match_meta`). The function ignores wear.
 * `get_location()`: returns a location compatible to
   `core.get_inventory(location)`.
     * returns `{type="undefined"}` in case location is not known

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7850,11 +7850,10 @@ An `InvRef` is a reference to an inventory.
   the stack of items can be fully taken from the list.
   If `match_meta` is false, only the items' names are compared
   (default: `false`).
-* `remove_item(listname, stack)`: take as many items as specified from the
-  list, returns the items that were actually removed (as an `ItemStack`)
-  -- note that any item metadata is ignored, so attempting to remove a specific
-  unique item this way will likely remove the wrong one -- to do that use
-  `set_stack` with an empty `ItemStack`.
+* `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
+  list, returns the items that were actually removed (as an `ItemStack`).
+  If `match_meta` is `true`, the function also takes metadata into account
+  (since version `5.11.0`).
 * `get_location()`: returns a location compatible to
   `core.get_inventory(location)`.
     * returns `{type="undefined"}` in case location is not known

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7851,13 +7851,13 @@ An `InvRef` is a reference to an inventory.
 * `contains_item(listname, stack, [match_meta])`: returns `true` if
   the stack of items can be fully taken from the list.
     * If `match_meta` is `true`, item metadata is also considered when comparing
-      items. Otherwise, only the items' names are compared. Default: `false`
+      items. Otherwise, only the items names are compared. Default: `false`
     * The method ignores wear.
 * `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
   list, returns the items that were actually removed (as an `ItemStack`).
     * If `match_meta` is `true` (available since feature `remove_item_match_meta`),
       item metadata is also considered when comparing items. Otherwise, only the
-      items' names are compared. Default: `false`
+      items names are compared. Default: `false`
     * The method ignores wear.
 * `get_location()`: returns a location compatible to
   `core.get_inventory(location)`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7850,7 +7850,7 @@ An `InvRef` is a reference to an inventory.
   can be fully added to the list
 * `contains_item(listname, stack, [match_meta])`: returns `true` if
   the stack of items can be fully taken from the list.
-  If `match_meta` is false, only the items' names are compared
+  If `match_meta` is `true`, the stack's metadata should also match
   (default: `false`). The method ignores wear.
 * `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
   list, returns the items that were actually removed (as an `ItemStack`).

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7851,11 +7851,11 @@ An `InvRef` is a reference to an inventory.
 * `contains_item(listname, stack, [match_meta])`: returns `true` if
   the stack of items can be fully taken from the list.
   If `match_meta` is false, only the items' names are compared
-  (default: `false`). The function ignores wear.
+  (default: `false`). The method ignores wear.
 * `remove_item(listname, stack, [match_meta])`: take as many items as specified from the
   list, returns the items that were actually removed (as an `ItemStack`).
   If `match_meta` is `true`, an item is only taken when the metadata also matches
-  (available since feature `remove_item_match_meta`). The function ignores wear.
+  (available since feature `remove_item_match_meta`). The method ignores wear.
 * `get_location()`: returns a location compatible to
   `core.get_inventory(location)`.
     * returns `{type="undefined"}` in case location is not known

--- a/games/devtest/mods/unittests/inventory.lua
+++ b/games/devtest/mods/unittests/inventory.lua
@@ -1,10 +1,11 @@
-
-local item_with_meta = ItemStack({name = "air", meta = {test = "abc"}})
+local function get_stack_with_meta(count)
+	return ItemStack({name = "air", count = count, meta = {test = "abc"}})
+end
 
 local test_list = {
 	ItemStack("air"),
 	ItemStack(""),
-	ItemStack(item_with_meta),
+	ItemStack(get_stack_with_meta(1)),
 }
 
 local function compare_lists(a, b)
@@ -34,12 +35,12 @@ local function test_inventory()
 	assert(not inv:set_width("test", -1))
 
 	inv:set_stack("test", 1, "air")
-	inv:set_stack("test", 3, item_with_meta)
+	inv:set_stack("test", 3, get_stack_with_meta(1))
 	assert(not inv:is_empty("test"))
 	assert(compare_lists(inv:get_list("test"), test_list))
 
 	assert(inv:add_item("test", "air") == ItemStack())
-	assert(inv:add_item("test", item_with_meta) == ItemStack())
+	assert(inv:add_item("test", get_stack_with_meta(1)) == ItemStack())
 	assert(inv:get_stack("test", 1) == ItemStack("air 2"))
 
 	assert(inv:room_for_item("test", "air 99"))
@@ -48,15 +49,25 @@ local function test_inventory()
 	inv:set_stack("test", 2, "")
 
 	assert(inv:contains_item("test", "air"))
+	assert(inv:contains_item("test", "air 4"))
+	assert(not inv:contains_item("test", "air 5"))
 	assert(not inv:contains_item("test", "air 99"))
-	assert(inv:contains_item("test", item_with_meta, true))
+	assert(inv:contains_item("test", "air 2", true))
+	assert(not inv:contains_item("test", "air 3", true))
+	assert(inv:contains_item("test", get_stack_with_meta(2), true))
+	assert(not inv:contains_item("test", get_stack_with_meta(3), true))
 
 	-- Items should be removed in reverse and combine with first stack removed
-	assert(inv:remove_item("test", "air") == item_with_meta)
-	item_with_meta:set_count(2)
-	assert(inv:remove_item("test", "air 2") == item_with_meta)
+	assert(inv:remove_item("test", "air") == get_stack_with_meta(1))
+	assert(inv:remove_item("test", "air 2") == get_stack_with_meta(2))
 	assert(inv:remove_item("test", "air") == ItemStack("air"))
 	assert(inv:is_empty("test"))
+	inv:set_stack("test", 1, "air 3")
+	inv:set_stack("test", 3, get_stack_with_meta(2))
+	assert(inv:remove_item("test", "air 4", true) == ItemStack("air 3"))
+	inv:set_stack("test", 1, "air 3")
+	assert(inv:remove_item("test", get_stack_with_meta(3), true) == get_stack_with_meta(2))
+	assert(inv:remove_item("test", "air 3", true) == ItemStack("air 3"))
 
 	-- Failure of set_list(s) should not change inventory
 	local before = inv:get_list("test")

--- a/games/devtest/mods/unittests/inventory.lua
+++ b/games/devtest/mods/unittests/inventory.lua
@@ -62,6 +62,7 @@ local function test_inventory()
 	assert(inv:remove_item("test", "air 2") == get_stack_with_meta(2))
 	assert(inv:remove_item("test", "air") == ItemStack("air"))
 	assert(inv:is_empty("test"))
+
 	inv:set_stack("test", 1, "air 3")
 	inv:set_stack("test", 3, get_stack_with_meta(2))
 	assert(inv:remove_item("test", "air 4", true) == ItemStack("air 3"))

--- a/games/devtest/mods/unittests/inventory.lua
+++ b/games/devtest/mods/unittests/inventory.lua
@@ -68,6 +68,7 @@ local function test_inventory()
 	inv:set_stack("test", 1, "air 3")
 	assert(inv:remove_item("test", get_stack_with_meta(3), true) == get_stack_with_meta(2))
 	assert(inv:remove_item("test", "air 3", true) == ItemStack("air 3"))
+	assert(inv:is_empty("test"))
 
 	-- Failure of set_list(s) should not change inventory
 	local before = inv:get_list("test")

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -697,7 +697,7 @@ ItemStack InventoryList::removeItem(const ItemStack &item, bool match_meta)
 {
 	ItemStack removed;
 	for (auto i = m_items.rbegin(); i != m_items.rend(); ++i) {
-		if (i->name == item.name && (!match_meta || (i->metadata == item.metadata))) {
+		if (i->name == item.name && (!match_meta || i->metadata == item.metadata)) {
 			u32 still_to_remove = item.count - removed.count;
 			ItemStack leftover = removed.addItem(i->takeItem(still_to_remove),
 					m_itemdef);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -693,11 +693,11 @@ bool InventoryList::containsItem(const ItemStack &item, bool match_meta) const
 	return false;
 }
 
-ItemStack InventoryList::removeItem(const ItemStack &item)
+ItemStack InventoryList::removeItem(const ItemStack &item, bool match_meta)
 {
 	ItemStack removed;
 	for (auto i = m_items.rbegin(); i != m_items.rend(); ++i) {
-		if (i->name == item.name) {
+		if (i->name == item.name && (!match_meta || (i->metadata == item.metadata))) {
 			u32 still_to_remove = item.count - removed.count;
 			ItemStack leftover = removed.addItem(i->takeItem(still_to_remove),
 					m_itemdef);

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -262,7 +262,7 @@ public:
 	// If not as many items exist as requested, removes as
 	// many as possible.
 	// Returns the items that were actually removed.
-	ItemStack removeItem(const ItemStack &item);
+	ItemStack removeItem(const ItemStack &item, bool match_meta);
 
 	// Takes some items from a slot.
 	// If there are not enough, takes as many as it can.

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -330,7 +330,7 @@ int InvRef::l_contains_item(lua_State *L)
 	return 1;
 }
 
-// remove_item(self, listname, itemstack or itemstring or table or nil) -> itemstack
+// remove_item(self, listname, itemstack or itemstring or table or nil, [match_meta]) -> itemstack
 // Returns the items that were actually removed
 int InvRef::l_remove_item(lua_State *L)
 {
@@ -339,8 +339,11 @@ int InvRef::l_remove_item(lua_State *L)
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
+	bool match_meta = false;
+	if (lua_isboolean(L, 4))
+		match_meta = readParam<bool>(L, 4);
 	if(list){
-		ItemStack removed = list->removeItem(item);
+		ItemStack removed = list->removeItem(item, match_meta);
 		if(!removed.empty())
 			reportInventoryChange(L, ref);
 		LuaItemStack::create(L, removed);

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -319,9 +319,7 @@ int InvRef::l_contains_item(lua_State *L)
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
-	bool match_meta = false;
-	if (lua_isboolean(L, 4))
-		match_meta = readParam<bool>(L, 4);
+	bool match_meta = readParam<bool>(L, 4, false);
 	if (list) {
 		lua_pushboolean(L, list->containsItem(item, match_meta));
 	} else {

--- a/src/script/lua_api/l_inventory.cpp
+++ b/src/script/lua_api/l_inventory.cpp
@@ -339,9 +339,7 @@ int InvRef::l_remove_item(lua_State *L)
 	const char *listname = luaL_checkstring(L, 2);
 	ItemStack item = read_item(L, 3, getServer(L)->idef());
 	InventoryList *list = getlist(L, ref, listname);
-	bool match_meta = false;
-	if (lua_isboolean(L, 4))
-		match_meta = readParam<bool>(L, 4);
+	bool match_meta = readParam<bool>(L, 4, false);
 	if(list){
 		ItemStack removed = list->removeItem(item, match_meta);
 		if(!removed.empty())


### PR DESCRIPTION
This patch adds a third optional parameters to `InvRef:remove_item()` which allows to remove only items with the same metadata as in the `ItemStack` passed in the second parameter.

## To do

This PR is Ready for Review.

## How to test

1. Install the mod with the following init.lua: [init.txt](https://github.com/user-attachments/files/18726083/init.txt)
2. Place "Node with formspec"
3. Right-click the node. It'll display a formspec with an inventory filled with "default:stone" with 2 different "description" metadata parameters.
4. Click the buttons to see how it works with or without the third parameters. The button "Delete (all meta)" calls `remove_item()` without the third parameter (will remove stacks with any metadata). The button "Delete (only meta 2)" calls `remove_item()` with the third parameter set to `true` (will remove stacks with metadata `description == "Stone 2"`).
