### PR TITLE
Note that `core.hash_node_position` is not a hash function

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7456,7 +7456,9 @@ Misc.
     * This function can be overridden by mods to change the leave message.
 * `core.hash_node_position(pos)`: returns a 48-bit integer
     * `pos`: table {x=number, y=number, z=number},
-    * Gives a unique hash number for a node position (16+16+16=48bit)
+    * Gives a unique numeric encoding for a node position (16+16+16=48bit)
+    * Despite the name, this does not have collisions and this is not a mixing
+      hash function, neighboring x positions will have consecutive values.
 * `core.get_position_from_hash(hash)`: returns a position
     * Inverse transform of `core.hash_node_position`
 * `core.get_item_group(name, group)`: returns a rating

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7457,8 +7457,7 @@ Misc.
 * `core.hash_node_position(pos)`: returns a 48-bit integer
     * `pos`: table {x=number, y=number, z=number},
     * Gives a unique numeric encoding for a node position (16+16+16=48bit)
-    * Despite the name, this does not have collisions and this is not a mixing
-      hash function, neighboring x positions will have consecutive values.
+    * Despite the name, this is not a hash function (so it doesn't mix or produce collisions).
 * `core.get_position_from_hash(hash)`: returns a position
     * Inverse transform of `core.hash_node_position`
 * `core.get_item_group(name, group)`: returns a rating


### PR DESCRIPTION
A simple encoding by concatenation, not a hash function.

https://github.com/luanti-org/luanti/blob/5e89371ecdba4eb706841a6776b174d1194acff4/builtin/game/misc_s.lua#L12

In proper terminology, a *hash function* usually:
- maps into a smaller domain
- mixes values to distribute them evenly
- may have collisions, but these should not have patterns
- is not reversible

The function here does not have collisions, but fails at mixing or any of the other "desirable" properties of a hash function. It is *not* a good choice to use this in a hash table. Hence the term "hash" should be avoided.

I would suggest to rename this function as `core.encode_node_position` respectively `core.decode_node_position`, and deprecate the old functions in the API (for obvious reasons they will not be easy to remove anytime soon, though).
This pull request only makes a tiny change to the documentation, so people do not expect this to be a hash function.