### PR TITLE
Fixes #15822: Finish removing 'disable_escape_sequences'

### DIFF
--- a/src/terminal_chat_console.cpp
+++ b/src/terminal_chat_console.cpp
@@ -333,10 +333,6 @@ void TerminalChatConsole::step(int ch)
 			continue;
 
 		std::wstring error_message = utf8_to_wide(Logger::getLevelLabel(p.first));
-		if (!g_settings->getBool("disable_escape_sequences")) {
-			error_message = std::wstring(L"\x1b(c@red)").append(error_message)
-				.append(L"\x1b(c@white)");
-		}
 		m_chat_backend.addMessage(error_message, utf8_to_wide(p.second));
 	}
 


### PR DESCRIPTION
As discussed in #15822, PR 15633 removed the setting "disable_escape_sequences", but the reference in terminal_chat_console.cpp escaped attention. This change removes that missed reference. No other references remain.

## To do

This PR is Ready for Review.

## How to test

* build Luanti with ncurses support
* Start a server with --terminal
* note crash
* apply patch, rebuild, start server again
* note lack of crash

Confession: I did not perform the above testing. This change mirrors the other related changes in the referenced PR. The only effect of the removed block (besides querying the non-existent setting) is to add the escape sequences in question to the message to be emitted. Removing the code cannot have any surprise performance, I/O or memory use impact.

If I'm wrong I'll eat my hat (I don't wear a hat).