### PR TITLE
Bump OARS content rating to 1.1

### DIFF
--- a/misc/net.minetest.minetest.metainfo.xml
+++ b/misc/net.minetest.minetest.metainfo.xml
@@ -25,11 +25,30 @@
         <display_length compare="ge">360</display_length>
     </requires>
 
-    <content_rating type="oars-1.0">
+    <content_rating type="oars-1.1">
         <content_attribute id="violence-cartoon">mild</content_attribute>
         <content_attribute id="violence-fantasy">mild</content_attribute>
+        <content_attribute id="violence-realistic">none</content_attribute>
+        <content_attribute id="violence-bloodshed">none</content_attribute>
+        <content_attribute id="violence-sexual">none</content_attribute>
+        <content_attribute id="violence-desecration">none</content_attribute>
+        <content_attribute id="violence-slavery">none</content_attribute>
+        <content_attribute id="drugs-alcohol">none</content_attribute>
+        <content_attribute id="drugs-narcotics">none</content_attribute>
+        <content_attribute id="drugs-tobacco">none</content_attribute>
+        <content_attribute id="sex-nudity">none</content_attribute>
+        <content_attribute id="sex-themes">none</content_attribute>
+        <content_attribute id="language-profanity">none</content_attribute>
+        <content_attribute id="language-humor">none</content_attribute>
+        <content_attribute id="language-discrimination">none</content_attribute>
         <content_attribute id="social-chat">intense</content_attribute>
         <content_attribute id="social-info">mild</content_attribute>
+        <content_attribute id="social-audio">none</content_attribute>
+        <content_attribute id="social-location">none</content_attribute>
+        <content_attribute id="social-contacts">none</content_attribute>
+        <content_attribute id="money-purchasing">none</content_attribute>
+        <content_attribute id="money-advertising">none</content_attribute>
+        <content_attribute id="money-gambling">none</content_attribute>
     </content_rating>
 
     <description>


### PR DESCRIPTION
Currently in GNOME Software, the age rating have several categories marked as "unknown".

This notably includes categories added in 1.1 (desecration, slavery, etc), but it seems in the case of GNOME Software the nudity category as a whole is also considered unknown when using OARS 1.0.

![image](https://github.com/user-attachments/assets/180b769f-b120-41d8-a4e2-7ec0feaaee10)


So I did the following:

- [x] Bump OARS version to 1.1
- [x] Explicitly set all available categories to "none"

_Theorically_ the spec defines that if a property isn't there it's considered "none" by both versions of the spec so just bumping the version could be enough, but it seems GNOME Software at least with the 1.0 spec doesn't seem to do that.

The switch to 1.1 may fix this but tbh I prefer an explicit approach. If required I can remove all "none" properties.

I don't know if it matches a goal in the roadmap but it improves app metadata on Linux's software centers.

## To do

This PR is Ready for Review.

## How to test

Read the patch, validate metainfo file. Check if it matches the [OARS 1.1 spec](https://hughsie.github.io/oars).