### PR TITLE
Enforce minimum `client_mapblock_limit` depending on view range

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1998,7 +1998,9 @@ max_out_chat_queue_size (Maximum size of the outgoing chat queue) int 20 -1 3276
 client_unload_unused_data_timeout (Mapblock unload timeout) float 600.0 0.0
 
 #    Maximum number of mapblocks for client to be kept in memory.
-#    Set to -1 for unlimited amount.
+#    Note that there is an internal dynamic minimum number of blocks that
+#    won't be deleted, depending on the current view range.
+#    Set to -1 for no limit.
 client_mapblock_limit (Mapblock limit) int 7500 -1 2147483647
 
 #    Maximum number of blocks that are simultaneously sent per client.

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -486,23 +486,18 @@ private:
 	u8 m_server_ser_ver;
 
 	// Used version of the protocol with server
-	// Values smaller than 25 only mean they are smaller than 25,
-	// and aren't accurate. We simply just don't know, because
-	// the server didn't send the version back then.
 	// If 0, server init hasn't been received yet.
 	u16 m_proto_ver = 0;
 
 	bool m_update_wielded_item = false;
 	Inventory *m_inventory_from_server = nullptr;
 	float m_inventory_from_server_age = 0.0f;
+	s32 m_mapblock_limit_logged = 0;
 	PacketCounter m_packetcounter;
 	// Block mesh animation parameters
 	float m_animation_time = 0.0f;
 	int m_crack_level = -1;
 	v3s16 m_crack_pos;
-	// 0 <= m_daynight_i < DAYNIGHT_CACHE_COUNT
-	//s32 m_daynight_i;
-	//u32 m_daynight_ratio;
 	std::queue<std::wstring> m_out_chat_queue;
 	u32 m_last_chat_message_sent;
 	float m_chat_message_allowance = 5.0f;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -112,7 +112,7 @@ void set_default_settings()
 	settings->setDefault("screenshot_format", "png");
 	settings->setDefault("screenshot_quality", "0");
 	settings->setDefault("client_unload_unused_data_timeout", "600");
-	settings->setDefault("client_mapblock_limit", "7500");
+	settings->setDefault("client_mapblock_limit", "7500"); // about 120 MB
 	settings->setDefault("enable_build_where_you_stand", "false");
 	settings->setDefault("curl_timeout", "20000");
 	settings->setDefault("curl_parallel_limit", "8");
@@ -547,6 +547,7 @@ void set_default_settings()
 	settings->setDefault("virtual_joystick_triggers_aux1", "false");
 	settings->setDefault("touch_punch_gesture", "short_tap");
 	settings->setDefault("clickable_chat_weblinks", "true");
+
 	// Altered settings for Android
 #ifdef __ANDROID__
 	settings->setDefault("screen_w", "0");
@@ -558,9 +559,9 @@ void set_default_settings()
 	settings->setDefault("max_block_generate_distance", "5");
 	settings->setDefault("sqlite_synchronous", "1");
 	settings->setDefault("server_map_save_interval", "15");
-	settings->setDefault("client_mapblock_limit", "1000");
+	settings->setDefault("client_mapblock_limit", "1500");
 	settings->setDefault("active_block_range", "2");
-	settings->setDefault("viewing_range", "50");
+	settings->setDefault("viewing_range", "70");
 	settings->setDefault("leaves_style", "simple");
 	// Note: OpenGL ES 2.0 is not guaranteed to provide depth textures,
 	// which we would need for PP.
@@ -568,6 +569,7 @@ void set_default_settings()
 	// still set these two settings in case someone wants to enable it
 	settings->setDefault("debanding", "false");
 	settings->setDefault("post_processing_texture_bits", "8");
+	// We don't have working certificate verification...
 	settings->setDefault("curl_verify_cert", "false");
 
 	// Apply settings according to screen size

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -106,9 +106,9 @@ EmergeManager::EmergeManager(Server *server, MetricsBackend *mb)
 		m_qlimit_generate = nthreads + 1;
 
 	// don't trust user input for something very important like this
-	m_qlimit_total = rangelim(m_qlimit_total, 1, 1000000);
-	m_qlimit_diskonly = rangelim(m_qlimit_diskonly, 1, 1000000);
+	m_qlimit_diskonly = rangelim(m_qlimit_diskonly, 2, 1000000);
 	m_qlimit_generate = rangelim(m_qlimit_generate, 1, 1000000);
+	m_qlimit_total = std::max(m_qlimit_diskonly, m_qlimit_generate);
 
 	for (s16 i = 0; i < nthreads; i++)
 		m_threads.push_back(new EmergeThread(server, i));


### PR DESCRIPTION
implements a modified suggestion from #10703

fixes #15849
closes #12010
closes #10703

table: view range -> number of mapblocks needed for entire view sphere
```
20 33
30 33
40 113
50 268
60 268
70 523
80 523
90 904
100 1436
110 1436
120 2144
130 3053
140 3053
150 4188
160 4188
170 5575
180 7238
190 7238
200 9202
^ this is as far as the code enforces it
210 11494
220 11494
230 14137
240 14137
250 17157
260 20579
270 20579
280 24429
290 28730
300 28730
310 33510
320 33510
330 38792
340 44602
350 44602
360 50965
370 57905
380 57905
390 65449
400 65449
```

1000 MapBlocks is about 16 MB of just the map data

## To do

This PR is Ready for Review.

## How to test

1. set `client_mapblock_limit = 1`
2. notice how nothing seems to be going wrong
