### PR TITLE
Prevent accidental wallmounted_to_dir poisoning by mods

### DIFF
--- a/builtin/common/item_s.lua
+++ b/builtin/common/item_s.lua
@@ -90,7 +90,7 @@ local facedir_to_dir_map = {
 	1, 4, 3, 2,
 }
 function core.facedir_to_dir(facedir)
-	return facedir_to_dir[facedir_to_dir_map[facedir % 32]]
+	return vector.copy(facedir_to_dir[facedir_to_dir_map[facedir % 32]])
 end
 
 function core.dir_to_fourdir(dir)
@@ -110,7 +110,7 @@ function core.dir_to_fourdir(dir)
 end
 
 function core.fourdir_to_dir(fourdir)
-	return facedir_to_dir[facedir_to_dir_map[fourdir % 4]]
+	return vector.copy(facedir_to_dir[facedir_to_dir_map[fourdir % 4]])
 end
 
 function core.dir_to_wallmounted(dir)
@@ -147,7 +147,7 @@ local wallmounted_to_dir = {
 	vector.new( 0, -1,  0),
 }
 function core.wallmounted_to_dir(wallmounted)
-	return wallmounted_to_dir[wallmounted % 8]
+	return vector.copy(wallmounted_to_dir[wallmounted % 8])
 end
 
 function core.dir_to_yaw(dir)


### PR DESCRIPTION
- Goal of the PR

I'll copy paste the commit's description (but slightly edited to correct things):

Prior to this commit, if you used a function like `core.wallmounted_to_dir`, and modified its output, it would modify all of the output in the future

So, something like this:
```lua
local v = core.wallmounted_to_dir(0)
v.y = v.y + 1
core.debug(v:to_string()) -- result: (0, 2, 0)
local v2 = core.wallmounted_to_dir(0)
core.debug(v2:to_string()) -- result: (0, 2, 0)
```

This would result in some bugs that are really hard to catch if you don't know this undocumented behavior
<hr>

**Now that i'm writing this i realize i made an error in the commit description**, line 9 of the commit description was supposed to have `result: (0, 2, 0)` not `result: (0, 1, 0)`, and in line 10 i have put `core.get_wallmounted_to_dir(0)` when i should've put `core.wallmounted_to_dir(0)`, i'm never making commit descriptions again

I don't know how to change the commit message description, besides just making a new fork and PR, is this a problem?  


<hr>

- How does the PR work?
Uses vector.copy on outputs of `core.wallmounted_to_dir`, `core.fourdir_to_dir`, `core.facedir_to_dir` so that can't happen  
- Does it resolve any reported issue?
Not in the issue tracker, but in discord (i reported it): 
https://discord.com/channels/369122544273588224/369123175583186964/1341121598895423591  
The content of the message:
```
i think i just experienced possibly the weirdest engine bug ever?
`core.wallmounted_to_dir(1)` for some reason wasn't `vector.new(0,-1,0)` but was `vector.new(0,1,0)` instead, 

it starts to happen completely randomly
```
(i was completely clueless about it back then)
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
No
## To do

This PR is Ready for Review.
<!-- ^ delete one -->

## How to test
<!-- Example code or instructions -->

```lua
local v = core.wallmounted_to_dir(0)
v.y = v.y + 1
local v2 = core.wallmounted_to_dir(0)
assert(v2.y == 1, "test failed") 
```