### PR TITLE
TouchControls: touch_use_crosshair, dig/place simulation refactoring

### DIFF
--- a/src/gui/touchscreenlayout.cpp
+++ b/src/gui/touchscreenlayout.cpp
@@ -14,6 +14,9 @@
 #include "IGUIStaticText.h"
 
 const char *button_names[] = {
+	"dig",
+	"place",
+
 	"jump",
 	"sneak",
 	"zoom",
@@ -41,6 +44,9 @@ const char *button_names[] = {
 
 // compare with GUIKeyChangeMenu::init_keys
 const char *button_titles[] = {
+	N_("Dig/punch/use"),
+	N_("Place/use"),
+
 	N_("Jump"),
 	N_("Sneak"),
 	N_("Zoom"),
@@ -67,6 +73,9 @@ const char *button_titles[] = {
 };
 
 const char *button_image_names[] = {
+	"",
+	"",
+
 	"jump_btn.png",
 	"down.png",
 	"zoom.png",
@@ -123,7 +132,8 @@ void ButtonMeta::setPos(v2s32 pos, v2u32 screensize, s32 button_size)
 
 bool ButtonLayout::isButtonAllowed(touch_gui_button_id id)
 {
-	return id != joystick_off_id && id != joystick_bg_id && id != joystick_center_id &&
+	return id != dig_id && id != place_id &&
+			id != joystick_off_id && id != joystick_bg_id && id != joystick_center_id &&
 			id != touch_gui_button_id_END;
 }
 

--- a/src/gui/touchscreenlayout.h
+++ b/src/gui/touchscreenlayout.h
@@ -22,7 +22,11 @@ namespace irr::video
 
 enum touch_gui_button_id : u8
 {
-	jump_id = 0,
+	// these two are no actual buttons ... yet
+	dig_id = 0,
+	place_id,
+
+	jump_id,
 	sneak_id,
 	zoom_id,
 	aux1_id,


### PR DESCRIPTION
this unifies some refactoring from #15567 and a future PR into its own PR, so it can be merged more quickly

-   get rid of simulated mouse events for digging/placing, use keyboard events instead

    -   consistent with other simulated events, less code, no need for a pointer position
    -   more correct: touch controls no longer break if you have custom dig/place keybindings set

-   move reading of "touch_use_crosshair" setting from Game to TouchControls 

## To do

This PR is a Ready for Review.

## How to test

touch controls should still work:
1. dig/place should still work
2. touch_use_crosshair=true/false should both still work
3. touch_use_crosshair changes in-game should still apply immediately
4. it shouldn't be possible to add (broken) dig/place buttons in the touch controls editor

there should be no crashes/problems when using desktop controls