### PR TITLE
Clang-Tidy config: Ignore performance-avoid-endl and performance-inefficient-string-concatenation

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,modernize-use-emplace,modernize-avoid-bind,misc-throw-by-value-catch-by-reference,misc-unconventional-assign-operator,performance-*,-performance-avoid-endl'
+Checks: '-*,modernize-use-emplace,modernize-avoid-bind,misc-throw-by-value-catch-by-reference,misc-unconventional-assign-operator,performance-*,-performance-avoid-endl,performance-inefficient-string-concatenation'
 WarningsAsErrors: '-*,modernize-use-emplace,performance-type-promotion-in-math-fn,performance-faster-string-find,performance-implicit-cast-in-loop'
 CheckOptions:
   - key: performance-unnecessary-value-param.AllowedTypes

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,modernize-use-emplace,modernize-avoid-bind,misc-throw-by-value-catch-by-reference,misc-unconventional-assign-operator,performance-*'
+Checks: '-*,modernize-use-emplace,modernize-avoid-bind,misc-throw-by-value-catch-by-reference,misc-unconventional-assign-operator,performance-*,-performance-avoid-endl'
 WarningsAsErrors: '-*,modernize-use-emplace,performance-type-promotion-in-math-fn,performance-faster-string-find,performance-implicit-cast-in-loop'
 CheckOptions:
   - key: performance-unnecessary-value-param.AllowedTypes


### PR DESCRIPTION
It's unlikely that we want to replace `std::endl` with `"\n"`. And if we did, it could be done in semi-automatic a bulk PR, there's no need to annoy people with spam.

---

I'd also like to disable performance-inefficient-string-concatenation (`String concatenation results in allocation of unnecessary temporary strings; consider using 'operator+=' or 'string::append()' instead`). If I go to definition, operator+ already uses append (or insert if left side is const):
```cpp
#if __cplusplus >= 201103L // (C++11)
  template<typename _CharT, typename _Traits, typename _Alloc>
    _GLIBCXX_NODISCARD _GLIBCXX20_CONSTEXPR
    inline basic_string<_CharT, _Traits, _Alloc>
    operator+(basic_string<_CharT, _Traits, _Alloc>&& __lhs,
	      const basic_string<_CharT, _Traits, _Alloc>& __rhs)
    { return std::move(__lhs.append(__rhs)); }

// (more overloads exist)
```
I *guess* it's a warning from pre C++11 days.

## To do

This PR is a Ready for Review.

## How to test

The code editor I use (kate) shows clang tidy warnings.