### PR TITLE
[nosq] skip decos outside of y limits for faster decoration placement

### DIFF
--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -36,21 +36,17 @@ DecorationManager::DecorationManager(IGameDef *gamedef) :
 }
 
 
-size_t DecorationManager::placeAllDecos(Mapgen *mg, u32 blockseed,
+void DecorationManager::placeAllDecos(Mapgen *mg, u32 blockseed,
 	v3s16 nmin, v3s16 nmax)
 {
-	size_t nplaced = 0;
-
 	for (size_t i = 0; i != m_objects.size(); i++) {
 		Decoration *deco = (Decoration *)m_objects[i];
 		if (!deco)
 			continue;
 
-		nplaced += deco->placeDeco(mg, blockseed, nmin, nmax);
+		deco->placeDeco(mg, blockseed, nmin, nmax);
 		blockseed++;
 	}
-
-	return nplaced;
 }
 
 DecorationManager *DecorationManager::clone() const
@@ -128,38 +124,27 @@ bool Decoration::canPlaceDecoration(MMVManip *vm, v3s16 p)
 }
 
 
-size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
+void Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 {
 	PcgRandom ps(blockseed + 53);
 	int carea_size = nmax.X - nmin.X + 1;
 
 	// Divide area into parts
 	// If chunksize is changed it may no longer be divisable by sidelen
-	if (carea_size % sidelen)
+	if (carea_size % sidelen != 0)
 		sidelen = carea_size;
 
-	s16 divlen = carea_size / sidelen;
 	int area = sidelen * sidelen;
 
-	for (s16 z0 = 0; z0 < divlen; z0++)
-	for (s16 x0 = 0; x0 < divlen; x0++) {
-		v2s16 p2d_center( // Center position of part of division
-			nmin.X + sidelen / 2 + sidelen * x0,
-			nmin.Z + sidelen / 2 + sidelen * z0
-		);
-		v2s16 p2d_min( // Minimum edge of part of division
-			nmin.X + sidelen * x0,
-			nmin.Z + sidelen * z0
-		);
-		v2s16 p2d_max( // Maximum edge of part of division
-			nmin.X + sidelen + sidelen * x0 - 1,
-			nmin.Z + sidelen + sidelen * z0 - 1
-		);
+	for (s16 z0 = 0; z0 < carea_size; z0 += sidelen)
+	for (s16 x0 = 0; x0 < carea_size; x0 += sidelen) {
+		v2s16 p2d_min(nmin.X + x0, nmin.Z + z0);
+		v2s16 p2d_max(nmin.X + x0 + sidelen - 1, nmin.Z + z0 + sidelen - 1);
 
 		bool cover = false;
 		// Amount of decorations
 		float nval = (flags & DECO_USE_NOISE) ?
-			NoisePerlin2D(&np, p2d_center.X, p2d_center.Y, mapseed) :
+			NoisePerlin2D(&np, p2d_min.X + sidelen / 2, p2d_min.Y + sidelen / 2, mapseed) :
 			fill_ratio;
 		u32 deco_count = 0;
 
@@ -262,7 +247,7 @@ size_t Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 		}
 	}
 
-	return 0;
+	return;
 }
 
 

--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -126,6 +126,10 @@ bool Decoration::canPlaceDecoration(MMVManip *vm, v3s16 p)
 
 void Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 {
+	// Skip if y ranges do not overlap
+	if (nmax.Y < y_min || y_max < nmin.Y)
+		return;
+
 	PcgRandom ps(blockseed + 53);
 	int carea_size = nmax.X - nmin.X + 1;
 

--- a/src/mapgen/mg_decoration.h
+++ b/src/mapgen/mg_decoration.h
@@ -44,7 +44,7 @@ public:
 	virtual void resolveNodeNames();
 
 	bool canPlaceDecoration(MMVManip *vm, v3s16 p);
-	size_t placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
+	void placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 
 	virtual size_t generate(MMVManip *vm, PcgRandom *pr, v3s16 p, bool ceiling) = 0;
 
@@ -135,7 +135,7 @@ public:
 		}
 	}
 
-	size_t placeAllDecos(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
+	void placeAllDecos(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax);
 
 private:
 	DecorationManager() {};


### PR DESCRIPTION
- `placeDeco` only ever returns 0, hence `placeAllDecos` also. Use `void` then.
- some trivial code cleanups
- skip decorations whose ylimits do not overlap the current chunk. This helps in particular when multiple "dimensions" are implemented by verticals stacking (e.g., nether in voxelibre, mineclonia).