### PR TITLE
SDL irr device: Ignore +-0.0f y mouse wheel events

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -706,6 +706,10 @@ bool CIrrDeviceSDL::run()
 			irrevent.MouseInput.X = MouseX;
 			irrevent.MouseInput.Y = MouseY;
 
+			// wheel y can be 0 if scrolling sideways
+			if (irrevent.MouseInput.Wheel == 0.0f)
+				break;
+
 			postEventFromUser(irrevent);
 			break;
 		}


### PR DESCRIPTION
Our code often assumes that it's non-zero, e.g.: `event.MouseInput.Wheel < 0 ? -1 : 1`

~~Fix es #15814.~~ Fixes it for SDL irr device.

(Related: <https://github.com/luanti-org/luanti/pull/15221#issuecomment-2495936783>)

## To do

This PR is a Ready for Review.

## How to test

* Scroll a scrollbar a bit down.
* Scroll sideways.
* Master: It goes up. PR: It stays where it is.
