### PR TITLE
Make tab_about.lua more robust and readable

### DIFF
--- a/builtin/mainmenu/tab_about.lua
+++ b/builtin/mainmenu/tab_about.lua
@@ -17,123 +17,126 @@
 
 
 local function prepare_credits(dest, source)
-	local string = table.concat(source, "\n") .. "\n"
-
-	string = core.hypertext_escape(string)
-	string = string:gsub("%[.-%]", "<gray>%1</gray>")
-
-	table.insert(dest, string)
+    local credit_string = table.concat(source, "\n") .. "\n"
+    credit_string = core.hypertext_escape(credit_string)
+    credit_string = credit_string:gsub("%[.-%]", "<gray>%1</gray>")
+    table.insert(dest, credit_string)
 end
 
 local function get_credits()
-	local f = assert(io.open(core.get_mainmenu_path() .. "/credits.json"))
-	local json = core.parse_json(f:read("*all"))
-	f:close()
-	return json
+    local credits_file = core.get_mainmenu_path() .. "/credits.json"
+    local file, err = io.open(credits_file, "r")
+    if not file then
+        core.log("error", "Could not open credits file: " .. err)
+        return {}
+    end
+    local content = file:read("*all")
+    file:close()
+    return core.parse_json(content) or {}
 end
 
 local function get_renderer_info()
-	local ret = {}
+    local ret = {}
 
