### PR TITLE
Add vcpkg.json

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,6 +70,8 @@ jobs:
   msvc:
     name: VS 2019 ${{ matrix.config.arch }}-${{ matrix.type }}
     runs-on: windows-2019
+    env:
+      VCPKG_DEFAULT_TRIPLET: ${{matrix.config.vcpkg_triplet}}
     strategy:
       fail-fast: false
       matrix:
@@ -93,11 +95,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore from cache and run vcpkg
-        uses: lukka/run-vcpkg@v7
+        uses: lukka/run-vcpkg@v11
         with:
           vcpkgDirectory: '${{ github.workspace }}\vcpkg'
-          appendedCacheKey: ${{ matrix.config.vcpkg_triplet }}
-          vcpkgTriplet: ${{ matrix.config.vcpkg_triplet }}
 
       - name: CMake
         # Note: See #15976 for why CMAKE_POLICY_VERSION_MINIMUM=3.5 is set.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,10 +70,6 @@ jobs:
   msvc:
     name: VS 2019 ${{ matrix.config.arch }}-${{ matrix.type }}
     runs-on: windows-2019
-    env:
-      VCPKG_VERSION: d5ec528843d29e3a52d745a64b469f810b2cedbf
-      # 2025.02.14
-      vcpkg_packages: zlib zstd curl[winssl] openal-soft libvorbis libogg libjpeg-turbo sqlite3 freetype luajit gmp jsoncpp sdl2
     strategy:
       fail-fast: false
       matrix:
@@ -99,10 +95,8 @@ jobs:
       - name: Restore from cache and run vcpkg
         uses: lukka/run-vcpkg@v7
         with:
-          vcpkgArguments: ${{env.vcpkg_packages}}
           vcpkgDirectory: '${{ github.workspace }}\vcpkg'
           appendedCacheKey: ${{ matrix.config.vcpkg_triplet }}
-          vcpkgGitCommitId: ${{ env.VCPKG_VERSION }}
           vcpkgTriplet: ${{ matrix.config.vcpkg_triplet }}
 
       - name: CMake

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf",
+  "dependencies": [
+    "zlib",
+    "zstd",
+    {
+      "name": "curl",
+      "features": [
+        "winssl"
+      ]
+    },
+    "openal-soft",
+    "libvorbis",
+    "libogg",
+    "libjpeg-turbo",
+    "sqlite3",
+    "freetype",
+    "luajit",
+    "gmp",
+    "jsoncpp",
+    {
+      "name": "gettext",
+      "features": [
+        "tools"
+      ]
+    },
+    "sdl2"
+  ]
+}


### PR DESCRIPTION
Apparently I wrote a `vcpkg.json` (with the baseline updated yesterday) when I set up the compilation environment last year.

Also note that this also upgrades `run-vcpkg` to v11 which has caching built-in, see e.g. https://github.com/y5nw/minetest/actions/runs/13639555007/job/38129304037#step:4:47 (the step is re-run - for the first run see https://github.com/y5nw/minetest/actions/runs/13639555007/job/38129303119).

Related: #15789

- Goal of the PR
  Provide `vcpkg.json` for use in Windows.
- Does it resolve any reported issue?
  Fixes #13962.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  It makes it easier to build with MSVC.

## To do
- Update documentation on `docs`.

## How to test

Observe CI output.