### PR TITLE
Create SSCSM skeleton and scripting

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -47,6 +47,12 @@ files["builtin/client/init.lua"] = {
 	}
 }
 
+files["builtin/sscsm_client/init.lua"] = {
+	globals = {
+		debug = {fields={"getinfo"}},
+	}
+}
+
 files["builtin/common/math.lua"] = {
 	globals = {
 		"math",

--- a/builtin/common/item_s.lua
+++ b/builtin/common/item_s.lua
@@ -232,6 +232,14 @@ if core.set_read_node and core.set_push_node then
 	core.set_read_node = nil
 
 	local function push_node(content, param1, param2)
+		if false then -- TODO: tmp
+			print(dump(debug.traceback()))
+			--~ error()
+			for i = 0, 10 do
+				print("i="..i)
+				print(dump(debug.getinfo(i)))
+			end
+		end
 		return {name = content2name[content], param1 = param1, param2 = param2}
 	end
 	core.set_push_node(push_node)

--- a/builtin/common/item_s.lua
+++ b/builtin/common/item_s.lua
@@ -232,14 +232,6 @@ if core.set_read_node and core.set_push_node then
 	core.set_read_node = nil
 
 	local function push_node(content, param1, param2)
-		if false then -- TODO: tmp
-			print(dump(debug.traceback()))
-			--~ error()
-			for i = 0, 10 do
-				print("i="..i)
-				print(dump(debug.getinfo(i)))
-			end
-		end
 		return {name = content2name[content], param1 = param1, param2 = param2}
 	end
 	core.set_push_node(push_node)

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -76,6 +76,9 @@ elseif INIT == "async_game" then
 	dofile(asyncpath .. "game.lua")
 elseif INIT == "client" then
 	dofile(scriptdir .. "client" .. DIR_DELIM .. "init.lua")
+elseif INIT == "sscsm" then
+	-- FIXME: different branch for sscsm_server
+	dofile(scriptdir .. "sscsm_client" .. DIR_DELIM .. "init.lua")
 elseif INIT == "emerge" then
 	dofile(scriptdir .. "emerge" .. DIR_DELIM .. "init.lua")
 elseif INIT == "pause_menu" then

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -76,9 +76,10 @@ elseif INIT == "async_game" then
 	dofile(asyncpath .. "game.lua")
 elseif INIT == "client" then
 	dofile(scriptdir .. "client" .. DIR_DELIM .. "init.lua")
-elseif INIT == "sscsm" then
-	-- FIXME: different branch for sscsm_server
+elseif INIT == "sscsm" and core.get_current_modname() == "*client_builtin*" then
 	dofile(scriptdir .. "sscsm_client" .. DIR_DELIM .. "init.lua")
+elseif INIT == "sscsm" and core.get_current_modname() == "*server_builtin*" then
+	dofile(scriptdir .. "sscsm_server" .. DIR_DELIM .. "init.lua")
 elseif INIT == "emerge" then
 	dofile(scriptdir .. "emerge" .. DIR_DELIM .. "init.lua")
 elseif INIT == "pause_menu" then

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1889,7 +1889,7 @@ enable_client_modding (Client modding) [client] bool false
 
 #    Where to enable server-sent client-side modding (SSCSM).
 #    Warning: Experimental.
-enable_sscsm (Enable SSCSM) enum nowhere nowhere,singleplayer,localhost,lan,everywhere
+enable_sscsm (Enable SSCSM) [client] enum nowhere nowhere,singleplayer,localhost,lan,everywhere
 
 #    Replaces the default main menu with a custom one.
 main_menu_script (Main menu script) [client] string

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1889,7 +1889,7 @@ enable_client_modding (Client modding) [client] bool false
 
 #    Where to enable server-sent client-side modding (SSCSM).
 #    Warning: Experimental.
-enable_sscsm (Client modding) enum off off,singleplayer,localhost,lan,worldwide
+enable_sscsm (Enable SSCSM) enum nowhere nowhere,singleplayer,localhost,lan,everywhere
 
 #    Replaces the default main menu with a custom one.
 main_menu_script (Main menu script) [client] string

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1887,6 +1887,10 @@ mgvalleys_np_dungeons (Dungeon noise) noise_params_3d 0.9, 0.5, (500, 500, 500),
 #    This support is experimental and API can change.
 enable_client_modding (Client modding) [client] bool false
 
+#    Where to enable server-sent client-side modding (SSCSM).
+#    Warning: Experimental.
+enable_sscsm (Client modding) enum off off,singleplayer,localhost,lan,worldwide
+
 #    Replaces the default main menu with a custom one.
 main_menu_script (Main menu script) [client] string
 

--- a/builtin/sscsm_client/init.lua
+++ b/builtin/sscsm_client/init.lua
@@ -7,7 +7,28 @@ local mypath     = scriptpath .. "sscsm_client".. DIR_DELIM
 -- not exposed to outer context
 local builtin_shared = {}
 
+-- placeholders
+-- FIXME: send actual content defs to sscsm env
+function core.get_content_id(name)
+	return tonumber(name)
+end
+function core.get_name_from_content_id(id)
+	return tostring(id)
+end
+
+assert(loadfile(commonpath .. "item_s.lua"))(builtin_shared)
 assert(loadfile(commonpath .. "register.lua"))(builtin_shared)
 assert(loadfile(mypath .. "register.lua"))(builtin_shared)
 
 dofile(commonpath .. "after.lua")
+
+
+-- TODO: tmp
+
+local function dings()
+	print(dump(core.get_node_or_nil(vector.zero())))
+	core.after(1, dings)
+end
+--~ core.after(0, dings)
+
+print(core.get_current_modname())

--- a/builtin/sscsm_client/init.lua
+++ b/builtin/sscsm_client/init.lua
@@ -20,14 +20,3 @@ assert(loadfile(commonpath .. "register.lua"))(builtin_shared)
 assert(loadfile(mypath .. "register.lua"))(builtin_shared)
 
 dofile(commonpath .. "after.lua")
-
-
--- TODO: tmp
-
-local function dings()
-	print(dump(core.get_node_or_nil(vector.zero())))
-	core.after(1, dings)
-end
---~ core.after(0, dings)
-
-print(core.get_current_modname())

--- a/builtin/sscsm_client/init.lua
+++ b/builtin/sscsm_client/init.lua
@@ -1,0 +1,13 @@
+
+local scriptpath = core.get_builtin_path()
+local commonpath = scriptpath .. "common" .. DIR_DELIM
+local mypath     = scriptpath .. "sscsm_client".. DIR_DELIM
+
+-- Shared between builtin files, but
+-- not exposed to outer context
+local builtin_shared = {}
+
+assert(loadfile(commonpath .. "register.lua"))(builtin_shared)
+assert(loadfile(mypath .. "register.lua"))(builtin_shared)
+
+dofile(commonpath .. "after.lua")

--- a/builtin/sscsm_client/init.lua
+++ b/builtin/sscsm_client/init.lua
@@ -1,4 +1,3 @@
-
 local scriptpath = core.get_builtin_path()
 local commonpath = scriptpath .. "common" .. DIR_DELIM
 local mypath     = scriptpath .. "sscsm_client".. DIR_DELIM

--- a/builtin/sscsm_client/init.lua
+++ b/builtin/sscsm_client/init.lua
@@ -20,3 +20,6 @@ assert(loadfile(commonpath .. "register.lua"))(builtin_shared)
 assert(loadfile(mypath .. "register.lua"))(builtin_shared)
 
 dofile(commonpath .. "after.lua")
+
+-- unset, as promised in initializeSecuritySSCSM()
+debug.getinfo = nil

--- a/builtin/sscsm_client/register.lua
+++ b/builtin/sscsm_client/register.lua
@@ -1,0 +1,5 @@
+local builtin_shared = ...
+
+local make_registration = builtin_shared.make_registration
+
+core.registered_globalsteps, core.register_globalstep = make_registration()

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -1,0 +1,212 @@
+# Server-sent client-side modding (SSCSM) API reference
+
+**Warning:** SSCSM is very experimental. The API will break. Always start your
+mod with a version check (using `core.get_version()`).
+
+In SSCSM, the server sends scripts to the client, which it executes
+client-side (in a sandbox, see also `sscsm_security.md`).
+As modder, you can add these scripts to your server-side mod, and tell the engine
+to send them.
+
+Please refer to `lua_api.md` for server-side modding.
+(And refer to `client_lua_api.md` for client-provided client-side modding (CPCSM).)
+
+
+
+## Loading mods
+
+### Paths
+
+SSCSM uses a virtual file system (just a dictionary of virtual paths (strings))
+to file contents (strings).
+
+Each mod's files have paths of the form `modname:foo/bla.lua`.
+Please don't rely on this, use `core.get_modpath()` instead.
+
+The virtual file paths within a mod are meant to mimic the filepaths on the
+server, for example `<modpath>/common/foo.lua` gets sent as `modname:common/foo.lua`.
+
+The engine loads `modname:init.lua` for all mods, in server mod dependency order.
+
+There is client and server builtin (modnames are `*client_builtin*` and
+`*server_builtin*`). The server builtin is sent from the server, like any other
+SSCSM, and the client builtin is located on the client.
+
+
+### Mod sending API
+
+Currently, you can not add any mods. There's only a small hardcoded preview script
+in C++ which is loaded when you set `enable_sscsm` to `singleplayer`.
+
+
+
+## API
+
+Unless noted otherwise, these work the same as in the server modding API.
+
+### Global callbacks
+
+* `core.register_globalstep(function(dtime))`
+
+
+### SSCSM-specific API
+
+* `core.get_node_or_nil(pos)`
+* `core.get_content_id(name)`
+* `core.get_name_from_content_id(id)`
+
+
+### Util API
+
+* `core.log([level,] text)`
+* `core.get_us_time()`
+  * Limited in precision.
+* `core.parse_json(str[, nullvalue])`
+* `core.write_json(data[, styled])`
+* `core.is_yes(arg)`
+* `core.compress(data, method, ...)`
+* `core.decompress(data, method, ...)`
+* `core.encode_base64(string)`
+* `core.decode_base64(string)`
+* `core.get_version()`
+* `core.sha1(string, raw)`
+* `core.sha256(string, raw)`
+* `core.colorspec_to_colorstring(colorspec)`
+* `core.colorspec_to_bytes(colorspec)`
+* `core.colorspec_to_table(colorspec)`
+* `core.time_to_day_night_ratio(time_of_day)`
+* `core.get_last_run_mod()`
+* `core.set_last_run_mod(modname)`
+* `core.urlencode(value)`
+
+
+### Other
+
+* `core.get_current_modname()`
+* `core.get_modpath(modname)`
+
+
+### Builtin helpers
+
+* `math.*` additions
+
+* `vector.*`
+
+* `core.global_exists(name)`
+
+* `core.serialize(value)`
+* `core.deserialize(str, safe)`
+
+* `dump2(obj, name, dumped)`
+* `dump(obj, dumped)`
+* `string.*` additions
+* `table.*` additions
+* `core.formspec_escape(text)`
+* `core.hypertext_escape(text)`
+* `core.wrap_text(str, limit, as_table)`
+* `core.explode_table_event(evt)`
+* `core.explode_textlist_event(evt)`
+* `core.explode_scrollbar_event(evt)`
+* `core.rgba(r, g, b, a)`
+* `core.pos_to_string(pos, decimal_places)`
+* `core.string_to_pos(value)`
+* `core.string_to_area(value, relative_to)`
+* `core.get_color_escape_sequence(color)`
+* `core.get_background_escape_sequence(color)`
+* `core.colorize(color, message)`
+* `core.strip_foreground_colors(str)`
+* `core.strip_background_colors(str)`
+* `core.strip_colors(str)`
+* `core.translate(textdomain, str, ...)`
+* `core.translate_n(textdomain, str, str_plural, n, ...)`
+* `core.get_translator(textdomain)`
+* `core.pointed_thing_to_face_pos(placer, pointed_thing)`
+* `core.string_to_privs(str, delim)`
+* `core.privs_to_string(privs, delim)`
+* `core.is_nan(number)`
+* `core.parse_relative_number(arg, relative_to)`
+* `core.parse_coordinates(x, y, z, relative_to)`
+
+* `core.inventorycube(img1, img2, img3)`
+* `core.dir_to_facedir(dir, is6d)`
+* `core.facedir_to_dir(facedir)`
+* `core.dir_to_fourdir(dir)`
+* `core.fourdir_to_dir(fourdir)`
+* `core.dir_to_wallmounted(dir)`
+* `core.wallmounted_to_dir(wallmounted)`
+* `core.dir_to_yaw(dir)`
+* `core.yaw_to_dir(yaw)`
+* `core.is_colored_paramtype(ptype)`
+* `core.strip_param2_color(param2, paramtype2)`
+
+* `core.after(time, func, ...)`
+
+
+### Lua standard library
+
+* `assert`
+* `collectgarbage`
+* `error`
+* `getfenv`
+* `ipairs`
+* `next`
+* `pairs`
+* `pcall`
+* `rawequal`
+* `rawget`
+* `rawset`
+* `select`
+* `setfenv`
+* `getmetatable`
+* `setmetatable`
+* `tonumber`
+* `tostring`
+* `type`
+* `unpack`
+* `_VERSION`
+* `xpcall`
+* `dofile`
+  * Overwritten.
+* `load`
+  * Overwritten.
+* `loadfile`
+  * Overwritten.
+* `loadstring`
+  * Overwritten.
+* `coroutine.*`
+* `table.*`
+* `math.*`
+* `string.*`
+  * except `string.dump`
+* `os.difftime`
+* `os.time`
+* `os.clock`
+  * Reduced precision.
+* `debug.traceback`
+
+
+### LuaJIT `jit` library
+
+* `jit.arch`
+* `jit.flush`
+* `jit.off`
+* `jit.on`
+* `jit.opt`
+* `jit.os`
+* `jit.status`
+* `jit.version`
+* `jit.version_num`
+
+
+### Bit library
+
+* `bit.*`
+
+
+### API only for client builtin
+
+* `core.get_builtin_path()`
+  * Returns path, depending on which builtin currently loads, or `nil`.
+* `debug.getinfo(...)`
+* `INIT`
+  * Is `"sscsm"`.

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -17,8 +17,8 @@ Please refer to `lua_api.md` for server-side modding.
 
 ### Paths
 
-SSCSM uses a virtual file system (just a dictionary of virtual paths (strings))
-to file contents (strings).
+SSCSM uses a virtual file system (just a dictionary of virtual paths (strings)
+to file contents (strings)).
 
 Each mod's files have paths of the form `modname:foo/bla.lua`.
 Please don't rely on this, use `core.get_modpath()` instead.
@@ -43,6 +43,8 @@ in C++ which is loaded when you set `enable_sscsm` to `singleplayer`.
 ## API
 
 Unless noted otherwise, these work the same as in the server modding API.
+
+Functions that take or return paths always use virtual paths.
 
 ### Global callbacks
 
@@ -167,13 +169,13 @@ Unless noted otherwise, these work the same as in the server modding API.
 * `_VERSION`
 * `xpcall`
 * `dofile`
-  * Overwritten.
+  * Overwritten: Loading bytecode is prohibited (like in SSM).
 * `load`
-  * Overwritten.
+  * As above.
 * `loadfile`
-  * Overwritten.
+  * As above.
 * `loadstring`
-  * Overwritten.
+  * As above.
 * `coroutine.*`
 * `table.*`
 * `math.*`

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -152,6 +152,7 @@ Unless noted otherwise, these work the same as in the server modding API.
 * `next`
 * `pairs`
 * `pcall`
+* `print`
 * `rawequal`
 * `rawget`
 * `rawset`

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -1,7 +1,8 @@
 # Server-sent client-side modding (SSCSM) API reference
 
 **Warning:** SSCSM is very experimental. The API will break. Always start your
-mod with a version check (using `core.get_version()`).
+mod with a version check (i.e. at least check if `core.get_version().proto_max`
+is (less or) equal to (any of) the tested version(s)).
 
 In SSCSM, the server sends scripts to the client, which it executes
 client-side (in a sandbox, see also `sscsm_security.md`).

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -4,7 +4,7 @@
 ## Threat model
 
 * SSCSM scripts come from the server (potential malicious actor). We are the client.
-* Authenticity of server is not given (our networking is not secure). So we have
+* Authenticity of server is not given (Luanti's networking is not secure). So we have
   to expect anyone who can send us UDP packets to the appropriate IP address to be
   able to act on behalf of the server.
 * The server may not tamper with, or get access to information of, anything besides
@@ -12,8 +12,9 @@
   stuff, like map, node definitions, ...).
   In particular, this excludes for (non-exhaustive) example files, file paths,
   and settings.
-* DOS is not an issue (as it is already easily possible to DOS a client).
-* We already have an API via network packets (see `networkprotocol.h`).
+* DOS is not an issue (as it is already easily possible to DOS a client, and
+  because it's low risk (uninteresting target, and no catastrophic impact)).
+* There already is an API via network packets (see `networkprotocol.h`).
   This acts as upper bound: Every SSCSM API function could instead be a network
   packet endpoint. There are no efforts to make SSCSM more secure than this.
 

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -1,0 +1,76 @@
+# SSCSM security
+
+
+## Threat model
+
+* SSCSM scripts come from the server (potential malicious actor). We are the client.
+* Authenticity of server is not given (our networking is not secure). So we have
+  to expect anyone who can send us UDP packets to the appropriate IP address to be
+  able to act on behalf of the server.
+* The server may not tamper with, or get access to information of, anything besides
+  the stuff explicitly made accessible via the modding API (i.e. gameplay relevant
+  stuff, like map, node definitions, ...).
+  In particular, this excludes for (non-exhaustive) example files, file paths,
+  and settings.
+* DOS is not an issue (as it is already easily possible to DOS a client).
+* We already have an API via network packets (see `networkprotocol.h`).
+  This acts as upper bound: Every SSCSM API function could instead be a network
+  packet endpoint. There are no efforts to make SSCSM more secure than this.
+
+
+## Non-binary `enable_sscsm` setting
+
+The `enable_sscsm` setting does not just allow en-/disabling SSCSM, it also allows
+limiting on what sort of servers to enable SSCSM. Options are `nowhere`, `singleplayer`,
+`localhost` (or singleplayer), `lan` (or lower), and everywhere.
+On options `localhost` and lower, we know that (anyone who acts on the behalf of)
+the server runs on the same machine, and the risk of it being malicious is pretty
+much zero.
+
+Until sufficient security measures are in place, users are disallowed to set this
+setting to anything higher than `localhost`.
+
+
+## Lua sandbox
+
+* We execute only Lua scripts, in a Lua sandbox.
+* See also `initializeSecuritySSCSM()`.
+* We do not trust the Lua implementation to not have bugs. => Additional process
+  isolation layer as fallback.
+
+
+## Process isolation
+
+* Not yet implemented.
+* Separate SSCSM process.
+* Sandboxing:
+  * Linux: Uses SECCOMP.
+  * ... (FIXME: write down stuff when you implement)
+
+
+## Limit where we call into SSCSM
+
+* Even if the Lua sandbox and/or the process isolation are bug-free, the main
+  process client code can still be vulnerable. Consider this example:
+  * Client has an inventorylist A.
+  * User moves an item.
+  * SSCSM gets called (callback when item is moved).
+  * SSCSM can do anything now. It decides to delete A, then returns.
+  * Client still has reference to A on stack, tries to access it.
+  * => Use-after-free.
+* To avoid these sort of issues, we only give control-flow to SSCSM in few special
+  places.
+  In particular, this includes packet handlers, and the client's `step()` function.
+* In these places, the client already does not assume anything about the current
+  state (e.g. that an inventory exists).
+* This makes sure that SSCSM API calls can also just happen in these places.
+  In packet handlers, the server can already cause arbitrary network API "calls"
+  to happen. Hence, new SSCSM API calls here do not lead to new vulnerabilities
+  that a network API would not cause as well.
+
+
+## No precise clocks
+
+To mitigate time-based side-channel attacks, all available clock API functions
+(`os.clock()` and `core.get_us_time()`) only have a precision of
+`SSCSM_CLOCK_RESOLUTION_US` (20) us.

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -12,8 +12,8 @@
   stuff, like map, node definitions, ...).
   In particular, this excludes for (non-exhaustive) example files, file paths,
   and settings.
-* DOS is not an issue (as it is already easily possible to DOS a client, and
-  because it's low risk (uninteresting target, and no catastrophic impact)).
+* DOS is not an issue (as it is already easily possible to DOS a client).
+  (It's also low risk (uninteresting target, and no catastrophic impact).)
 * There already is an API via network packets (see `networkprotocol.h`).
   This acts as upper bound: Every SSCSM API function could instead be a network
   packet endpoint. There are no efforts to make SSCSM more secure than this.

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -76,6 +76,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/texturesource.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/imagesource.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/wieldmesh.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/mod_vfs.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shadows/dynamicshadows.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shadows/dynamicshadowsrender.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/shadows/shadowsshadercallbacks.cpp

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -41,12 +41,17 @@
 #include "util/string.h"
 #include "version.h"
 
-// Modding
+// CPCSM
 #include "content/mod_configuration.h"
 #include "content/mods.h"
 #include "modchannels.h"
 #include "script/common/c_types.h" // LuaError
 #include "script/scripting_client.h"
+
+// SSCSM
+#include "client/mod_vfs.h"
+#include "script/sscsm/sscsm_controller.h"
+#include "script/sscsm/sscsm_events.h"
 
 // Network
 #include "network/clientopcodes.h"
@@ -67,11 +72,6 @@
 #include <algorithm>
 #include <sstream>
 #include <cmath>
-
-//TODO: move
-#include "client/mod_vfs.h"
-#include "script/sscsm/sscsm_controller.h"
-#include "script/sscsm/sscsm_events.h"
 
 extern gui::IGUIEnvironment* guienv;
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -556,7 +556,11 @@ void Client::step(float dtime)
 	*/
 	LocalPlayer *player = m_env.getLocalPlayer();
 
-	m_sscsm_controller->eventOnStep(this, dtime);
+	{
+		auto event = std::make_unique<SSCSMEventOnStep>();
+		event->dtime = dtime;
+		m_sscsm_controller->runEvent(this, std::move(event));
+	}
 
 	// Step environment (also handles player controls)
 	m_env.step(dtime);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -159,36 +159,38 @@ Client::Client(
 
 	{
 		auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
-		//TODO: read files
-		event1->files.emplace_back("/client_builtin/sscsm_client/init.lua",
-				R"=+=(
-print("client builtin: loading")
-				)=+=");
 
-		//TODO: checksum
+		ModVFS tmp_mod_vfs;
+		// FIXME: only read files that are relevant to sscsm, and compute sha2 digests
+		tmp_mod_vfs.scanModIntoMemory("*client_builtin*", getBuiltinLuaPath());
+
+		for (auto &p : tmp_mod_vfs.m_vfs) {
+			event1->files.emplace_back(p.first, std::move(p.second));
+		}
 
 		m_sscsm_controller->runEvent(this, std::move(event1));
 
 		// load client builtin immediately
 		auto event2 = std::make_unique<SSCSMEventLoadMods>();
-		event2->init_paths.emplace_back("/client_builtin/sscsm_client/init.lua");
+		event2->mods.emplace_back("*client_builtin*", "*client_builtin*:init.lua");
 		m_sscsm_controller->runEvent(this, std::move(event2));
 	}
 
 	{
 		//TODO: network packets
+		//TODO: check that *client_builtin* is not overridden
 
 		std::string enable_sscsm = g_settings->get("enable_sscsm");
 		if (enable_sscsm == "singleplayer") {
 			auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
-			event1->files.emplace_back("/mods/sscsm_test0/init.lua",
+			event1->files.emplace_back("sscsm_test0:init.lua",
 					R"=+=(
 print("sscsm_test0: loading")
 					)=+=");
 			m_sscsm_controller->runEvent(this, std::move(event1));
 
 			auto event2 = std::make_unique<SSCSMEventLoadMods>();
-			event2->init_paths.emplace_back("/client_builtin/sscsm_client/init.lua");
+			event2->mods.emplace_back("sscsm_test0", "sscsm_test0:init.lua");
 			m_sscsm_controller->runEvent(this, std::move(event2));
 		}
 	}

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -186,6 +186,8 @@ Client::Client(
 			event1->files.emplace_back("sscsm_test0:init.lua",
 					R"=+=(
 print("sscsm_test0: loading")
+--print(dump(_G))
+--print(debug.traceback())
 					)=+=");
 			m_sscsm_controller->runEvent(this, std::move(event1));
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -67,6 +67,7 @@
 #include <algorithm>
 #include <sstream>
 #include <cmath>
+#include "script/sscsm/sscsm_controller.h"
 
 extern gui::IGUIEnvironment* guienv;
 
@@ -149,6 +150,8 @@ Client::Client(
 
 	m_cache_save_interval = g_settings->getU16("server_map_save_interval");
 	m_mesh_grid = { g_settings->getU16("client_mesh_chunk") };
+
+	m_sscsm_controller = SSCSMController::create();
 }
 
 void Client::migrateModStorage()
@@ -535,6 +538,8 @@ void Client::step(float dtime)
 		Handle environment
 	*/
 	LocalPlayer *player = m_env.getLocalPlayer();
+
+	m_sscsm_controller->eventOnStep(this, dtime);
 
 	// Step environment (also handles player controls)
 	m_env.step(dtime);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -67,6 +67,9 @@
 #include <algorithm>
 #include <sstream>
 #include <cmath>
+
+//TODO: move
+#include "client/mod_vfs.h"
 #include "script/sscsm/sscsm_controller.h"
 #include "script/sscsm/sscsm_events.h"
 
@@ -236,12 +239,14 @@ void Client::loadMods()
 		return;
 	}
 
+	m_mod_vfs = std::make_unique<ModVFS>();
+
 	m_script = new ClientScripting(this);
 	m_env.setScript(m_script);
 	m_script->setEnv(&m_env);
 
 	// Load builtin
-	scanModIntoMemory(BUILTIN_MOD_NAME, getBuiltinLuaPath());
+	m_mod_vfs->scanModIntoMemory(BUILTIN_MOD_NAME, getBuiltinLuaPath());
 	m_script->loadModFromMemory(BUILTIN_MOD_NAME);
 	m_script->checkSetByBuiltin();
 
@@ -280,7 +285,7 @@ void Client::loadMods()
 	// Load "mod" scripts
 	for (const ModSpec &mod : m_mods) {
 		mod.checkAndLog();
-		scanModIntoMemory(mod.name, mod.path);
+		m_mod_vfs->scanModIntoMemory(mod.name, mod.path);
 	}
 
 	// Run them
@@ -300,35 +305,6 @@ void Client::loadMods()
 		m_script->on_camera_ready(m_camera);
 	if (m_minimap)
 		m_script->on_minimap_ready(m_minimap.get());
-}
-
-void Client::scanModSubfolder(const std::string &mod_name, const std::string &mod_path,
-			std::string mod_subpath)
-{
-	std::string full_path = mod_path + DIR_DELIM + mod_subpath;
-	std::vector<fs::DirListNode> mod = fs::GetDirListing(full_path);
-	for (const fs::DirListNode &j : mod) {
-		if (j.name[0] == '.')
-			continue;
-
-		if (j.dir) {
-			scanModSubfolder(mod_name, mod_path, mod_subpath + j.name + DIR_DELIM);
-			continue;
-		}
-		std::replace(mod_subpath.begin(), mod_subpath.end(), DIR_DELIM_CHAR, '/');
-
-		std::string real_path = full_path + j.name;
-		std::string vfs_path = mod_name + ":" + mod_subpath + j.name;
-		infostream << "Client::scanModSubfolder(): Loading \"" << real_path
-				<< "\" as \"" << vfs_path << "\"." << std::endl;
-
-		std::string contents;
-		if (!fs::ReadFile(real_path, contents, true)) {
-			continue;
-		}
-
-		m_mod_vfs.emplace(vfs_path, contents);
-	}
 }
 
 const std::string &Client::getBuiltinLuaPath()
@@ -2097,23 +2073,6 @@ scene::IAnimatedMesh* Client::getMesh(const std::string &filename, bool cache)
 	if (!cache)
 		m_rendering_engine->removeMesh(mesh);
 	return mesh;
-}
-
-const std::string* Client::getModFile(std::string filename)
-{
-	// strip dir delimiter from beginning of path
-	auto pos = filename.find_first_of(':');
-	if (pos == std::string::npos)
-		return nullptr;
-	pos++;
-	auto pos2 = filename.find_first_not_of('/', pos);
-	if (pos2 > pos)
-		filename.erase(pos, pos2 - pos);
-
-	StringMap::const_iterator it = m_mod_vfs.find(filename);
-	if (it == m_mod_vfs.end())
-		return nullptr;
-	return &it->second;
 }
 
 /*

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -68,6 +68,7 @@
 #include <sstream>
 #include <cmath>
 #include "script/sscsm/sscsm_controller.h"
+#include "script/sscsm/sscsm_events.h"
 
 extern gui::IGUIEnvironment* guienv;
 
@@ -152,6 +153,42 @@ Client::Client(
 	m_mesh_grid = { g_settings->getU16("client_mesh_chunk") };
 
 	m_sscsm_controller = SSCSMController::create();
+
+	{
+		auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
+		//TODO: read files
+		event1->files.emplace_back("/client_builtin/sscsm_client/init.lua",
+				R"=+=(
+print("client builtin: loading")
+				)=+=");
+
+		//TODO: checksum
+
+		m_sscsm_controller->runEvent(this, std::move(event1));
+
+		// load client builtin immediately
+		auto event2 = std::make_unique<SSCSMEventLoadMods>();
+		event2->init_paths.emplace_back("/client_builtin/sscsm_client/init.lua");
+		m_sscsm_controller->runEvent(this, std::move(event2));
+	}
+
+	{
+		//TODO: network packets
+
+		std::string enable_sscsm = g_settings->get("enable_sscsm");
+		if (enable_sscsm == "singleplayer") {
+			auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
+			event1->files.emplace_back("/mods/sscsm_test0/init.lua",
+					R"=+=(
+print("sscsm_test0: loading")
+					)=+=");
+			m_sscsm_controller->runEvent(this, std::move(event1));
+
+			auto event2 = std::make_unique<SSCSMEventLoadMods>();
+			event2->init_paths.emplace_back("/client_builtin/sscsm_client/init.lua");
+			m_sscsm_controller->runEvent(this, std::move(event2));
+		}
+	}
 }
 
 void Client::migrateModStorage()

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -177,11 +177,11 @@ Client::Client(
 	}
 
 	{
-		//TODO: network packets
-		//TODO: check that *client_builtin* is not overridden
+		//FIXME: network packets
+		//FIXME: check that *client_builtin* is not overridden
 
 		std::string enable_sscsm = g_settings->get("enable_sscsm");
-		if (enable_sscsm == "singleplayer") {
+		if (enable_sscsm == "singleplayer") { //FIXME: enum
 			auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
 			event1->files.emplace_back("sscsm_test0:init.lua",
 					R"=+=(

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -183,12 +183,26 @@ Client::Client(
 		std::string enable_sscsm = g_settings->get("enable_sscsm");
 		if (enable_sscsm == "singleplayer") { //FIXME: enum
 			auto event1 = std::make_unique<SSCSMEventUpdateVFSFiles>();
+
+			// some simple test code
 			event1->files.emplace_back("sscsm_test0:init.lua",
 					R"=+=(
 print("sscsm_test0: loading")
+
 --print(dump(_G))
 --print(debug.traceback())
+
+do
+	local pos = vector.zero()
+	local function print_nodes()
+		print(string.format("node at %s: %s", pos, dump(core.get_node_or_nil(pos))))
+		pos = pos:offset(1, 0, 0)
+		core.after(1, print_nodes)
+	end
+	core.after(0, print_nodes)
+end
 					)=+=");
+
 			m_sscsm_controller->runEvent(this, std::move(event1));
 
 			auto event2 = std::make_unique<SSCSMEventLoadMods>();

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -45,6 +45,8 @@ class NodeDefManager;
 class ParticleManager;
 class RenderingEngine;
 class SingleMediaDownloader;
+class ClientScripting;
+class SSCSMController;
 struct ChatMessage;
 struct ClientDynamicInfo;
 struct ClientEvent;
@@ -53,8 +55,6 @@ struct MapNode;
 struct PlayerControl;
 struct PointedThing;
 struct ItemVisualsManager;
-class ClientScripting;
-class SSCSMController;
 struct ModVFS;
 
 namespace scene {

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -53,6 +53,8 @@ struct MapNode;
 struct PlayerControl;
 struct PointedThing;
 struct ItemVisualsManager;
+class ClientScripting;
+class SSCSMController;
 
 namespace scene {
 class IAnimatedMesh;
@@ -99,8 +101,6 @@ private:
 	// command, count
 	std::map<u16, u32> m_packets;
 };
-
-class ClientScripting;
 
 class Client : public con::PeerHandler, public InventoryManager, public IGameDef
 {
@@ -586,6 +586,9 @@ private:
 	float m_mod_storage_save_timer = 10.0f;
 	std::vector<ModSpec> m_mods;
 	StringMap m_mod_vfs;
+
+	// SSCSM
+	std::unique_ptr<SSCSMController> m_sscsm_controller;
 
 	bool m_shutdown = false;
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -55,6 +55,7 @@ struct PointedThing;
 struct ItemVisualsManager;
 class ClientScripting;
 class SSCSMController;
+struct ModVFS;
 
 namespace scene {
 class IAnimatedMesh;
@@ -126,14 +127,6 @@ public:
 
 	~Client();
 	DISABLE_CLASS_COPY(Client);
-
-	// Load local mods into memory
-	void scanModSubfolder(const std::string &mod_name, const std::string &mod_path,
-				std::string mod_subpath);
-	inline void scanModIntoMemory(const std::string &mod_name, const std::string &mod_path)
-	{
-		scanModSubfolder(mod_name, mod_path, "");
-	}
 
 	/*
 	 request all threads managed by client to be stopped
@@ -383,7 +376,7 @@ public:
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
 	virtual scene::IAnimatedMesh* getMesh(const std::string &filename, bool cache = false);
-	const std::string* getModFile(std::string filename);
+	ModVFS *getModVFS() { return m_mod_vfs.get(); }
 	ModStorageDatabase *getModStorageDatabase() override { return m_mod_storage_database; }
 
 	ItemVisualsManager *getItemVisualsManager() { return m_item_visuals_manager; }
@@ -585,7 +578,7 @@ private:
 	ModStorageDatabase *m_mod_storage_database = nullptr;
 	float m_mod_storage_save_timer = 10.0f;
 	std::vector<ModSpec> m_mods;
-	StringMap m_mod_vfs;
+	std::unique_ptr<ModVFS> m_mod_vfs;
 
 	// SSCSM
 	std::unique_ptr<SSCSMController> m_sscsm_controller;

--- a/src/client/mod_vfs.cpp
+++ b/src/client/mod_vfs.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "mod_vfs.h"
+#include "filesys.h"
+#include "log.h"
+#include <algorithm>
+
+void ModVFS::scanModSubfolder(const std::string &mod_name, const std::string &mod_path,
+		std::string mod_subpath)
+{
+	std::string full_path = mod_path + DIR_DELIM + mod_subpath;
+	std::vector<fs::DirListNode> mod = fs::GetDirListing(full_path);
+	for (const fs::DirListNode &j : mod) {
+		if (j.name[0] == '.')
+			continue;
+
+		if (j.dir) {
+			scanModSubfolder(mod_name, mod_path, mod_subpath + j.name + DIR_DELIM);
+			continue;
+		}
+		std::replace(mod_subpath.begin(), mod_subpath.end(), DIR_DELIM_CHAR, '/');
+
+		std::string real_path = full_path + j.name;
+		std::string vfs_path = mod_name + ":" + mod_subpath + j.name;
+		infostream << "ModVFS::scanModSubfolder(): Loading \"" << real_path
+				<< "\" as \"" << vfs_path << "\"." << std::endl;
+
+		std::string contents;
+		if (!fs::ReadFile(real_path, contents)) {
+			errorstream << "ModVFS::scanModSubfolder(): Can't read file \""
+					<< real_path << "\"." << std::endl;
+			continue;
+		}
+
+		m_vfs.emplace(vfs_path, contents);
+	}
+}
+
+const std::string *ModVFS::getModFile(std::string filename)
+{
+	// strip dir delimiter from beginning of path
+	auto pos = filename.find_first_of(':');
+	if (pos == std::string::npos)
+		return nullptr;
+	++pos;
+	auto pos2 = filename.find_first_not_of('/', pos);
+	if (pos2 > pos)
+		filename.erase(pos, pos2 - pos);
+
+	auto it = m_vfs.find(filename);
+	if (it == m_vfs.end())
+		return nullptr;
+	return &it->second;
+}

--- a/src/client/mod_vfs.h
+++ b/src/client/mod_vfs.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+struct ModVFS
+{
+	void scanModSubfolder(const std::string &mod_name, const std::string &mod_path,
+			std::string mod_subpath);
+
+	inline void scanModIntoMemory(const std::string &mod_name, const std::string &mod_path)
+	{
+		scanModSubfolder(mod_name, mod_path, "");
+	}
+
+	const std::string *getModFile(std::string filename);
+
+	std::unordered_map<std::string, std::string> m_vfs;
+};

--- a/src/constants.h
+++ b/src/constants.h
@@ -105,3 +105,7 @@
 // The intent is to ensure that the rendering doesn't turn terribly blurry
 // when filtering is enabled.
 #define TEXTURE_FILTER_MIN_SIZE 192U
+
+// Resolution of clocks that SSCSM has access to, in us.
+// Used as countermeasure against side-channel attacks.
+#define SSCSM_CLOCK_RESOLUTION_US 20

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -121,6 +121,7 @@ void set_default_settings()
 	settings->setDefault("curl_verify_cert", "true");
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
+	settings->setDefault("enable_sscsm", "off");
 	settings->setDefault("max_out_chat_queue_size", "20");
 	settings->setDefault("pause_on_lost_focus", "false");
 	settings->setDefault("enable_split_login_register", "true");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -121,7 +121,7 @@ void set_default_settings()
 	settings->setDefault("curl_verify_cert", "true");
 	settings->setDefault("enable_remote_media_server", "true");
 	settings->setDefault("enable_client_modding", "false");
-	settings->setDefault("enable_sscsm", "off");
+	settings->setDefault("enable_sscsm", "nowhere");
 	settings->setDefault("max_out_chat_queue_size", "20");
 	settings->setDefault("pause_on_lost_focus", "false");
 	settings->setDefault("enable_split_login_register", "true");

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -87,6 +87,11 @@ public:
 	ModError(const std::string &s): BaseException(s) {}
 };
 
+class MisbehavedSSCSMException : public BaseException {
+public:
+	MisbehavedSSCSMException(const std::string &s): BaseException(s) {}
+};
+
 
 /*
 	Some "old-style" interrupts:

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(common)
 add_subdirectory(cpp_api)
 add_subdirectory(lua_api)
+add_subdirectory(sscsm)
 
 # Used by server and client
 file(GLOB common_SCRIPT_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
@@ -24,5 +25,6 @@ set(client_SCRIPT_SRCS
 	${client_SCRIPT_COMMON_SRCS}
 	${client_SCRIPT_CPP_API_SRCS}
 	${client_SCRIPT_LUA_API_SRCS}
+	${client_SCRIPT_SSCSM_SRCS}
 	PARENT_SCOPE)
 

--- a/src/script/CMakeLists.txt
+++ b/src/script/CMakeLists.txt
@@ -21,6 +21,7 @@ set(client_SCRIPT_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/scripting_mainmenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/scripting_client.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/scripting_pause_menu.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/scripting_sscsm.cpp
 
 	${client_SCRIPT_COMMON_SRCS}
 	${client_SCRIPT_CPP_API_SRCS}

--- a/src/script/cpp_api/CMakeLists.txt
+++ b/src/script/cpp_api/CMakeLists.txt
@@ -22,5 +22,6 @@ set(client_SCRIPT_CPP_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/s_client_common.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_mainmenu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/s_pause_menu.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/s_sscsm.cpp
 	PARENT_SCOPE)
 

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -141,7 +141,8 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 	// Finally, put the table into the global environment:
 	lua_setglobal(m_luastack, "core");
 
-	if (m_type == ScriptingType::Client)
+	if (m_type == ScriptingType::Client
+			|| m_type == ScriptingType::SSCSM)
 		lua_pushstring(m_luastack, "/");
 	else
 		lua_pushstring(m_luastack, DIR_DELIM);
@@ -263,17 +264,18 @@ void ScriptApiBase::loadScript(const std::string &script_path)
 }
 
 #if CHECK_CLIENT_BUILD()
-void ScriptApiBase::loadModFromMemory(const std::string &mod_name)
+void ScriptApiBase::loadModFromMemory(const std::string &mod_name, std::string init_path)
 {
 	ModNameStorer mod_name_storer(getStack(), mod_name);
 
 	sanity_check(m_type == ScriptingType::Client
 			|| m_type == ScriptingType::SSCSM);
 
-	const std::string init_filename = mod_name + ":init.lua";
-	const std::string chunk_name = "@" + init_filename;
+	if (init_path.empty())
+		init_path = mod_name + ":init.lua";
+	const std::string chunk_name = "@" + init_path;
 
-	const std::string *contents = getModVFS()->getModFile(init_filename);
+	const std::string *contents = getModVFS()->getModFile(init_path);
 	if (!contents)
 		throw ModError("Mod \"" + mod_name + "\" lacks init.lua");
 

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -14,6 +14,8 @@
 #include "server.h"
 #if CHECK_CLIENT_BUILD()
 #include "client/client.h"
+#include "client/mod_vfs.h"
+#include "sscsm/sscsm_environment.h"
 #endif
 
 #if BUILD_WITH_TRACY
@@ -265,12 +267,13 @@ void ScriptApiBase::loadModFromMemory(const std::string &mod_name)
 {
 	ModNameStorer mod_name_storer(getStack(), mod_name);
 
-	sanity_check(m_type == ScriptingType::Client);
+	sanity_check(m_type == ScriptingType::Client
+			|| m_type == ScriptingType::SSCSM);
 
 	const std::string init_filename = mod_name + ":init.lua";
 	const std::string chunk_name = "@" + init_filename;
 
-	const std::string *contents = getClient()->getModFile(init_filename);
+	const std::string *contents = getModVFS()->getModFile(init_filename);
 	if (!contents)
 		throw ModError("Mod \"" + mod_name + "\" lacks init.lua");
 
@@ -536,8 +539,18 @@ Server* ScriptApiBase::getServer()
 }
 
 #if CHECK_CLIENT_BUILD()
-Client* ScriptApiBase::getClient()
+Client *ScriptApiBase::getClient()
 {
 	return dynamic_cast<Client *>(m_gamedef);
+}
+
+ModVFS *ScriptApiBase::getModVFS()
+{
+	if (m_type == ScriptingType::Client)
+		return getClient()->getModVFS();
+	else if (m_type == ScriptingType::SSCSM)
+		return getSSCSMEnv()->getModVFS();
+	else
+		return nullptr;
 }
 #endif

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -72,7 +72,7 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 
 	lua_atpanic(m_luastack, &luaPanic);
 
-	if (m_type == ScriptingType::Client)
+	if (m_type == ScriptingType::Client || m_type == ScriptingType::SSCSM)
 		clientOpenLibs(m_luastack);
 	else
 		luaL_openlibs(m_luastack);
@@ -209,7 +209,8 @@ void ScriptApiBase::checkSetByBuiltin()
 	if (getType() == ScriptingType::Server ||
 			(getType() == ScriptingType::Async && m_gamedef) ||
 			getType() == ScriptingType::Emerge ||
-			getType() == ScriptingType::Client) {
+			getType() == ScriptingType::Client ||
+			getType() == ScriptingType::SSCSM) {
 		CHECK(CUSTOM_RIDX_READ_NODE, "read_node");
 		CHECK(CUSTOM_RIDX_PUSH_NODE, "push_node");
 	}

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -79,7 +79,7 @@ public:
 	void loadScript(const std::string &script_path);
 
 #if CHECK_CLIENT_BUILD()
-	void loadModFromMemory(const std::string &mod_name);
+	void loadModFromMemory(const std::string &mod_name, std::string init_path = "");
 #endif
 
 	void runCallbacksRaw(int nargs,

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -61,6 +61,7 @@ class GUIEngine;
 class SSCSMEnvironment;
 class ServerActiveObject;
 struct PlayerHPChangeReason;
+struct ModVFS;
 
 class ScriptApiBase : protected LuaHelper {
 public:
@@ -94,6 +95,7 @@ public:
 	Server *getServer();
 #if CHECK_CLIENT_BUILD()
 	Client *getClient();
+	ModVFS *getModVFS();
 #endif
 
 	// IMPORTANT: These cannot be used for any security-related uses, they exist

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -42,11 +42,12 @@ extern "C" {
 
 enum class ScriptingType: u8 {
 	Async, // either mainmenu (client) or ingame (server)
-	Client,
+	Client, // CPCSM
 	MainMenu,
 	Server,
 	Emerge,
 	PauseMenu,
+	SSCSM,
 };
 
 class Server;
@@ -57,6 +58,7 @@ class EmergeThread;
 class IGameDef;
 class Environment;
 class GUIEngine;
+class SSCSMEnvironment;
 class ServerActiveObject;
 struct PlayerHPChangeReason;
 
@@ -89,9 +91,9 @@ public:
 	ScriptingType getType() { return m_type; }
 
 	IGameDef *getGameDef() { return m_gamedef; }
-	Server* getServer();
+	Server *getServer();
 #if CHECK_CLIENT_BUILD()
-	Client* getClient();
+	Client *getClient();
 #endif
 
 	// IMPORTANT: These cannot be used for any security-related uses, they exist
@@ -157,6 +159,9 @@ protected:
 #if CHECK_CLIENT_BUILD()
 	GUIEngine* getGuiEngine() { return m_guiengine; }
 	void setGuiEngine(GUIEngine* guiengine) { m_guiengine = guiengine; }
+
+	SSCSMEnvironment *getSSCSMEnv() { return m_sscsm_environment; }
+	void setSSCSMEnv(SSCSMEnvironment *env) { m_sscsm_environment = env; }
 #endif
 
 	EmergeThread* getEmergeThread() { return m_emerge; }
@@ -177,14 +182,15 @@ protected:
 private:
 	static int luaPanic(lua_State *L);
 
-	lua_State      *m_luastack = nullptr;
+	lua_State        *m_luastack = nullptr;
 
-	IGameDef       *m_gamedef = nullptr;
-	Environment    *m_environment = nullptr;
+	IGameDef         *m_gamedef = nullptr;
+	Environment      *m_environment = nullptr;
 #if CHECK_CLIENT_BUILD()
-	GUIEngine      *m_guiengine = nullptr;
+	GUIEngine        *m_guiengine = nullptr;
+	SSCSMEnvironment *m_sscsm_environment = nullptr;
 #endif
-	EmergeThread   *m_emerge = nullptr;
+	EmergeThread     *m_emerge = nullptr;
 
-	ScriptingType  m_type;
+	ScriptingType     m_type;
 };

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -401,7 +401,7 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"assert",
 		"core",
 		"collectgarbage",
-		"DIR_DELIM", //TODO: useless?
+		"DIR_DELIM",
 		"error",
 		"getfenv",
 		"ipairs",
@@ -434,6 +434,10 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"date",
 		"difftime",
 		"time"
+	};
+	static const char *debug_whitelist[] = {
+		"getinfo", // used by builtin and unset before mods load //TODO
+		"traceback" //TODO
 	};
 
 #if USE_LUAJIT
@@ -479,6 +483,14 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	copy_safe(L, os_whitelist, sizeof(os_whitelist));
 	lua_setfield(L, -3, "os");
 	lua_pop(L, 1);  // Pop old OS
+
+
+	// Copy safe debug functions //TODO
+	lua_getglobal(L, "debug");
+	lua_newtable(L);
+	copy_safe(L, debug_whitelist, sizeof(debug_whitelist));
+	lua_setfield(L, -3, "debug");
+	lua_pop(L, 1);  // Pop old debug
 
 
 #if USE_LUAJIT

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -424,19 +424,33 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"xpcall",
 		// Completely safe libraries
 		"coroutine",
-		"string", //TODO: string.dump?
 		"table",
 		"math",
 		"bit",
 	};
 	static const char *os_whitelist[] = {
-		"date", // TODO: can crash? (<http://lua-users.org/wiki/SandBoxes>)
 		"difftime",
 		"time"
 	};
 	static const char *debug_whitelist[] = {
 		"getinfo", // used by builtin and unset before mods load //TODO
-		"traceback" //TODO: is this fine, or does it print paths of C functions?
+		"traceback"
+	};
+	static const char *string_whitelist[] = { // all but string.dump
+		"byte",
+		"char",
+		"dump",
+		"find",
+		"format",
+		"gmatch",
+		"gsub",
+		"len",
+		"lower",
+		"match",
+		"rep",
+		"reverse",
+		"sub",
+		"upper"
 	};
 #if USE_LUAJIT
 	static const char *jit_whitelist[] = {
@@ -493,6 +507,14 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	copy_safe(L, debug_whitelist, sizeof(debug_whitelist));
 	lua_setfield(L, -3, "debug");
 	lua_pop(L, 1);  // Pop old debug
+
+
+	// Copy safe string functions
+	lua_getglobal(L, "string");
+	lua_newtable(L);
+	copy_safe(L, string_whitelist, sizeof(string_whitelist));
+	lua_setfield(L, -3, "string");
+	lua_pop(L, 1);  // Pop old string
 
 
 #if USE_LUAJIT

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -394,6 +394,105 @@ void ScriptApiSecurity::initializeSecurityClient()
 	setLuaEnv(L, thread);
 }
 
+void ScriptApiSecurity::initializeSecuritySSCSM()
+{
+	static const char *whitelist[] = {
+		"assert",
+		"core",
+		"collectgarbage",
+		"DIR_DELIM", //TODO: useless?
+		"error",
+		"getfenv",
+		"ipairs",
+		"next",
+		"pairs",
+		"pcall",
+		"print", //TODO
+		"rawequal",
+		"rawget",
+		"rawset",
+		"select",
+		"setfenv",
+		"getmetatable",
+		"setmetatable",
+		"tonumber",
+		"tostring",
+		"type",
+		"unpack", //TODO: replace, because of UB in some lua versions
+		"_VERSION",
+		"xpcall",
+		// Completely safe libraries
+		"coroutine",
+		"string",
+		"table",
+		"math",
+		"bit",
+	};
+	static const char *os_whitelist[] = {
+		"clock", //TODO: limit resolution, to mitigate side channel attacks
+		"date",
+		"difftime",
+		"time"
+	};
+
+#if USE_LUAJIT
+	static const char *jit_whitelist[] = {
+		"arch",
+		"flush",
+		"off",
+		"on",
+		"opt",
+		"os",
+		"status",
+		"version",
+		"version_num",
+	};
+#endif
+
+	m_secure = true;
+
+	lua_State *L = getStack();
+	int thread = getThread(L);
+
+	// create an empty environment
+	createEmptyEnv(L);
+
+	// Copy safe base functions
+	lua_getglobal(L, "_G");
+	lua_getfield(L, -2, "_G");
+	copy_safe(L, whitelist, sizeof(whitelist));
+
+	// And replace unsafe ones
+	SECURE_API(g, dofile);
+	SECURE_API(g, load);
+	SECURE_API(g, loadfile);
+	SECURE_API(g, loadstring);
+	SECURE_API(g, require);
+	lua_pop(L, 2);
+
+
+
+	// Copy safe OS functions
+	lua_getglobal(L, "os");
+	lua_newtable(L);
+	copy_safe(L, os_whitelist, sizeof(os_whitelist));
+	lua_setfield(L, -3, "os");
+	lua_pop(L, 1);  // Pop old OS
+
+
+#if USE_LUAJIT
+	// Copy safe jit functions, if they exist
+	lua_getglobal(L, "jit");
+	lua_newtable(L);
+	copy_safe(L, jit_whitelist, sizeof(jit_whitelist));
+	lua_setfield(L, -3, "jit");
+	lua_pop(L, 1);  // Pop old jit
+#endif
+
+	// Set the environment to the one we created earlier
+	setLuaEnv(L, thread);
+}
+
 #endif
 
 int ScriptApiSecurity::getThread(lua_State *L)
@@ -791,10 +890,11 @@ int ScriptApiSecurity::sl_g_loadfile(lua_State *L)
 #if CHECK_CLIENT_BUILD()
 	ScriptApiBase *script = ModApiBase::getScriptApiBase(L);
 
-	// Client implementation
-	if (script->getType() == ScriptingType::Client) {
+	// SSCSM & CPCSM implementation
+	if (script->getType() == ScriptingType::Client
+			|| script->getType() == ScriptingType::SSCSM) {
 		std::string path = readParam<std::string>(L, 1);
-		const std::string *contents = script->getClient()->getModFile(path);
+		const std::string *contents = script->getClient()->getModFile(path); //TODO
 		if (!contents) {
 			std::string error_msg = "Couldn't find script called: " + path;
 			lua_pushnil(L);

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -437,7 +437,7 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	};
 	static const char *debug_whitelist[] = {
 		"getinfo", // used by builtin and unset before mods load //TODO
-		"traceback" //TODO
+		"traceback" //TODO: is this fine, or does it print paths of C functions?
 	};
 
 #if USE_LUAJIT
@@ -504,6 +504,8 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 
 	// Set the environment to the one we created earlier
 	setLuaEnv(L, thread);
+
+	// TODO: tostring({})
 }
 
 #endif

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -439,7 +439,6 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	static const char *string_whitelist[] = { // all but string.dump
 		"byte",
 		"char",
-		"dump",
 		"find",
 		"format",
 		"gmatch",

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -502,8 +502,6 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 
 	// Set the environment to the one we created earlier
 	setLuaEnv(L, thread);
-
-	// TODO: tostring({})
 }
 
 #endif

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -8,6 +8,7 @@
 #include "server.h"
 #if CHECK_CLIENT_BUILD()
 #include "client/client.h"
+#include "client/mod_vfs.h"
 #endif
 #include "content/mods.h" // ModSpec
 #include "settings.h"
@@ -894,7 +895,7 @@ int ScriptApiSecurity::sl_g_loadfile(lua_State *L)
 	if (script->getType() == ScriptingType::Client
 			|| script->getType() == ScriptingType::SSCSM) {
 		std::string path = readParam<std::string>(L, 1);
-		const std::string *contents = script->getClient()->getModFile(path); //TODO
+		const std::string *contents = script->getModVFS()->getModFile(path);
 		if (!contents) {
 			std::string error_msg = "Couldn't find script called: " + path;
 			lua_pushnil(L);

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -408,7 +408,6 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"next",
 		"pairs",
 		"pcall",
-		"print", //TODO
 		"rawequal",
 		"rawget",
 		"rawset",
@@ -419,7 +418,7 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"tonumber",
 		"tostring",
 		"type",
-		"unpack", //TODO: replace, because of UB in some lua versions
+		"unpack",
 		"_VERSION",
 		"xpcall",
 		// Completely safe libraries
@@ -439,7 +438,6 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"getinfo", // used by builtin and unset before mods load //TODO
 		"traceback" //TODO: is this fine, or does it print paths of C functions?
 	};
-
 #if USE_LUAJIT
 	static const char *jit_whitelist[] = {
 		"arch",
@@ -485,7 +483,7 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	lua_pop(L, 1);  // Pop old OS
 
 
-	// Copy safe debug functions //TODO
+	// Copy safe debug functions
 	lua_getglobal(L, "debug");
 	lua_newtable(L);
 	copy_safe(L, debug_whitelist, sizeof(debug_whitelist));

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -433,7 +433,7 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"time"
 	};
 	static const char *debug_whitelist[] = {
-		"getinfo", // used by builtin and unset before mods load //TODO
+		"getinfo", // used by client builtin and unset before mods load
 		"traceback"
 	};
 	static const char *string_whitelist[] = { // all but string.dump

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -12,6 +12,7 @@
 #endif
 #include "content/mods.h" // ModSpec
 #include "settings.h"
+#include "constants.h"
 
 #include <cerrno>
 #include <string>
@@ -429,7 +430,6 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"bit",
 	};
 	static const char *os_whitelist[] = {
-		"clock", //TODO: limit resolution, to mitigate side channel attacks
 		"date",
 		"difftime",
 		"time"
@@ -479,6 +479,10 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	lua_getglobal(L, "os");
 	lua_newtable(L);
 	copy_safe(L, os_whitelist, sizeof(os_whitelist));
+
+	// And replace unsafe ones
+	SECURE_API(os, clock);
+
 	lua_setfield(L, -3, "os");
 	lua_pop(L, 1);  // Pop old OS
 
@@ -1088,6 +1092,15 @@ int ScriptApiSecurity::sl_os_setlocale(lua_State *L)
 	if (cat)
 		lua_pushvalue(L, 2);
 	lua_call(L, cat ? 2 : 1, 1);
+	return 1;
+}
+
+
+int ScriptApiSecurity::sl_os_clock(lua_State *L)
+{
+	auto t = clock();
+	t = t - t % (SSCSM_CLOCK_RESOLUTION_US * CLOCKS_PER_SEC / 1'000'000);
+	lua_pushnumber(L, static_cast<lua_Number>(t) / static_cast<lua_Number>(CLOCKS_PER_SEC));
 	return 1;
 }
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -424,13 +424,13 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 		"xpcall",
 		// Completely safe libraries
 		"coroutine",
-		"string",
+		"string", //TODO: string.dump?
 		"table",
 		"math",
 		"bit",
 	};
 	static const char *os_whitelist[] = {
-		"date",
+		"date", // TODO: can crash? (<http://lua-users.org/wiki/SandBoxes>)
 		"difftime",
 		"time"
 	};

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -117,6 +117,7 @@ private:
 	static int sl_os_rename(lua_State *L);
 	static int sl_os_remove(lua_State *L);
 	static int sl_os_setlocale(lua_State *L);
+	static int sl_os_clock(lua_State *L);
 
 	static int sl_debug_getinfo(lua_State *L);
 };

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -117,6 +117,8 @@ private:
 	static int sl_os_rename(lua_State *L);
 	static int sl_os_remove(lua_State *L);
 	static int sl_os_setlocale(lua_State *L);
+
+	// reduced precision (for SSCSM)
 	static int sl_os_clock(lua_State *L);
 
 	static int sl_debug_getinfo(lua_State *L);

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -31,8 +31,10 @@ public:
 	void initializeSecurity();
 #if CHECK_CLIENT_BUILD()
 	void initializeSecurityClient();
+	void initializeSecuritySSCSM();
 #else
-	inline void initializeSecurityClient() { assert(0); }
+	void initializeSecurityClient() { assert(0); }
+	void initializeSecuritySSCSM() { assert(0); }
 #endif
 
 	// Checks if the Lua state has been secured

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -17,8 +17,7 @@ void ScriptApiSSCSM::load_mods(const std::vector<std::string> &init_paths)
 		actionstream << "    " << p << ":\n";
 		auto f = env->readVFSFile(p);
 		if (!f.has_value()) {
-			env->setFatalError("load_mods(): File doesn't exist: " + p);
-			return;
+			throw ModError("load_mods(): File doesn't exist: " + p);
 		}
 		actionstream << *f << "\n";
 	}
@@ -33,9 +32,5 @@ void ScriptApiSSCSM::environment_step(float dtime)
 	lua_getfield(L, -1, "registered_globalsteps");
 	// Call callbacks
 	lua_pushnumber(L, dtime);
-	try {
-		runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
-	} catch (LuaError &e) {
-		getSSCSMEnv()->setFatalError(e);
-	}
+	runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
 }

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -7,19 +7,12 @@
 #include "s_internal.h"
 #include "script/sscsm/sscsm_environment.h"
 
-void ScriptApiSSCSM::load_mods(const std::vector<std::string> &init_paths)
+void ScriptApiSSCSM::load_mods(const std::vector<std::pair<std::string, std::string>> &mods)
 {
-	//TODO
-
-	SSCSMEnvironment *env = getSSCSMEnv();
-	actionstream << "load_mods:\n";
-	for (const auto &p : init_paths) {
-		actionstream << "    " << p << ":\n";
-		auto f = env->readVFSFile(p);
-		if (!f.has_value()) {
-			throw ModError("load_mods(): File doesn't exist: " + p);
-		}
-		actionstream << *f << "\n";
+	infostream << "Loading SSCSMs:" << std::endl;
+	for (const auto &m : mods) {
+		infostream << "Loading SSCSM " << m.first << std::endl;
+		loadModFromMemory(m.first, m.second);
 	}
 }
 

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "s_sscsm.h"
+
+#include "s_internal.h"
+#include "script/sscsm/sscsm_environment.h"
+
+void ScriptApiSSCSM::load_mods(const std::vector<std::string> &init_paths)
+{
+	//TODO
+}
+
+void ScriptApiSSCSM::environment_step(float dtime)
+{
+	SCRIPTAPI_PRECHECKHEADER
+
+	// Get core.registered_globalsteps
+	lua_getglobal(L, "core");
+	lua_getfield(L, -1, "registered_globalsteps");
+	// Call callbacks
+	lua_pushnumber(L, dtime);
+	try {
+		runCallbacks(1, RUN_CALLBACKS_MODE_FIRST);
+	} catch (LuaError &e) {
+		getSSCSMEnv()->setFatalError(e);
+	}
+}

--- a/src/script/cpp_api/s_sscsm.cpp
+++ b/src/script/cpp_api/s_sscsm.cpp
@@ -10,6 +10,18 @@
 void ScriptApiSSCSM::load_mods(const std::vector<std::string> &init_paths)
 {
 	//TODO
+
+	SSCSMEnvironment *env = getSSCSMEnv();
+	actionstream << "load_mods:\n";
+	for (const auto &p : init_paths) {
+		actionstream << "    " << p << ":\n";
+		auto f = env->readVFSFile(p);
+		if (!f.has_value()) {
+			env->setFatalError("load_mods(): File doesn't exist: " + p);
+			return;
+		}
+		actionstream << *f << "\n";
+	}
 }
 
 void ScriptApiSSCSM::environment_step(float dtime)

--- a/src/script/cpp_api/s_sscsm.h
+++ b/src/script/cpp_api/s_sscsm.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "cpp_api/s_base.h"
+
+class ScriptApiSSCSM : virtual public ScriptApiBase
+{
+public:
+	void load_mods(const std::vector<std::string> &init_paths);
+
+	void environment_step(float dtime);
+};

--- a/src/script/cpp_api/s_sscsm.h
+++ b/src/script/cpp_api/s_sscsm.h
@@ -9,7 +9,7 @@
 class ScriptApiSSCSM : virtual public ScriptApiBase
 {
 public:
-	void load_mods(const std::vector<std::string> &init_paths);
+	void load_mods(const std::vector<std::pair<std::string, std::string>> &mods);
 
 	void environment_step(float dtime);
 };

--- a/src/script/lua_api/CMakeLists.txt
+++ b/src/script/lua_api/CMakeLists.txt
@@ -43,4 +43,5 @@ set(client_SCRIPT_LUA_API_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/l_particles_local.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_pause_menu.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/l_storage.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/l_sscsm.cpp
 	PARENT_SCOPE)

--- a/src/script/lua_api/l_base.cpp
+++ b/src/script/lua_api/l_base.cpp
@@ -57,6 +57,11 @@ GUIEngine *ModApiBase::getGuiEngine(lua_State *L)
 {
 	return getScriptApiBase(L)->getGuiEngine();
 }
+
+SSCSMEnvironment *ModApiBase::getSSCSMEnv(lua_State *L)
+{
+	return getScriptApiBase(L)->getSSCSMEnv();
+}
 #endif
 
 EmergeThread *ModApiBase::getEmergeThread(lua_State *L)

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -22,6 +22,7 @@ class EmergeThread;
 class ScriptApiBase;
 class Server;
 class Environment;
+class SSCSMEnvironment;
 class ServerInventoryManager;
 
 class ModApiBase : protected LuaHelper {
@@ -32,6 +33,7 @@ public:
 	#if CHECK_CLIENT_BUILD()
 	static Client*          getClient(lua_State *L);
 	static GUIEngine*       getGuiEngine(lua_State *L);
+	static SSCSMEnvironment *getSSCSMEnv(lua_State *L);
 	#endif // !SERVER
 	static EmergeThread*    getEmergeThread(lua_State *L);
 

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -59,7 +59,7 @@ int ModApiClient::l_get_current_modname(lua_State *L)
 int ModApiClient::l_get_modpath(lua_State *L)
 {
 	std::string modname = readParam<std::string>(L, 1);
-	// Client mods use a virtual filesystem, see Client::scanModSubfolder()
+	// Client mods use a virtual filesystem, see ModVFS::scanModSubfolder()
 	std::string path = modname + ":";
 	lua_pushstring(L, path.c_str());
 	return 1;
@@ -284,7 +284,12 @@ int ModApiClient::l_get_privilege_list(lua_State *L)
 // get_builtin_path()
 int ModApiClient::l_get_builtin_path(lua_State *L)
 {
-	lua_pushstring(L, BUILTIN_MOD_NAME ":");
+	if (getScriptApiBase(L)->getType() == ScriptingType::Client)
+		lua_pushstring(L, BUILTIN_MOD_NAME ":");
+	else if (getScriptApiBase(L)->getType() == ScriptingType::SSCSM)
+		lua_pushstring(L, "*client_builtin*:"); //TODO
+	else
+		return 0;
 	return 1;
 }
 
@@ -321,4 +326,12 @@ void ModApiClient::Initialize(lua_State *L, int top)
 	API_FCT(get_builtin_path);
 	API_FCT(get_language);
 	API_FCT(get_csm_restrictions);
+}
+
+void ModApiClient::InitializeSSCSM(lua_State *L, int top)
+{
+	API_FCT(get_current_modname);
+	API_FCT(get_modpath);
+	API_FCT(print);
+	API_FCT(get_builtin_path);
 }

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -285,10 +285,14 @@ int ModApiClient::l_get_privilege_list(lua_State *L)
 int ModApiClient::l_get_builtin_path(lua_State *L)
 {
 	std::string modname;
-	if (getScriptApiBase(L)->getType() == ScriptingType::Client)
+	if (getScriptApiBase(L)->getType() == ScriptingType::Client) {
 		modname = BUILTIN_MOD_NAME;
-	else if (getScriptApiBase(L)->getType() == ScriptingType::SSCSM)
+	} else if (getScriptApiBase(L)->getType() == ScriptingType::SSCSM) {
+		// get_builtin_path() is only called in builtin, so this is fine
 		modname = ScriptApiBase::getCurrentModNameInsecure(L);
+		if (modname != "*client_builtin*" && modname != "*server_builtin*")
+			modname = "";
+	}
 
 	if (modname.empty())
 		return 0;

--- a/src/script/lua_api/l_client.cpp
+++ b/src/script/lua_api/l_client.cpp
@@ -284,12 +284,16 @@ int ModApiClient::l_get_privilege_list(lua_State *L)
 // get_builtin_path()
 int ModApiClient::l_get_builtin_path(lua_State *L)
 {
+	std::string modname;
 	if (getScriptApiBase(L)->getType() == ScriptingType::Client)
-		lua_pushstring(L, BUILTIN_MOD_NAME ":");
+		modname = BUILTIN_MOD_NAME;
 	else if (getScriptApiBase(L)->getType() == ScriptingType::SSCSM)
-		lua_pushstring(L, "*client_builtin*:"); //TODO
-	else
+		modname = ScriptApiBase::getCurrentModNameInsecure(L);
+
+	if (modname.empty())
 		return 0;
+
+	lua_pushstring(L, (modname + ":").c_str());
 	return 1;
 }
 

--- a/src/script/lua_api/l_client.h
+++ b/src/script/lua_api/l_client.h
@@ -69,4 +69,5 @@ private:
 
 public:
 	static void Initialize(lua_State *L, int top);
+	static void InitializeSSCSM(lua_State *L, int top);
 };

--- a/src/script/lua_api/l_sscsm.cpp
+++ b/src/script/lua_api/l_sscsm.cpp
@@ -13,12 +13,43 @@
 #include "mapnode.h"
 
 // print(text)
-int ModApiSSCSM::l_print(lua_State *L)
+int ModApiSSCSM::l_print(lua_State *L) //TODO: not core.print
 {
 	auto request = SSCSMRequestPrint{};
 	request.text = luaL_checkstring(L, 1);
 	getSSCSMEnv(L)->doRequest(std::move(request));
 
+	return 0;
+}
+
+// log([level], text)
+int ModApiSSCSM::l_log(lua_State *L)
+{
+	/*
+	auto request = SSCSMRequestLog{};
+	request.text = luaL_checkstring(L, 1);
+	getSSCSMEnv(L)->doRequest(std::move(request));
+
+	std::string_view text;
+	LogLevel level = LL_NONE;
+	if (lua_isnoneornil(L, 2)) {
+		text = readParam<std::string_view>(L, 1);
+	} else {
+		auto name = readParam<std::string_view>(L, 1);
+		text = readParam<std::string_view>(L, 2);
+		// if (name == "deprecated") { //TODO
+			// log_deprecated(L, text, 2);
+			// return 0;
+		// }
+		level = Logger::stringToLevel(name);
+		if (level == LL_MAX) {
+			warningstream << "Tried to log at unknown level '" << name
+				<< "'. Defaulting to \"none\"." << std::endl;
+			level = LL_WARNING;
+		}
+	}
+	g_logger.log(level, text);
+	*/
 	return 0;
 }
 
@@ -46,5 +77,6 @@ int ModApiSSCSM::l_get_node_or_nil(lua_State *L)
 void ModApiSSCSM::Initialize(lua_State *L, int top)
 {
 	API_FCT(print);
+	API_FCT(log);
 	API_FCT(get_node_or_nil);
 }

--- a/src/script/lua_api/l_sscsm.cpp
+++ b/src/script/lua_api/l_sscsm.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "l_sscsm.h"
+
+#include "common/c_content.h"
+#include "common/c_converter.h"
+#include "l_internal.h"
+#include "log.h"
+#include "script/sscsm/sscsm_environment.h"
+#include "mapnode.h"
+
+// print(text)
+int ModApiSSCSM::l_print(lua_State *L)
+{
+	// TODO: send request to main process
+	std::string text = luaL_checkstring(L, 1);
+	rawstream << text << std::endl;
+	return 0;
+}
+
+// get_node_or_nil(pos)
+// pos = {x=num, y=num, z=num}
+int ModApiSSCSM::l_get_node_or_nil(lua_State *L)
+{
+	// pos
+	v3s16 pos = read_v3s16(L, 1);
+
+	// Do it
+	bool pos_ok = true;
+	MapNode n = getSSCSMEnv(L)->requestGetNode(pos); //TODO: add pos_ok to request
+	if (pos_ok) {
+		// Return node
+		pushnode(L, n);
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+void ModApiSSCSM::Initialize(lua_State *L, int top)
+{
+	API_FCT(print);
+	API_FCT(get_node_or_nil);
+}

--- a/src/script/lua_api/l_sscsm.cpp
+++ b/src/script/lua_api/l_sscsm.cpp
@@ -7,51 +7,8 @@
 #include "common/c_content.h"
 #include "common/c_converter.h"
 #include "l_internal.h"
-#include "log.h"
 #include "script/sscsm/sscsm_environment.h"
 #include "script/sscsm/sscsm_requests.h"
-#include "mapnode.h"
-
-// print(text)
-int ModApiSSCSM::l_print(lua_State *L) //TODO: not core.print
-{
-	auto request = SSCSMRequestPrint{};
-	request.text = luaL_checkstring(L, 1);
-	getSSCSMEnv(L)->doRequest(std::move(request));
-
-	return 0;
-}
-
-// log([level], text)
-int ModApiSSCSM::l_log(lua_State *L)
-{
-	/*
-	auto request = SSCSMRequestLog{};
-	request.text = luaL_checkstring(L, 1);
-	getSSCSMEnv(L)->doRequest(std::move(request));
-
-	std::string_view text;
-	LogLevel level = LL_NONE;
-	if (lua_isnoneornil(L, 2)) {
-		text = readParam<std::string_view>(L, 1);
-	} else {
-		auto name = readParam<std::string_view>(L, 1);
-		text = readParam<std::string_view>(L, 2);
-		// if (name == "deprecated") { //TODO
-			// log_deprecated(L, text, 2);
-			// return 0;
-		// }
-		level = Logger::stringToLevel(name);
-		if (level == LL_MAX) {
-			warningstream << "Tried to log at unknown level '" << name
-				<< "'. Defaulting to \"none\"." << std::endl;
-			level = LL_WARNING;
-		}
-	}
-	g_logger.log(level, text);
-	*/
-	return 0;
-}
 
 // get_node_or_nil(pos)
 // pos = {x=num, y=num, z=num}
@@ -76,7 +33,5 @@ int ModApiSSCSM::l_get_node_or_nil(lua_State *L)
 
 void ModApiSSCSM::Initialize(lua_State *L, int top)
 {
-	API_FCT(print);
-	API_FCT(log);
 	API_FCT(get_node_or_nil);
 }

--- a/src/script/lua_api/l_sscsm.h
+++ b/src/script/lua_api/l_sscsm.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "lua_api/l_base.h"
+
+class ModApiSSCSM : public ModApiBase
+{
+private:
+	// print(text)
+	static int l_print(lua_State *L);
+
+	// get_node_or_nil(pos)
+	static int l_get_node_or_nil(lua_State *L);
+
+public:
+	static void Initialize(lua_State *L, int top);
+};

--- a/src/script/lua_api/l_sscsm.h
+++ b/src/script/lua_api/l_sscsm.h
@@ -12,6 +12,9 @@ private:
 	// print(text)
 	static int l_print(lua_State *L);
 
+	// log([level], text)
+	static int l_log(lua_State *L);
+
 	// get_node_or_nil(pos)
 	static int l_get_node_or_nil(lua_State *L);
 

--- a/src/script/lua_api/l_sscsm.h
+++ b/src/script/lua_api/l_sscsm.h
@@ -9,12 +9,6 @@
 class ModApiSSCSM : public ModApiBase
 {
 private:
-	// print(text)
-	static int l_print(lua_State *L);
-
-	// log([level], text)
-	static int l_log(lua_State *L);
-
 	// get_node_or_nil(pos)
 	static int l_get_node_or_nil(lua_State *L);
 

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -28,6 +28,7 @@
 #include "util/png.h"
 #include "player.h"
 #include "daynightratio.h"
+#include "constants.h"
 #include <cstdio>
 
 // only available in zstd 1.3.5+
@@ -77,6 +78,16 @@ int ModApiUtil::l_get_us_time(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	lua_pushnumber(L, porting::getTimeUs());
+	return 1;
+}
+
+// get_us_time() for SSCSM
+int ModApiUtil::l_get_us_time_sscsm(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	auto t = porting::getTimeUs();
+	t = t - t % SSCSM_CLOCK_RESOLUTION_US;
+	lua_pushnumber(L, t);
 	return 1;
 }
 
@@ -817,7 +828,7 @@ void ModApiUtil::InitializeSSCSM(lua_State *L, int top)
 {
 	API_FCT(log);
 
-	API_FCT(get_us_time); //TODO: is us to precise?
+	registerFunction(L, "get_us_time", l_get_us_time_sscsm, top);
 
 	API_FCT(parse_json);
 	API_FCT(write_json);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -813,6 +813,37 @@ void ModApiUtil::InitializeClient(lua_State *L, int top)
 	lua_setfield(L, top, "settings");
 }
 
+void ModApiUtil::InitializeSSCSM(lua_State *L, int top)
+{
+	API_FCT(log);
+
+	API_FCT(get_us_time); //TODO: is us to precise?
+
+	API_FCT(parse_json);
+	API_FCT(write_json);
+
+	API_FCT(is_yes);
+
+	API_FCT(compress);
+	API_FCT(decompress);
+
+	API_FCT(encode_base64);
+	API_FCT(decode_base64);
+
+	API_FCT(get_version);
+	API_FCT(sha1);
+	API_FCT(sha256);
+	API_FCT(colorspec_to_colorstring);
+	API_FCT(colorspec_to_bytes);
+	API_FCT(colorspec_to_table);
+	API_FCT(time_to_day_night_ratio);
+
+	API_FCT(get_last_run_mod);
+	API_FCT(set_last_run_mod);
+
+	API_FCT(urlencode);
+}
+
 void ModApiUtil::InitializeAsync(lua_State *L, int top)
 {
 	API_FCT(log);

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -137,4 +137,5 @@ public:
 	static void Initialize(lua_State *L, int top);
 	static void InitializeAsync(lua_State *L, int top);
 	static void InitializeClient(lua_State *L, int top);
+	static void InitializeSSCSM(lua_State *L, int top);
 };

--- a/src/script/lua_api/l_util.h
+++ b/src/script/lua_api/l_util.h
@@ -28,6 +28,9 @@ private:
 	// get us precision time
 	static int l_get_us_time(lua_State *L);
 
+	// get_us_time() for SSCSM. less precise
+	static int l_get_us_time_sscsm(lua_State *L);
+
 	// parse_json(str[, nullvalue])
 	static int l_parse_json(lua_State *L);
 

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "scripting_sscsm.h"
+
+SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env)
+{
+	setSSCSMEnv(env);
+
+	//TODO
+}
+
+void SSCSMScripting::initializeModApi(lua_State *L, int top)
+{
+	//TODO
+}

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -9,7 +9,7 @@
 #include "lua_api/l_client.h"
 
 SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
-	ScriptApiBase(ScriptingType::SSCSM) //TODO: use different CUSTOM_RIDX_ERROR_HANDLER, or set debug.traceback
+	ScriptApiBase(ScriptingType::SSCSM)
 {
 	setSSCSMEnv(env);
 
@@ -27,8 +27,6 @@ SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
 	// Push builtin initialization type
 	lua_pushstring(L, "sscsm");
 	lua_setglobal(L, "INIT");
-
-	// infostream << "SCRIPTAPI: Initialized SSCSM modules" << std::endl;
 }
 
 void SSCSMScripting::initializeModApi(lua_State *L, int top)

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -31,7 +31,7 @@ SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
 
 void SSCSMScripting::initializeModApi(lua_State *L, int top)
 {
-	ModApiUtil::InitializeClient(L, top); //TODO: probably needs an InitializeSSCSM
+	ModApiUtil::InitializeSSCSM(L, top);
 	ModApiClient::InitializeSSCSM(L, top);
 	ModApiSSCSM::Initialize(L, top);
 }

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -8,7 +8,7 @@
 // #include "lua_api/l_util.h"
 
 SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
-	ScriptApiBase(ScriptingType::SSCSM)
+	ScriptApiBase(ScriptingType::SSCSM) //TODO: use different CUSTOM_RIDX_ERROR_HANDLER, or set debug.traceback
 {
 	setSSCSMEnv(env);
 

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -3,16 +3,36 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include "scripting_sscsm.h"
+#include "cpp_api/s_internal.h"
+#include "lua_api/l_sscsm.h"
+// #include "lua_api/l_util.h"
 
 SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
 	ScriptApiBase(ScriptingType::SSCSM)
 {
 	setSSCSMEnv(env);
 
-	//TODO
+	SCRIPTAPI_PRECHECKHEADER
+
+	initializeSecuritySSCSM();
+
+	lua_getglobal(L, "core");
+	int top = lua_gettop(L);
+
+	// Initialize our lua_api modules
+	initializeModApi(L, top);
+	lua_pop(L, 1);
+
+	// Push builtin initialization type
+	lua_pushstring(L, "sscsm");
+	lua_setglobal(L, "INIT");
+
+	// infostream << "SCRIPTAPI: Initialized SSCSM modules" << std::endl;
 }
 
 void SSCSMScripting::initializeModApi(lua_State *L, int top)
 {
-	//TODO
+	// Initialize mod API modules
+	// ModApiUtil::Initialize(L, top);
+	ModApiSSCSM::Initialize(L, top);
 }

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -4,7 +4,8 @@
 
 #include "scripting_sscsm.h"
 
-SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env)
+SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
+	ScriptApiBase(ScriptingType::SSCSM)
 {
 	setSSCSMEnv(env);
 

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -5,7 +5,8 @@
 #include "scripting_sscsm.h"
 #include "cpp_api/s_internal.h"
 #include "lua_api/l_sscsm.h"
-// #include "lua_api/l_util.h"
+#include "lua_api/l_util.h"
+#include "lua_api/l_client.h"
 
 SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
 	ScriptApiBase(ScriptingType::SSCSM) //TODO: use different CUSTOM_RIDX_ERROR_HANDLER, or set debug.traceback
@@ -32,7 +33,7 @@ SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
 
 void SSCSMScripting::initializeModApi(lua_State *L, int top)
 {
-	// Initialize mod API modules
-	// ModApiUtil::Initialize(L, top);
+	ModApiUtil::InitializeClient(L, top); //TODO: probably needs an InitializeSSCSM
+	ModApiClient::InitializeSSCSM(L, top);
 	ModApiSSCSM::Initialize(L, top);
 }

--- a/src/script/scripting_sscsm.h
+++ b/src/script/scripting_sscsm.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "cpp_api/s_base.h"
+#include "cpp_api/s_sscsm.h"
+#include "cpp_api/s_security.h"
+
+class SSCSMScripting :
+		virtual public ScriptApiBase,
+		public ScriptApiSSCSM,
+		public ScriptApiSecurity
+{
+public:
+	SSCSMScripting(SSCSMEnvironment *env);
+
+protected:
+	bool checkPathInternal(const std::string &abs_path, bool write_required,
+		bool *write_allowed) { return false; };
+
+private:
+	void initializeModApi(lua_State *L, int top);
+};

--- a/src/script/sscsm/CMakeLists.txt
+++ b/src/script/sscsm/CMakeLists.txt
@@ -1,5 +1,7 @@
+file(GLOB client_SCRIPT_SSCSM_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
 set(client_SCRIPT_SSCSM_SRCS
+	${client_SCRIPT_SSCSM_HDRS}
 	${CMAKE_CURRENT_SOURCE_DIR}/sscsm_controller.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/sscsm_environment.cpp
 	PARENT_SCOPE)

--- a/src/script/sscsm/CMakeLists.txt
+++ b/src/script/sscsm/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+set(client_SCRIPT_SSCSM_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/sscsm_controller.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/sscsm_environment.cpp
+	PARENT_SCOPE)

--- a/src/script/sscsm/sscsm_controller.cpp
+++ b/src/script/sscsm/sscsm_controller.cpp
@@ -53,6 +53,9 @@ void SSCSMController::runEvent(Client *client, std::unique_ptr<ISSCSMEvent> even
 	while (true) {
 		auto request = deserializeSSCSMRequest(m_channel->exchangeB(std::move(answer)));
 
+		// SSCSMRequestPollNextEvent means `event` is finished and we need to
+		// answer with the next event (that will be passed in a subsequent runEvent()
+		// call)
 		if (dynamic_cast<SSCSMRequestPollNextEvent *>(request.get()) != nullptr) {
 			break;
 		}

--- a/src/script/sscsm/sscsm_controller.cpp
+++ b/src/script/sscsm/sscsm_controller.cpp
@@ -60,10 +60,3 @@ void SSCSMController::runEvent(Client *client, std::unique_ptr<ISSCSMEvent> even
 		answer = handleRequest(client, request.get());
 	}
 }
-
-void SSCSMController::eventOnStep(Client *client, f32 dtime)
-{
-	auto event = std::make_unique<SSCSMEventOnStep>();
-	event->dtime = dtime;
-	runEvent(client, std::move(event));
-}

--- a/src/script/sscsm/sscsm_controller.cpp
+++ b/src/script/sscsm/sscsm_controller.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "sscsm_controller.h"
+#include "sscsm_environment.h"
+#include "sscsm_requests.h"
+#include "sscsm_events.h"
+#include "sscsm_stupid_channel.h"
+
+std::unique_ptr<SSCSMController> SSCSMController::create()
+{
+	auto channel = std::make_shared<StupidChannel>();
+	auto thread = std::make_unique<SSCSMEnvironment>(channel);
+	thread->start();
+
+	// Wait for thread to finish initializing.
+	auto req0 = deserializeSSCSMRequest(channel->recvB());
+	FATAL_ERROR_IF(!dynamic_cast<SSCSMRequestPollNextEvent *>(req0.get()),
+			"First request must be pollEvent.");
+
+	return std::make_unique<SSCSMController>(std::move(thread), channel);
+}
+
+SSCSMController::SSCSMController(std::unique_ptr<SSCSMEnvironment> thread,
+		std::shared_ptr<StupidChannel> channel) :
+	m_thread(std::move(thread)), m_channel(std::move(channel))
+{
+}
+
+SSCSMController::~SSCSMController()
+{
+	// send tear-down
+	auto answer = SSCSMRequestPollNextEvent::Answer{};
+	answer.next_event = std::make_unique<SSCSMEventTearDown>();
+	m_channel->sendB(serializeSSCSMAnswer(std::move(answer)));
+	// wait for death
+	m_thread->stop();
+	m_thread->wait();
+}
+
+SerializedSSCSMAnswer SSCSMController::handleRequest(Client *client, ISSCSMRequest *req)
+{
+	return req->exec(client);
+}
+
+void SSCSMController::runEvent(Client *client, std::unique_ptr<ISSCSMEvent> event)
+{
+	auto answer0 = SSCSMRequestPollNextEvent::Answer{};
+	answer0.next_event = std::move(event);
+	auto answer = serializeSSCSMAnswer(std::move(answer0));
+
+	while (true) {
+		auto request = deserializeSSCSMRequest(m_channel->exchangeB(std::move(answer)));
+
+		if (dynamic_cast<SSCSMRequestPollNextEvent *>(request.get()) != nullptr) {
+			break;
+		}
+
+		answer = handleRequest(client, request.get());
+	}
+}
+
+void SSCSMController::eventOnStep(Client *client, f32 dtime)
+{
+	auto event = std::make_unique<SSCSMEventOnStep>();
+	event->dtime = dtime;
+	runEvent(client, std::move(event));
+}

--- a/src/script/sscsm/sscsm_controller.h
+++ b/src/script/sscsm/sscsm_controller.h
@@ -13,6 +13,14 @@
 class SSCSMEnvironment;
 class StupidChannel;
 
+/**
+ * The purpose of this class is to:
+ * * Be the RAII owner of the SSCSM process.
+ * * Send events to SSCSM process, and process requests. (`runEvent`)
+ * * Hide details (e.g. that it is a separate process, or that it has to do IPC calls).
+ *
+ * See also SSCSMEnvironment for other side.
+ */
 class SSCSMController
 {
 	std::unique_ptr<SSCSMEnvironment> m_thread;

--- a/src/script/sscsm/sscsm_controller.h
+++ b/src/script/sscsm/sscsm_controller.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include "irrlichttypes.h"
+#include "sscsm_irequest.h"
+#include "sscsm_ievent.h"
+#include "util/basic_macros.h"
+
+class SSCSMEnvironment;
+class StupidChannel;
+
+class SSCSMController
+{
+	std::unique_ptr<SSCSMEnvironment> m_thread;
+	std::shared_ptr<StupidChannel> m_channel;
+
+	SerializedSSCSMAnswer handleRequest(Client *client, ISSCSMRequest *req);
+
+public:
+	static std::unique_ptr<SSCSMController> create();
+
+	SSCSMController(std::unique_ptr<SSCSMEnvironment> thread,
+			std::shared_ptr<StupidChannel> channel);
+
+	~SSCSMController();
+
+	DISABLE_CLASS_COPY(SSCSMController);
+
+	// Handles requests until the next event is polled
+	void runEvent(Client *client, std::unique_ptr<ISSCSMEvent> event);
+
+	void eventOnStep(Client *client, f32 dtime);
+};

--- a/src/script/sscsm/sscsm_controller.h
+++ b/src/script/sscsm/sscsm_controller.h
@@ -32,6 +32,4 @@ public:
 
 	// Handles requests until the next event is polled
 	void runEvent(Client *client, std::unique_ptr<ISSCSMEvent> event);
-
-	void eventOnStep(Client *client, f32 dtime);
 };

--- a/src/script/sscsm/sscsm_environment.cpp
+++ b/src/script/sscsm/sscsm_environment.cpp
@@ -22,7 +22,11 @@ SSCSMEnvironment::~SSCSMEnvironment() = default;
 void *SSCSMEnvironment::run()
 {
 	while (true) {
-		auto next_event = requestPollNextEvent();
+		auto next_event = [&]{
+			auto request = SSCSMRequestPollNextEvent{};
+			auto answer = doRequest(std::move(request));
+			return std::move(answer.next_event);
+		}();
 
 		if (dynamic_cast<SSCSMEventTearDown *>(next_event.get())) {
 			break;
@@ -66,19 +70,4 @@ void SSCSMEnvironment::setFatalError(const std::string &reason)
 	auto request = SSCSMRequestSetFatalError{};
 	request.reason = reason;
 	doRequest(std::move(request));
-}
-
-std::unique_ptr<ISSCSMEvent> SSCSMEnvironment::requestPollNextEvent()
-{
-	auto request = SSCSMRequestPollNextEvent{};
-	auto answer = doRequest(std::move(request));
-	return std::move(answer.next_event);
-}
-
-MapNode SSCSMEnvironment::requestGetNode(v3s16 pos)
-{
-	auto request = SSCSMRequestGetNode{};
-	request.pos = pos;
-	auto answer = doRequest(std::move(request));
-	return answer.node;
 }

--- a/src/script/sscsm/sscsm_environment.cpp
+++ b/src/script/sscsm/sscsm_environment.cpp
@@ -8,6 +8,13 @@
 #include "sscsm_stupid_channel.h"
 
 
+SSCSMEnvironment::SSCSMEnvironment(std::shared_ptr<StupidChannel> channel) :
+	Thread("SSCSMEnvironment-thread"),
+	m_channel(std::move(channel)),
+	m_script(std::make_unique<SSCSMScripting>(this))
+{
+}
+
 void *SSCSMEnvironment::run()
 {
 	while (true) {
@@ -26,6 +33,21 @@ void *SSCSMEnvironment::run()
 SerializedSSCSMAnswer SSCSMEnvironment::exchange(SerializedSSCSMRequest req)
 {
 	return m_channel->exchangeA(std::move(req));
+}
+
+void SSCSMEnvironment::updateVFSFiles(std::vector<std::pair<std::string, std::string>> &&files)
+{
+	for (auto &&p : files) {
+		m_vfs.emplace(std::move(p.first), std::move(p.second));
+	}
+}
+
+void SSCSMEnvironment::setFatalError(const std::string &reason)
+{
+	//TODO
+	// what to do on error?
+	// probably send a request
+	errorstream << "SSCSMEnvironment::setFatalError() reason: " << reason << std::endl;
 }
 
 std::unique_ptr<ISSCSMEvent> SSCSMEnvironment::requestPollNextEvent()

--- a/src/script/sscsm/sscsm_environment.cpp
+++ b/src/script/sscsm/sscsm_environment.cpp
@@ -6,14 +6,18 @@
 #include "sscsm_requests.h"
 #include "sscsm_events.h"
 #include "sscsm_stupid_channel.h"
+#include "client/mod_vfs.h"
 
 
 SSCSMEnvironment::SSCSMEnvironment(std::shared_ptr<StupidChannel> channel) :
 	Thread("SSCSMEnvironment-thread"),
 	m_channel(std::move(channel)),
-	m_script(std::make_unique<SSCSMScripting>(this))
+	m_script(std::make_unique<SSCSMScripting>(this)),
+	m_vfs(std::make_unique<ModVFS>())
 {
 }
+
+SSCSMEnvironment::~SSCSMEnvironment() = default;
 
 void *SSCSMEnvironment::run()
 {
@@ -44,14 +48,14 @@ SerializedSSCSMAnswer SSCSMEnvironment::exchange(SerializedSSCSMRequest req)
 void SSCSMEnvironment::updateVFSFiles(std::vector<std::pair<std::string, std::string>> &&files)
 {
 	for (auto &&p : files) {
-		m_vfs.emplace(std::move(p.first), std::move(p.second));
+		m_vfs->m_vfs.emplace(std::move(p.first), std::move(p.second));
 	}
 }
 
 std::optional<std::string_view> SSCSMEnvironment::readVFSFile(const std::string &path)
 {
-	auto it = m_vfs.find(path);
-	if (it == m_vfs.end())
+	auto it = m_vfs->m_vfs.find(path);
+	if (it == m_vfs->m_vfs.end())
 		return std::nullopt;
 	else
 		return it->second;

--- a/src/script/sscsm/sscsm_environment.cpp
+++ b/src/script/sscsm/sscsm_environment.cpp
@@ -24,7 +24,13 @@ void *SSCSMEnvironment::run()
 			break;
 		}
 
-		next_event->exec(this);
+		try {
+			next_event->exec(this);
+		} catch (LuaError &e) {
+			setFatalError(std::string("Lua error: ") + e.what());
+		} catch (ModError &e) {
+			setFatalError(std::string("Mod error: ") + e.what());
+		}
 	}
 
 	return nullptr;

--- a/src/script/sscsm/sscsm_environment.cpp
+++ b/src/script/sscsm/sscsm_environment.cpp
@@ -7,6 +7,7 @@
 #include "sscsm_events.h"
 #include "sscsm_stupid_channel.h"
 #include "client/mod_vfs.h"
+#include "common/c_types.h" // LuaError
 
 
 SSCSMEnvironment::SSCSMEnvironment(std::shared_ptr<StupidChannel> channel) :

--- a/src/script/sscsm/sscsm_environment.cpp
+++ b/src/script/sscsm/sscsm_environment.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "sscsm_environment.h"
+#include "sscsm_requests.h"
+#include "sscsm_events.h"
+#include "sscsm_stupid_channel.h"
+
+
+void *SSCSMEnvironment::run()
+{
+	while (true) {
+		auto next_event = requestPollNextEvent();
+
+		if (dynamic_cast<SSCSMEventTearDown *>(next_event.get())) {
+			break;
+		}
+
+		next_event->exec(this);
+	}
+
+	return nullptr;
+}
+
+SerializedSSCSMAnswer SSCSMEnvironment::exchange(SerializedSSCSMRequest req)
+{
+	return m_channel->exchangeA(std::move(req));
+}
+
+std::unique_ptr<ISSCSMEvent> SSCSMEnvironment::requestPollNextEvent()
+{
+	auto request = SSCSMRequestPollNextEvent{};
+	auto answer = deserializeSSCSMAnswer<SSCSMRequestPollNextEvent::Answer>(
+			exchange(serializeSSCSMRequest(request))
+		);
+	return std::move(answer.next_event);
+}
+
+MapNode SSCSMEnvironment::requestGetNode(v3s16 pos)
+{
+	auto request = SSCSMRequestGetNode{};
+	request.pos = pos;
+	auto answer = deserializeSSCSMAnswer<SSCSMRequestGetNode::Answer>(
+			exchange(serializeSSCSMRequest(request))
+		);
+	return answer.node;
+}

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -5,6 +5,9 @@
 #pragma once
 
 #include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
 #include "client/client.h"
 #include "threading/thread.h"
 #include "sscsm_controller.h"
@@ -34,11 +37,20 @@ public:
 	SSCSMScripting *getScript() { return m_script.get(); }
 
 	void updateVFSFiles(std::vector<std::pair<std::string, std::string>> &&files);
+	std::optional<std::string_view> readVFSFile(const std::string &path);
 
 	void setFatalError(const std::string &reason);
 	void setFatalError(const LuaError &e)
 	{
 		setFatalError(std::string("Lua: ") + e.what());
+	}
+
+	template <typename RQ>
+	typename RQ::Answer doRequest(RQ &&rq)
+	{
+		return deserializeSSCSMAnswer<typename RQ::Answer>(
+				exchange(serializeSSCSMRequest(std::forward<RQ>(rq)))
+			);
 	}
 
 	std::unique_ptr<ISSCSMEvent> requestPollNextEvent();

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include "client/client.h"
+#include "threading/thread.h"
+#include "sscsm_controller.h"
+#include "sscsm_irequest.h"
+
+// The thread that runs SSCSM code.
+// Meant to be replaced by a sandboxed process.
+class SSCSMEnvironment : public Thread
+{
+	std::shared_ptr<StupidChannel> m_channel;
+
+	void *run() override;
+
+	SerializedSSCSMAnswer exchange(SerializedSSCSMRequest req);
+
+public:
+	SSCSMEnvironment(std::shared_ptr<StupidChannel> channel) :
+		Thread("SSCSMEnvironment-thread"),
+		m_channel(std::move(channel))
+	{
+	}
+
+	std::unique_ptr<ISSCSMEvent> requestPollNextEvent();
+	MapNode requestGetNode(v3s16 pos);
+};

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -50,7 +50,4 @@ public:
 				exchange(serializeSSCSMRequest(std::forward<RQ>(rq)))
 			);
 	}
-
-	std::unique_ptr<ISSCSMEvent> requestPollNextEvent();
-	MapNode requestGetNode(v3s16 pos);
 };

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -14,8 +14,14 @@
 #include "sscsm_irequest.h"
 #include "../scripting_sscsm.h"
 
-// The thread that runs SSCSM code.
-// Meant to be replaced by a sandboxed process.
+/** The thread that runs SSCSM code.
+ *
+ * Meant to be replaced by a sandboxed process.
+ *
+ * RAII-owns and abstracts away resources to communicate to the main process / thread.
+ *
+ * See also SSCSMController for other side.
+ */
 class SSCSMEnvironment : public Thread
 {
 	std::shared_ptr<StupidChannel> m_channel;

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -39,7 +39,7 @@ class SSCSMEnvironment : public Thread
 
 public:
 	SSCSMEnvironment(std::shared_ptr<StupidChannel> channel);
-	~SSCSMEnvironment();
+	~SSCSMEnvironment() override;
 
 	SSCSMScripting *getScript() { return m_script.get(); }
 

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -25,7 +25,7 @@ class SSCSMEnvironment : public Thread
 	// /client_builtin/subdir/foo.lua
 	// /server_builtin/subdir/foo.lua
 	// /mods/modname/subdir/foo.lua
-	std::unordered_map<std::string, std::string> m_vfs;
+	std::unique_ptr<ModVFS> m_vfs;
 
 	void *run() override;
 
@@ -33,9 +33,11 @@ class SSCSMEnvironment : public Thread
 
 public:
 	SSCSMEnvironment(std::shared_ptr<StupidChannel> channel);
+	~SSCSMEnvironment();
 
 	SSCSMScripting *getScript() { return m_script.get(); }
 
+	ModVFS *getModVFS() { return m_vfs.get(); }
 	void updateVFSFiles(std::vector<std::pair<std::string, std::string>> &&files);
 	std::optional<std::string_view> readVFSFile(const std::string &path);
 

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -9,22 +9,36 @@
 #include "threading/thread.h"
 #include "sscsm_controller.h"
 #include "sscsm_irequest.h"
+#include "../scripting_sscsm.h"
 
 // The thread that runs SSCSM code.
 // Meant to be replaced by a sandboxed process.
 class SSCSMEnvironment : public Thread
 {
 	std::shared_ptr<StupidChannel> m_channel;
+	std::unique_ptr<SSCSMScripting> m_script;
+	// virtual file system.
+	// TODO: decide and doc how paths look like, maybe:
+	// /client_builtin/subdir/foo.lua
+	// /server_builtin/subdir/foo.lua
+	// /mods/modname/subdir/foo.lua
+	std::unordered_map<std::string, std::string> m_vfs;
 
 	void *run() override;
 
 	SerializedSSCSMAnswer exchange(SerializedSSCSMRequest req);
 
 public:
-	SSCSMEnvironment(std::shared_ptr<StupidChannel> channel) :
-		Thread("SSCSMEnvironment-thread"),
-		m_channel(std::move(channel))
+	SSCSMEnvironment(std::shared_ptr<StupidChannel> channel);
+
+	SSCSMScripting *getScript() { return m_script.get(); }
+
+	void updateVFSFiles(std::vector<std::pair<std::string, std::string>> &&files);
+
+	void setFatalError(const std::string &reason);
+	void setFatalError(const LuaError &e)
 	{
+		setFatalError(std::string("Lua: ") + e.what());
 	}
 
 	std::unique_ptr<ISSCSMEvent> requestPollNextEvent();

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -40,10 +40,6 @@ public:
 	std::optional<std::string_view> readVFSFile(const std::string &path);
 
 	void setFatalError(const std::string &reason);
-	void setFatalError(const LuaError &e)
-	{
-		setFatalError(std::string("Lua: ") + e.what());
-	}
 
 	template <typename RQ>
 	typename RQ::Answer doRequest(RQ &&rq)

--- a/src/script/sscsm/sscsm_environment.h
+++ b/src/script/sscsm/sscsm_environment.h
@@ -20,11 +20,11 @@ class SSCSMEnvironment : public Thread
 {
 	std::shared_ptr<StupidChannel> m_channel;
 	std::unique_ptr<SSCSMScripting> m_script;
-	// virtual file system.
-	// TODO: decide and doc how paths look like, maybe:
-	// /client_builtin/subdir/foo.lua
-	// /server_builtin/subdir/foo.lua
-	// /mods/modname/subdir/foo.lua
+	// the virtual file system.
+	// paths look like this:
+	// *client_builtin*:subdir/foo.lua
+	// *server_builtin*:subdir/foo.lua
+	// modname:subdir/foo.lua
 	std::unique_ptr<ModVFS> m_vfs;
 
 	void *run() override;

--- a/src/script/sscsm/sscsm_events.h
+++ b/src/script/sscsm/sscsm_events.h
@@ -30,12 +30,12 @@ struct SSCSMEventUpdateVFSFiles : public ISSCSMEvent
 
 struct SSCSMEventLoadMods : public ISSCSMEvent
 {
-	// paths to init.lua files, in load order
-	std::vector<std::string> init_paths;
+	// modnames and paths to init.lua file, in load order
+	std::vector<std::pair<std::string, std::string>> mods;
 
 	void exec(SSCSMEnvironment *env) override
 	{
-		env->getScript()->load_mods(init_paths);
+		env->getScript()->load_mods(mods);
 	}
 };
 

--- a/src/script/sscsm/sscsm_events.h
+++ b/src/script/sscsm/sscsm_events.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "sscsm_ievent.h"
+#include "debug.h"
+#include "irrlichttypes.h"
+#include "irr_v3d.h"
+#include "sscsm_environment.h"
+#include "mapnode.h"
+
+struct SSCSMEventTearDown : public ISSCSMEvent
+{
+	void exec(SSCSMEnvironment *env) override
+	{
+		FATAL_ERROR("SSCSMEventTearDown needs to be handled by SSCSMEnvironment::run()");
+	}
+};
+
+struct SSCSMEventOnStep final : public ISSCSMEvent
+{
+	f32 dtime;
+
+	void exec(SSCSMEnvironment *env) override
+	{
+		// example
+		env->requestGetNode(v3s16(0, 0, 0));
+	}
+};
+

--- a/src/script/sscsm/sscsm_events.h
+++ b/src/script/sscsm/sscsm_events.h
@@ -7,9 +7,7 @@
 #include "sscsm_ievent.h"
 #include "debug.h"
 #include "irrlichttypes.h"
-#include "irr_v3d.h"
 #include "sscsm_environment.h"
-#include "mapnode.h"
 
 struct SSCSMEventTearDown : public ISSCSMEvent
 {
@@ -19,14 +17,35 @@ struct SSCSMEventTearDown : public ISSCSMEvent
 	}
 };
 
-struct SSCSMEventOnStep final : public ISSCSMEvent
+struct SSCSMEventUpdateVFSFiles : public ISSCSMEvent
+{
+	// pairs are virtual path and file content
+	std::vector<std::pair<std::string, std::string>> files;
+
+	void exec(SSCSMEnvironment *env) override
+	{
+		env->updateVFSFiles(std::move(files));
+	}
+};
+
+struct SSCSMEventLoadMods : public ISSCSMEvent
+{
+	// paths to init.lua files, in load order
+	std::vector<std::string> init_paths;
+
+	void exec(SSCSMEnvironment *env) override
+	{
+		env->getScript()->load_mods(init_paths);
+	}
+};
+
+struct SSCSMEventOnStep : public ISSCSMEvent
 {
 	f32 dtime;
 
 	void exec(SSCSMEnvironment *env) override
 	{
-		// example
-		env->requestGetNode(v3s16(0, 0, 0));
+		env->getScript()->environment_step(dtime);
 	}
 };
 

--- a/src/script/sscsm/sscsm_ievent.h
+++ b/src/script/sscsm/sscsm_ievent.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+class SSCSMEnvironment;
+
+// Event triggered from the main env for the SSCSM env.
+struct ISSCSMEvent
+{
+	virtual ~ISSCSMEvent() = default;
+
+	// Note: No return value (difference to ISSCSMRequest). These are not callbacks
+	// that you can run at arbitrary locations, because the untrusted code could
+	// then clobber your local variables.
+	virtual void exec(SSCSMEnvironment *cntrl) = 0;
+};
+
+// FIXME: actually serialize, and replace this with a string
+using SerializedSSCSMEvent = std::unique_ptr<ISSCSMEvent>;
+
+template <typename T>
+inline SerializedSSCSMEvent serializeSSCSMEvent(const T &event)
+{
+	static_assert(std::is_base_of_v<ISSCSMEvent, T>);
+
+	return std::make_unique<T>(event);
+}
+
+inline std::unique_ptr<ISSCSMEvent> deserializeSSCSMEvent(SerializedSSCSMEvent event_serialized)
+{
+	// The actual deserialization will have to use a type tag, and then choose
+	// the appropriate deserializer.
+	return event_serialized;
+}

--- a/src/script/sscsm/sscsm_irequest.h
+++ b/src/script/sscsm/sscsm_irequest.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "exceptions.h"
+#include <memory>
+#include <type_traits>
+
+class SSCSMController;
+class Client;
+
+struct ISSCSMAnswer
+{
+	virtual ~ISSCSMAnswer() = default;
+};
+
+// FIXME: actually serialize, and replace this with a string
+using SerializedSSCSMAnswer = std::unique_ptr<ISSCSMAnswer>;
+
+// Request made by the sscsm env to the main env.
+struct ISSCSMRequest
+{
+	virtual ~ISSCSMRequest() = default;
+
+	virtual SerializedSSCSMAnswer exec(Client *client) = 0;
+};
+
+// FIXME: actually serialize, and replace this with a string
+using SerializedSSCSMRequest = std::unique_ptr<ISSCSMRequest>;
+
+template <typename T>
+inline SerializedSSCSMRequest serializeSSCSMRequest(const T &request)
+{
+	static_assert(std::is_base_of_v<ISSCSMRequest, T>);
+
+	return std::make_unique<T>(request);
+}
+
+template <typename T>
+inline T deserializeSSCSMAnswer(SerializedSSCSMAnswer answer_serialized)
+{
+	static_assert(std::is_base_of_v<ISSCSMAnswer, T>);
+
+	// dynamic cast in place of actual deserialization
+	auto ptr = dynamic_cast<T *>(answer_serialized.get());
+	if (!ptr) {
+		throw SerializationError("deserializeSSCSMAnswer failed");
+	}
+	return std::move(*ptr);
+}
+
+template <typename T>
+inline SerializedSSCSMAnswer serializeSSCSMAnswer(T &&answer)
+{
+	static_assert(std::is_base_of_v<ISSCSMAnswer, T>);
+
+	return std::make_unique<T>(std::move(answer));
+}
+
+inline std::unique_ptr<ISSCSMRequest> deserializeSSCSMRequest(SerializedSSCSMRequest request_serialized)
+{
+	// The actual deserialization will have to use a type tag, and then choose
+	// the appropriate deserializer.
+	return request_serialized;
+}

--- a/src/script/sscsm/sscsm_irequest.h
+++ b/src/script/sscsm/sscsm_irequest.h
@@ -11,12 +11,15 @@
 class SSCSMController;
 class Client;
 
+// FIXME: remove once we have actual serialization
+// this is just here so we can instead put them into unique_ptr
 struct ISSCSMAnswer
 {
 	virtual ~ISSCSMAnswer() = default;
 };
 
-// FIXME: actually serialize, and replace this with a string
+// FIXME: actually serialize, and replace this with a std::vector<u8>
+// (not polymorphic. the receiving side will know the answer type that is in here)
 using SerializedSSCSMAnswer = std::unique_ptr<ISSCSMAnswer>;
 
 // Request made by the sscsm env to the main env.
@@ -27,13 +30,16 @@ struct ISSCSMRequest
 	virtual SerializedSSCSMAnswer exec(Client *client) = 0;
 };
 
-// FIXME: actually serialize, and replace this with a string
+// FIXME: actually serialize, and replace this with a std::vector<u8>
+// (polymorphic. this can be any ISSCSMRequest. ==> needs type tag)
 using SerializedSSCSMRequest = std::unique_ptr<ISSCSMRequest>;
 
 template <typename T>
 inline SerializedSSCSMRequest serializeSSCSMRequest(const T &request)
 {
 	static_assert(std::is_base_of_v<ISSCSMRequest, T>);
+
+	// FIXME: this will need to use a type tag for T
 
 	return std::make_unique<T>(request);
 }
@@ -42,6 +48,10 @@ template <typename T>
 inline T deserializeSSCSMAnswer(SerializedSSCSMAnswer answer_serialized)
 {
 	static_assert(std::is_base_of_v<ISSCSMAnswer, T>);
+
+	// FIXME: should look something like this:
+	// return sscsm::Serializer<T>{}.deserialize(answer_serialized);
+	// (note: answer_serialized does not need a type tag)
 
 	// dynamic cast in place of actual deserialization
 	auto ptr = dynamic_cast<T *>(answer_serialized.get());
@@ -56,12 +66,15 @@ inline SerializedSSCSMAnswer serializeSSCSMAnswer(T &&answer)
 {
 	static_assert(std::is_base_of_v<ISSCSMAnswer, T>);
 
+	// FIXME: should look something like this:
+	// return sscsm::Serializer<T>{}.serialize(request);
+
 	return std::make_unique<T>(std::move(answer));
 }
 
 inline std::unique_ptr<ISSCSMRequest> deserializeSSCSMRequest(SerializedSSCSMRequest request_serialized)
 {
-	// The actual deserialization will have to use a type tag, and then choose
-	// the appropriate deserializer.
+	// FIXME: The actual deserialization will have to use a type tag, and then
+	// choose the appropriate deserializer.
 	return request_serialized;
 }

--- a/src/script/sscsm/sscsm_irequest.h
+++ b/src/script/sscsm/sscsm_irequest.h
@@ -18,7 +18,9 @@ struct ISSCSMAnswer
 	virtual ~ISSCSMAnswer() = default;
 };
 
-// FIXME: actually serialize, and replace this with a std::vector<u8>
+// FIXME: actually serialize, and replace this with a std::vector<u8>.
+//        also update function argument declarations, to take
+//        `const SerializedSSCSMAnswer &` or whatever
 // (not polymorphic. the receiving side will know the answer type that is in here)
 using SerializedSSCSMAnswer = std::unique_ptr<ISSCSMAnswer>;
 
@@ -30,7 +32,7 @@ struct ISSCSMRequest
 	virtual SerializedSSCSMAnswer exec(Client *client) = 0;
 };
 
-// FIXME: actually serialize, and replace this with a std::vector<u8>
+// FIXME: as above, actually serialize
 // (polymorphic. this can be any ISSCSMRequest. ==> needs type tag)
 using SerializedSSCSMRequest = std::unique_ptr<ISSCSMRequest>;
 

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -43,6 +43,7 @@ struct SSCSMRequestSetFatalError : public ISSCSMRequest
 };
 
 // print(text)
+// FIXME: override global loggers to use this in sscsm process
 struct SSCSMRequestPrint : public ISSCSMRequest
 {
 	struct Answer : public ISSCSMAnswer
@@ -73,7 +74,7 @@ struct SSCSMRequestLog : public ISSCSMRequest
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
 		if (level >= LL_MAX) {
-			errorstream << "Tried to log at non-existent level." << std::endl; // TODO: should probably throw
+			throw BaseException("Tried to log at non-existent level."); // TODO: choose better exception type
 		} else {
 			g_logger.log(level, text);
 		}

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -74,7 +74,7 @@ struct SSCSMRequestLog : public ISSCSMRequest
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
 		if (level >= LL_MAX) {
-			throw BaseException("Tried to log at non-existent level."); // TODO: choose better exception type
+			throw MisbehavedSSCSMException("Tried to log at non-existent level.");
 		} else {
 			g_logger.log(level, text);
 		}

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -9,7 +9,9 @@
 #include "mapnode.h"
 #include "map.h"
 #include "client/client.h"
+#include "log_internal.h"
 
+// Poll the next event (e.g. on_globalstep)
 struct SSCSMRequestPollNextEvent : public ISSCSMRequest
 {
 	struct Answer : public ISSCSMAnswer
@@ -23,21 +25,81 @@ struct SSCSMRequestPollNextEvent : public ISSCSMRequest
 	}
 };
 
+// Some error occured in the SSCSM env
+struct SSCSMRequestSetFatalError : public ISSCSMRequest
+{
+	struct Answer : public ISSCSMAnswer
+	{
+	};
+
+	std::string reason;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		client->setFatalError("[SSCSM] " + reason);
+
+		return serializeSSCSMAnswer(Answer{});
+	}
+};
+
+// print(text)
+struct SSCSMRequestPrint : public ISSCSMRequest
+{
+	struct Answer : public ISSCSMAnswer
+	{
+	};
+
+	std::string text;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		rawstream << text << std::endl;
+
+		return serializeSSCSMAnswer(Answer{});
+	}
+};
+
+// core.log(level, text)
+struct SSCSMRequestLog : public ISSCSMRequest
+{
+	struct Answer : public ISSCSMAnswer
+	{
+	};
+
+	std::string text;
+	LogLevel level;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		if (level >= LL_MAX) {
+			errorstream << "Tried to log at non-existent level." << std::endl; // TODO: should probably throw
+		} else {
+			g_logger.log(level, text);
+		}
+
+		return serializeSSCSMAnswer(Answer{});
+	}
+};
+
+// core.get_node(pos)
 struct SSCSMRequestGetNode : public ISSCSMRequest
 {
 	struct Answer : public ISSCSMAnswer
 	{
 		MapNode node;
+		bool is_pos_ok;
 	};
 
 	v3s16 pos;
 
 	SerializedSSCSMAnswer exec(Client *client) override
 	{
-		MapNode node = client->getEnv().getMap().getNode(pos);
+		bool is_pos_ok = false;
+		MapNode node = client->getEnv().getMap().getNode(pos, &is_pos_ok);
 
 		Answer answer{};
 		answer.node = node;
+		answer.is_pos_ok = is_pos_ok;
 		return serializeSSCSMAnswer(std::move(answer));
 	}
 };

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -12,9 +12,9 @@
 #include "log_internal.h"
 
 // Poll the next event (e.g. on_globalstep)
-struct SSCSMRequestPollNextEvent : public ISSCSMRequest
+struct SSCSMRequestPollNextEvent final : public ISSCSMRequest
 {
-	struct Answer : public ISSCSMAnswer
+	struct Answer final : public ISSCSMAnswer
 	{
 		std::unique_ptr<ISSCSMEvent> next_event;
 	};
@@ -26,9 +26,9 @@ struct SSCSMRequestPollNextEvent : public ISSCSMRequest
 };
 
 // Some error occured in the SSCSM env
-struct SSCSMRequestSetFatalError : public ISSCSMRequest
+struct SSCSMRequestSetFatalError final : public ISSCSMRequest
 {
-	struct Answer : public ISSCSMAnswer
+	struct Answer final : public ISSCSMAnswer
 	{
 	};
 
@@ -44,9 +44,9 @@ struct SSCSMRequestSetFatalError : public ISSCSMRequest
 
 // print(text)
 // FIXME: override global loggers to use this in sscsm process
-struct SSCSMRequestPrint : public ISSCSMRequest
+struct SSCSMRequestPrint final : public ISSCSMRequest
 {
-	struct Answer : public ISSCSMAnswer
+	struct Answer final : public ISSCSMAnswer
 	{
 	};
 
@@ -62,9 +62,9 @@ struct SSCSMRequestPrint : public ISSCSMRequest
 
 // core.log(level, text)
 // FIXME: override global loggers to use this in sscsm process
-struct SSCSMRequestLog : public ISSCSMRequest
+struct SSCSMRequestLog final : public ISSCSMRequest
 {
-	struct Answer : public ISSCSMAnswer
+	struct Answer final : public ISSCSMAnswer
 	{
 	};
 
@@ -84,9 +84,9 @@ struct SSCSMRequestLog : public ISSCSMRequest
 };
 
 // core.get_node(pos)
-struct SSCSMRequestGetNode : public ISSCSMRequest
+struct SSCSMRequestGetNode final : public ISSCSMRequest
 {
-	struct Answer : public ISSCSMAnswer
+	struct Answer final : public ISSCSMAnswer
 	{
 		MapNode node;
 		bool is_pos_ok;

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -60,6 +60,7 @@ struct SSCSMRequestPrint : public ISSCSMRequest
 };
 
 // core.log(level, text)
+// FIXME: override global loggers to use this in sscsm process
 struct SSCSMRequestLog : public ISSCSMRequest
 {
 	struct Answer : public ISSCSMAnswer

--- a/src/script/sscsm/sscsm_requests.h
+++ b/src/script/sscsm/sscsm_requests.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "sscsm_irequest.h"
+#include "sscsm_ievent.h"
+#include "mapnode.h"
+#include "map.h"
+#include "client/client.h"
+
+struct SSCSMRequestPollNextEvent : public ISSCSMRequest
+{
+	struct Answer : public ISSCSMAnswer
+	{
+		std::unique_ptr<ISSCSMEvent> next_event;
+	};
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		FATAL_ERROR("SSCSMRequestPollNextEvent needs to be handled by SSCSMControler::runEvent()");
+	}
+};
+
+struct SSCSMRequestGetNode : public ISSCSMRequest
+{
+	struct Answer : public ISSCSMAnswer
+	{
+		MapNode node;
+	};
+
+	v3s16 pos;
+
+	SerializedSSCSMAnswer exec(Client *client) override
+	{
+		MapNode node = client->getEnv().getMap().getNode(pos);
+
+		Answer answer{};
+		answer.node = node;
+		return serializeSSCSMAnswer(std::move(answer));
+	}
+};

--- a/src/script/sscsm/sscsm_stupid_channel.h
+++ b/src/script/sscsm/sscsm_stupid_channel.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 Luanti authors
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <condition_variable>
+#include "sscsm_irequest.h"
+
+// FIXME: replace this with an ipc channel
+class StupidChannel
+{
+	std::mutex m_mutex;
+	std::condition_variable m_condvar;
+	SerializedSSCSMRequest m_request;
+	SerializedSSCSMAnswer m_answer;
+
+public:
+	void sendA(SerializedSSCSMRequest request)
+	{
+		{
+			auto lock = std::lock_guard(m_mutex);
+
+			m_request = std::move(request);
+		}
+
+		m_condvar.notify_one();
+	}
+
+	SerializedSSCSMAnswer recvA()
+	{
+		auto lock = std::unique_lock(m_mutex);
+
+		while (!m_answer) {
+			m_condvar.wait(lock);
+		}
+
+		auto answer = std::move(m_answer);
+		m_answer = nullptr;
+
+		return answer;
+	}
+
+	SerializedSSCSMAnswer exchangeA(SerializedSSCSMRequest request)
+	{
+		sendA(std::move(request));
+
+		return recvA();
+	}
+
+	void sendB(SerializedSSCSMAnswer answer)
+	{
+		{
+			auto lock = std::lock_guard(m_mutex);
+
+			m_answer = std::move(answer);
+		}
+
+		m_condvar.notify_one();
+	}
+
+	SerializedSSCSMRequest recvB()
+	{
+		auto lock = std::unique_lock(m_mutex);
+
+		while (!m_request) {
+			m_condvar.wait(lock);
+		}
+
+		auto request = std::move(m_request);
+		m_request = nullptr;
+
+		return request;
+	}
+
+	SerializedSSCSMRequest exchangeB(SerializedSSCSMAnswer answer)
+	{
+		sendB(std::move(answer));
+
+		return recvB();
+	}
+};


### PR DESCRIPTION
Based on #15568. But I decided to not update that, as it received no reviews. => Not waiting.

### What this PR includes:
* Everything from #15568. (Might be worth reading PR description there.)
* A *minimal* scripting env.
* It is meant to be secure (i.e. includes overwritten functions, like a less precise `os.clock()`). (See also `doc/sscsm_security.md`.)
* Loading of client builtin.
* A non-binary setting `enable_sscsm`. This is not a bool, but an enum that says when (actually server-sent) sscsm is on. (Client builtin is always on.) The idea is that, for example, if it's `localhost`, sscsm is on in singleplayer, and when joining a server on localhost, but not lan or other servers. (See also `doc/sscsm_security.md`.)
* Documentation.

### Possible follow-up PRs:

Moved to: https://github.com/luanti-org/luanti/issues/5393#issuecomment-4883907434

## To do

This PR is Ready to be Reviewed.

## How to test

* Start the game.
* Set `enable_sscsm` to `singleplayer`. Start the game again. => It prints out nodes (not node names, but content ids).