### PR TITLE
Fix Microsoft Visual Studio error: string is not a member of std #15843

### DIFF
--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 #include <string_view>
 
 #include "irrlichttypes_bloated.h"

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <string>
 #include <string_view>
 
 extern "C" {


### PR DESCRIPTION
This fixes #15843

Microsoft Visual Studio error: string is not a member of std #15843
[Microsoft Visual Studio error: string is not a member of std #15843](https://github.com/luanti-org/luanti/issues/15843)

Thank your for the help and great project.