### PR TITLE
Disable debug-breaking locale workaround when debugging

### DIFF
--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -170,9 +170,12 @@ void init_gettext(const char *path, const std::string &configured_language,
 		SetEnvironmentVariableA("LANGUAGE", configured_language.c_str());
 
 #if CHECK_CLIENT_BUILD()
+#if NDEBUG
 		// Hack to force gettext to see the right environment
+		// Disabled during debug as it can break debugging
 		if (current_language != configured_language)
 			MSVC_LocaleWorkaround(argc, argv);
+#endif
 #else
 		errorstream << "*******************************************************" << std::endl;
 		errorstream << "Can't apply locale workaround for server!" << std::endl;

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -170,12 +170,10 @@ void init_gettext(const char *path, const std::string &configured_language,
 		SetEnvironmentVariableA("LANGUAGE", configured_language.c_str());
 
 #if CHECK_CLIENT_BUILD()
-#if NDEBUG
 		// Hack to force gettext to see the right environment
-		// Disabled during debug as it can break debugging
-		if (current_language != configured_language)
+		// Disabled when debugger is present as it can break debugging 
+		if (current_language != configured_language && !IsDebuggerPresent())
 			MSVC_LocaleWorkaround(argc, argv);
-#endif
 #else
 		errorstream << "*******************************************************" << std::endl;
 		errorstream << "Can't apply locale workaround for server!" << std::endl;

--- a/src/gettext.cpp
+++ b/src/gettext.cpp
@@ -171,9 +171,13 @@ void init_gettext(const char *path, const std::string &configured_language,
 
 #if CHECK_CLIENT_BUILD()
 		// Hack to force gettext to see the right environment
-		// Disabled when debugger is present as it can break debugging 
-		if (current_language != configured_language && !IsDebuggerPresent())
-			MSVC_LocaleWorkaround(argc, argv);
+		if (current_language != configured_language) {
+			// Disabled when debugger is present as it can break debugging
+			if (!IsDebuggerPresent())
+				MSVC_LocaleWorkaround(argc, argv);
+			else
+				actionstream << "Debugger detected. Skipping MSVC_LocaleWorkaround." << std::endl;
+		}
 #else
 		errorstream << "*******************************************************" << std::endl;
 		errorstream << "Can't apply locale workaround for server!" << std::endl;


### PR DESCRIPTION
Prevents a locale workaround from being used when a debugger is present. The locale workaround restarts the console application to correct the language, making Visual Studio lose sight of the application, preventing debugging. 

Tested on Visual Studio Community 2022.

## To do

This PR is Ready for Review. 

