### PR TITLE
[nosq] Don't use fps_max_unfocused for the pause menu, and a little more

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -257,7 +257,7 @@ fps_max (Maximum FPS) int 60 1 4294967295
 vsync (VSync) bool false
 
 #    Maximum FPS when the window is not focused.
-fps_max_unfocused (FPS when unfocused) int 20 1 4294967295
+fps_max_unfocused (FPS when unfocused) int 10 1 4294967295
 
 #    View distance in nodes.
 viewing_range (Viewing range) int 190 20 4000

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -256,8 +256,8 @@ fps_max (Maximum FPS) int 60 1 4294967295
 #    Vertical screen synchronization. Your system may still force VSync on even if this is disabled.
 vsync (VSync) bool false
 
-#    Maximum FPS when the window is not focused, or when the game is paused.
-fps_max_unfocused (FPS when unfocused or paused) int 20 1 4294967295
+#    Maximum FPS when the window is not focused.
+fps_max_unfocused (FPS when unfocused) int 20 1 4294967295
 
 #    View distance in nodes.
 viewing_range (Viewing range) int 190 20 4000

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2504,7 +2504,7 @@ inline void Game::step(f32 dtime)
 	ZoneScoped;
 
 	if (server) {
-		float fps_max = !device->isWindowFocused() ?
+		float fps_max = !device->isWindowFocused() && simple_singleplayer_mode ?
 				g_settings->getFloat("fps_max_unfocused") :
 				g_settings->getFloat("fps_max");
 		fps_max = std::max(fps_max, 1.0f);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -968,7 +968,7 @@ void Game::run()
 		// Calculate dtime =
 		//    m_rendering_engine->run() from this iteration
 		//  + Sleep time until the wanted FPS are reached
-		draw_times.limit(device, &dtime, g_menumgr.pausesGame());
+		draw_times.limit(device, &dtime);
 
 		framemarker.start();
 
@@ -2504,7 +2504,7 @@ inline void Game::step(f32 dtime)
 	ZoneScoped;
 
 	if (server) {
-		float fps_max = (!device->isWindowFocused() || g_menumgr.pausesGame()) ?
+		float fps_max = !device->isWindowFocused() ?
 				g_settings->getFloat("fps_max_unfocused") :
 				g_settings->getFloat("fps_max");
 		fps_max = std::max(fps_max, 1.0f);

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -34,9 +34,9 @@ void FpsControl::reset()
 	last_time = porting::getTimeUs();
 }
 
-void FpsControl::limit(IrrlichtDevice *device, f32 *dtime, bool assume_paused)
+void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
 {
-	const float fps_limit = (device->isWindowFocused() && !assume_paused)
+	const float fps_limit = device->isWindowFocused()
 			? g_settings->getFloat("fps_max")
 			: g_settings->getFloat("fps_max_unfocused");
 	const u64 frametime_min = 1000000.0f / std::max(fps_limit, 1.0f);

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -45,7 +45,7 @@ struct FpsControl {
 
 	void reset();
 
-	void limit(IrrlichtDevice *device, f32 *dtime, bool assume_paused = false);
+	void limit(IrrlichtDevice *device, f32 *dtime);
 
 	u32 getBusyMs() const { return busy_time / 1000; }
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -243,7 +243,7 @@ void set_default_settings()
 	settings->setDefault("tooltip_show_delay", "400");
 	settings->setDefault("tooltip_append_itemname", "false");
 	settings->setDefault("fps_max", "60");
-	settings->setDefault("fps_max_unfocused", "20");
+	settings->setDefault("fps_max_unfocused", "10");
 	settings->setDefault("viewing_range", "190");
 	settings->setDefault("client_mesh_chunk", "1");
 	settings->setDefault("screen_w", "1024");


### PR DESCRIPTION
Fixes <https://github.com/luanti-org/luanti/issues/8739#issuecomment-653393516>. x)

See commit msgs.

Edit: Fixes #15779.

## To do

This PR is a Ready for Review.

## How to test

* For fps: Look at F5 debug menu.
* For server step time: `/lua core.register_globalstep(core.log)`
* To unfocus, open chat and select other window.
