### PR TITLE
Use fallback font correctly for fonts provided by the server

### DIFF
--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -278,7 +278,7 @@ gui::IGUIFont *FontEngine::initFont(const FontSpec &spec)
 	};
 
 	auto it = m_media_faces.find(media_name);
-	if (it != m_media_faces.end()) {
+	if (spec.mode != _FM_Fallback && it != m_media_faces.end()) {
 		auto *face = it->second.get();
 		if (auto *font = createFont(face))
 			return font;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  See title.
- How does the PR work?
  It adds a condition to the font engine such that the fallback font uses the client-side font instead of querying `m_media_faces`.
- Does it resolve any reported issue?
  No. It fixes a minor issue (see screenshot) that is not reported.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  See description

## Screenshots

(The "server-side" font is [Ubuntu Regular](https://design.ubuntu.com/font). The default font configuration is used otherwise.)

5.10.0:
![2025-02-28-10-36-48](https://github.com/user-attachments/assets/2cc449bc-5923-4b87-932b-ea9adfe1f0be)

master:
![2025-02-28-10-40-38](https://github.com/user-attachments/assets/49457b26-e723-4d7a-9749-1006ba0b521b)

PR:
![2025-02-28-10-48-05](https://github.com/user-attachments/assets/376a3f48-5956-4190-88cb-937bdb30a546)

## Todo
This PR is ready for review.