### PR TITLE
[nosq] simplify position encoding, remove "black magic"

### DIFF
--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -7,48 +7,23 @@
 
 
 /****************
- * Black magic! *
- ****************
- * The position hashing is very messed up.
- * It's a lot more complicated than it looks.
+ * The position encoding is a bit messed up because negative
+ * values were not taken into account.
+ * But this also maps 0,0,0 to 0, which is nice, and we mostly
+ * need forward encoding in Luanti.
  */
-
-static inline s16 unsigned_to_signed(u16 i, u16 max_positive)
-{
-	if (i < max_positive) {
-		return i;
-	}
-
-	return i - (max_positive * 2);
-}
-
-
-// Modulo of a negative number does not work consistently in C
-static inline s64 pythonmodulo(s64 i, s16 mod)
-{
-	if (i >= 0) {
-		return i % mod;
-	}
-	return mod - ((-i) % mod);
-}
-
-
 s64 MapDatabase::getBlockAsInteger(const v3s16 &pos)
 {
-	return (u64) pos.Z * 0x1000000 +
-		(u64) pos.Y * 0x1000 +
-		(u64) pos.X;
+	return ((s64) pos.Z << 24) + ((s64) pos.Y << 12) + pos.X;
 }
 
 
 v3s16 MapDatabase::getIntegerAsBlock(s64 i)
 {
-	v3s16 pos;
-	pos.X = unsigned_to_signed(pythonmodulo(i, 4096), 2048);
-	i = (i - pos.X) / 4096;
-	pos.Y = unsigned_to_signed(pythonmodulo(i, 4096), 2048);
-	i = (i - pos.Y) / 4096;
-	pos.Z = unsigned_to_signed(pythonmodulo(i, 4096), 2048);
-	return pos;
+	// Offset so that all negative coordinates become non-negative
+	i = i + 0x800800800;
+	// Which is now easier to decode using simple bit masks:
+	return { (s16)( (i        & 0xFFF) - 0x800),
+	         (s16)(((i >> 12) & 0xFFF) - 0x800),
+	         (s16)(((i >> 24) & 0xFFF) - 0x800) };
 }
-

--- a/src/unittest/test_mapdatabase.cpp
+++ b/src/unittest/test_mapdatabase.cpp
@@ -72,6 +72,7 @@ public:
 	void testLoad();
 	void testList(int expect);
 	void testRemove();
+	void testPositionEncoding();
 
 private:
 	MapDatabaseProvider *provider = nullptr;
@@ -89,6 +90,8 @@ void TestMapDatabase::runTests(IGameDef *gamedef)
 	for (int c = 255; c >= 0; c--)
 		test_data.push_back(static_cast<char>(c));
 	sanity_check(!test_data.empty());
+
+	TEST(testPositionEncoding);
 
 	rawstream << "-------- Dummy" << std::endl;
 
@@ -192,4 +195,32 @@ void TestMapDatabase::testRemove()
 	// failed remove
 	// FIXME: this isn't working consistently, maybe later
 	//UASSERT(!db->deleteBlock({1, 2, 4}));
+}
+
+void TestMapDatabase::testPositionEncoding()
+{
+	auto db = std::make_unique<Database_Dummy>();
+
+	// Unit vectors and extremes
+	UASSERTEQ(s64, db->getBlockAsInteger({0, 0, 0}), 0)
+	UASSERTEQ(s64, db->getBlockAsInteger({1, 0, 0}), 1)
+	UASSERTEQ(s64, db->getBlockAsInteger({0, 1, 0}), 0x1000)
+	UASSERTEQ(s64, db->getBlockAsInteger({0, 0, 1}), 0x1000000)
+	UASSERTEQ(s64, db->getBlockAsInteger({-1, 0, 0}), -1)
+	UASSERTEQ(s64, db->getBlockAsInteger({0, -1, 0}), -0x1000)
+	UASSERTEQ(s64, db->getBlockAsInteger({0, 0, -1}), -0x1000000)
+	UASSERTEQ(s64, db->getBlockAsInteger({2047, 2047, 2047}), 0x7FF7FF7FF)
+	UASSERTEQ(s64, db->getBlockAsInteger({-2048, -2048, -2048}), -0x800800800)
+	UASSERTEQ(s64, db->getBlockAsInteger({-123, 456, -789}), -0x314e3807b)
+
+	UASSERT(db->getIntegerAsBlock(0) == v3s16(0, 0, 0))
+	UASSERT(db->getIntegerAsBlock(1) == v3s16(1, 0, 0))
+	UASSERT(db->getIntegerAsBlock(0x1000) == v3s16(0, 1, 0))
+	UASSERT(db->getIntegerAsBlock(0x1000000) == v3s16(0, 0, 1))
+	UASSERT(db->getIntegerAsBlock(-1) == v3s16(-1, 0, 0))
+	UASSERT(db->getIntegerAsBlock(-0x1000) == v3s16(0, -1, 0))
+	UASSERT(db->getIntegerAsBlock(-0x1000000) == v3s16(0, 0, -1))
+	UASSERT(db->getIntegerAsBlock(0x7FF7FF7FF) == v3s16(2047, 2047, 2047))
+	UASSERT(db->getIntegerAsBlock(-0x800800800) == v3s16(-2048, -2048, -2048))
+	UASSERT(db->getIntegerAsBlock(-0x314e3807b) == v3s16(-123, 456, -789))
 }


### PR DESCRIPTION
The encodings *should* have been (pos.Z + 0x800) * 0x1000000 + (pos.Y + 0x800) * 0x1000 + (pos.X + 0x800),
but we are not going to fix this easily.

Fortunately, this means we simply need to add the magic 0x800800800 to the "old" coordinates and we get nice 12 bit bitmask operation compatible values that are elegant to decode.

Note: this should *not* be called a "hash" function, as its reversible, does not mix, and does not distribute well. It should not be used as a hash function.