-	-- OpenGL version, stripped to just the important part
-	local s1 = core.get_active_renderer()
-	if s1:sub(1, 7) == "OpenGL " then
-		s1 = s1:sub(8)
-	end
-	local m = s1:match("^[%d.]+")
-	if not m then
-		m = s1:match("^ES [%d.]+")
-	end
-	ret[#ret+1] = m or s1
-	-- video driver
-	ret[#ret+1] = core.get_active_driver():lower()
-	-- irrlicht device
-	ret[#ret+1] = core.get_active_irrlicht_device():upper()
+    -- OpenGL version, stripped to just the important part
+    local renderer = core.get_active_renderer()
+    if renderer:sub(1, 7) == "OpenGL " then
+        renderer = renderer:sub(8)
+    end
+    local version_match = renderer:match("^[%d.]+") or renderer:match("^ES [%d.]+")
+    table.insert(ret, version_match or renderer)
+    -- video driver
+    table.insert(ret, core.get_active_driver():lower())
+    -- irrlicht device
+    table.insert(ret, core.get_active_irrlicht_device():upper())
 
-	return table.concat(ret, " / ")
+    return table.concat(ret, " / ")
 end
 
 return {
-	name = "about",
-	caption = fgettext("About"),
+    name = "about",
+    caption = fgettext("About"),
 
-	cbf_formspec = function(tabview, name, tabdata)
-		local logofile = defaulttexturedir .. "logo.png"
-		local version = core.get_version()
+    cbf_formspec = function(tabview, name, tabdata)
+        local logofile = defaulttexturedir .. "logo.png"
+        local version = core.get_version()
 
-		local hypertext = {
-			"<tag name=heading color=#ff0>",
-			"<tag name=gray color=#aaa>",
-		}
+        local hypertext = {
+            "<tag name=heading color=#ff0>",
+            "<tag name=gray color=#aaa>",
+        }
 
-		local credits = get_credits()
+        local credits = get_credits()
 
-		table.insert_all(hypertext, {
-			"<heading>", fgettext_ne("Core Developers"), "</heading>\n",
-		})
-		prepare_credits(hypertext, credits.core_developers)
-		table.insert_all(hypertext, {
-			"\n",
-			"<heading>", fgettext_ne("Core Team"), "</heading>\n",
-		})
-		prepare_credits(hypertext, credits.core_team)
-		table.insert_all(hypertext, {
-			"\n",
-			"<heading>", fgettext_ne("Active Contributors"), "</heading>\n",
-		})
-		prepare_credits(hypertext, credits.contributors)
-		table.insert_all(hypertext, {
-			"\n",
-			"<heading>", fgettext_ne("Previous Core Developers"), "</heading>\n",
-		})
-		prepare_credits(hypertext, credits.previous_core_developers)
-		table.insert_all(hypertext, {
-			"\n",
-			"<heading>", fgettext_ne("Previous Contributors"), "</heading>\n",
-		})
-		prepare_credits(hypertext, credits.previous_contributors)
+        table.insert_all(hypertext, {
+            "<heading>", fgettext_ne("Core Developers"), "</heading>\n",
+        })
+        prepare_credits(hypertext, credits.core_developers or {})
+        table.insert_all(hypertext, {
+            "\n",
+            "<heading>", fgettext_ne("Core Team"), "</heading>\n",
+        })
+        prepare_credits(hypertext, credits.core_team or {})
+        table.insert_all(hypertext, {
+            "\n",
+            "<heading>", fgettext_ne("Active Contributors"), "</heading>\n",
+        })
+        prepare_credits(hypertext, credits.contributors or {})
+        table.insert_all(hypertext, {
+            "\n",
+            "<heading>", fgettext_ne("Previous Core Developers"), "</heading>\n",
+        })
+        prepare_credits(hypertext, credits.previous_core_developers or {})
+        table.insert_all(hypertext, {
+            "\n",
+            "<heading>", fgettext_ne("Previous Contributors"), "</heading>\n",
+        })
+        prepare_credits(hypertext, credits.previous_contributors or {})
 
-		hypertext = table.concat(hypertext):sub(1, -2)
+        hypertext = table.concat(hypertext):sub(1, -2)
 
-		local fs = "image[1.5,0.6;2.5,2.5;" .. core.formspec_escape(logofile) .. "]" ..
-			"style[label_button;border=false]" ..
-			"button[0.1,3.4;5.3,0.5;label_button;" ..
-			core.formspec_escape(version.project .. " " .. version.string) .. "]" ..
-			"button_url[1.5,4.1;2.5,0.8;homepage;luanti.org;https://www.luanti.org/]" ..
-			"hypertext[5.5,0.25;9.75,6.6;credits;" .. core.formspec_escape(hypertext) .. "]"
+        local fs = [[
+            image[1.5,0.6;2.5,2.5;]] .. core.formspec_escape(logofile) .. [[]
+            style[label_button;border=false]
+            button[0.1,3.4;5.3,0.5;label_button;]] .. core.formspec_escape(version.project .. " " .. version.string) .. [[]
+            button_url[1.5,4.1;2.5,0.8;homepage;luanti.org;https://www.luanti.org/]
+            hypertext[5.5,0.25;9.75,6.6;credits;]] .. core.formspec_escape(hypertext) .. [[]
+        ]]
 
-		local active_renderer_info = fgettext("Active renderer:") .. "\n" ..
-			core.formspec_escape(get_renderer_info())
-		fs = fs .. "style[label_button2;border=false]" ..
-			"button[0.1,6;5.3,1;label_button2;" .. active_renderer_info .. "]"..
-			"tooltip[label_button2;" .. active_renderer_info .. "]"
+        local active_renderer_info = fgettext("Active renderer:") .. "\n" .. core.formspec_escape(get_renderer_info())
+        fs = fs .. [[
+            style[label_button2;border=false]
+            button[0.1,6;5.3,1;label_button2;]] .. active_renderer_info .. [[]
+            tooltip[label_button2;]] .. active_renderer_info .. [[]
+        ]]
 
-		if PLATFORM == "Android" then
-			fs = fs .. "button[0.5,5.1;4.5,0.8;share_debug;" .. fgettext("Share debug log") .. "]"
-		else
-			fs = fs .. "tooltip[userdata;" ..
-					fgettext("Opens the directory that contains user-provided worlds, games, mods,\n" ..
-							"and texture packs in a file manager / explorer.") .. "]"
-			fs = fs .. "button[0.5,5.1;4.5,0.8;userdata;" .. fgettext("Open User Data Directory") .. "]"
-		end
+        if PLATFORM == "Android" then
+            fs = fs .. "button[0.5,5.1;4.5,0.8;share_debug;" .. fgettext("Share debug log") .. "]"
+        else
+            fs = fs .. [[
+                tooltip[userdata;]] .. fgettext("Opens the directory that contains user-provided worlds, games, mods,\n" ..
+                        "and texture packs in a file manager / explorer.") .. [[]
+                button[0.5,5.1;4.5,0.8;userdata;]] .. fgettext("Open User Data Directory") .. [[]
+            ]]
+        end
 
-		return fs
-	end,
+        return fs
+    end,
 
-	cbf_button_handler = function(this, fields, name, tabdata)
-		if fields.share_debug then
-			local path = core.get_user_path() .. DIR_DELIM .. "debug.txt"
-			core.share_file(path)
-		end
+    cbf_button_handler = function(this, fields, name, tabdata)
+        if fields.share_debug then
+            local path = core.get_user_path() .. DIR_DELIM .. "debug.txt"
+            core.share_file(path)
+        end
 
-		if fields.userdata then
-			core.open_dir(core.get_user_path())
-		end
-	end,
+        if fields.userdata then
+            core.open_dir(core.get_user_path())
+        end
+    end,
 
-	on_change = function(type)
-		if type == "ENTER" then
-			mm_game_theme.set_engine()
-		end
-	end,
+    on_change = function(type)
+        if type == "ENTER" then
+            mm_game_theme.set_engine()
+        end
+    end,
 }


### PR DESCRIPTION
## Goal of the PR
This PR aims to make the `tab_about.lua` script more robust and easier to maintain. Specifically, it improves error handling and code readability, ensuring that the "About" menu doesn't crash if `credits.json` is missing or invalid.

## How does the PR work?
- If `credits.json` is missing or broken, the menu gracefully falls back to showing empty credits instead of crashing. An error is logged to help with debugging.
- The code has been refactored for better readability:
  - Variables now have more descriptive names (e.g., `renderer` instead of `s1`).
  - `table.insert` is used instead of manual indexing for clarity.
  - The logic for extracting the OpenGL version has been simplified.

## Does it resolve any reported issue?
No specific issue is resolved, but it prevents potential crashes related to missing or invalid `credits.json`, which improves the overall stability of the menu.

## Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Yes, this PR relates to **2.2 Internal code refactoring** from the roadmap. The changes improve code quality and maintainability, which is essential for sustainable development.

## If not a bug fix, why is this PR needed? What use cases does it solve?
This PR is needed to:
- Prevent crashes in the "About" menu when `credits.json` is missing or invalid, which is especially useful for modders and custom game developers.
- Make the code easier to read and maintain, reducing the risk of future bugs.

## To do
This PR is Ready for Review.

- [x] Improve error handling for missing `credits.json`.
- [x] Refactor code for better readability.

## How to test
1. Remove or rename the `credits.json` file in the main menu directory.
2. Launch Luanti and open the "About" menu.
3. Verify that the menu does not crash and shows empty credits.
4. Check the log for a warning message about the missing file.
5. Restore the `credits.json` file and verify that the menu works as expected.