### PR TITLE
Make it more convenient to implement item/player/entity abilities that modify node drops

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -514,7 +514,7 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name(), ItemStack(wielded), digger, vector.copy(pos))
+	local drops = core.get_node_drops(node, wielded and wielded:get_name(), wielded and ItemStack(wielded), digger, vector.copy(pos))
 
 	if wielded then
 		local wdef = wielded:get_definition()

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -514,7 +514,7 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name(), wielded, digger)
+	local drops = core.get_node_drops(node, wielded and wielded:get_name(), ItemStack(wielded), digger)
 
 	if wielded then
 		local wdef = wielded:get_definition()

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -514,7 +514,7 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name(), ItemStack(wielded), digger)
+	local drops = core.get_node_drops(node, wielded and wielded:get_name(), ItemStack(wielded), digger, pos)
 
 	if wielded then
 		local wdef = wielded:get_definition()

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -514,7 +514,8 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name(), wielded and ItemStack(wielded), digger, vector.copy(pos))
+	local drops = core.get_node_drops(node, wielded and wielded:get_name(),
+				wielded and ItemStack(wielded), digger, vector.copy(pos))
 
 	if wielded then
 		local wdef = wielded:get_definition()

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -514,7 +514,7 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name(), ItemStack(wielded), digger, pos)
+	local drops = core.get_node_drops(node, wielded and wielded:get_name(), ItemStack(wielded), digger, vector.copy(pos))
 
 	if wielded then
 		local wdef = wielded:get_definition()

--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -514,7 +514,7 @@ function core.node_dig(pos, node, digger)
 		.. node.name .. " at " .. core.pos_to_string(pos))
 
 	local wielded = digger and digger:get_wielded_item()
-	local drops = core.get_node_drops(node, wielded and wielded:get_name())
+	local drops = core.get_node_drops(node, wielded and wielded:get_name(), wielded, digger)
 
 	if wielded then
 		local wdef = wielded:get_definition()

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6829,13 +6829,14 @@ Item handling
       given `param2` value.
     * Returns `nil` if the given `paramtype2` does not contain color
       information.
-* `core.get_node_drops(node, toolname[, tool, digger])`
+* `core.get_node_drops(node, toolname[, tool, digger, pos])`
     * Returns list of itemstrings that are dropped by `node` when dug
       with the item `toolname` (not limited to tools).
     * `node`: node as table or node name
     * `toolname`: name of the item used to dig (can be `nil`)
     * `tool`: `ItemStack` used to dig (optional)
-    * `digger`: The ObjectRef that digs the node (optional)
+    * `digger`: the ObjectRef that digs the node (optional)
+    * `pos`: the pos of the dug node (optional)
 * `core.get_craft_result(input)`: returns `output, decremented_input`
     * `input.method` = `"normal"` or `"cooking"` or `"fuel"`
     * `input.width` = for example `3`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6830,13 +6830,15 @@ Item handling
     * Returns `nil` if the given `paramtype2` does not contain color
       information.
 * `core.get_node_drops(node, toolname[, tool, digger, pos])`
-    * Returns list of itemstrings that are dropped by `node` when dug
-      with the item `toolname` (not limited to tools).
+    * Returns list of itemstrings that are dropped by `node` when dug with the
+      item `toolname` (not limited to tools). The default implementation doesn't
+      use `tool`, `digger`, and `pos`, but these are provided by `core.node_dig`
+      since 5.12.0 for games/mods implementing customized drops.
     * `node`: node as table or node name
     * `toolname`: name of the item used to dig (can be `nil`)
-    * `tool`: `ItemStack` used to dig (optional)
-    * `digger`: the ObjectRef that digs the node (optional)
-    * `pos`: the pos of the dug node (optional)
+    * `tool`: `ItemStack` used to dig (can be `nil`)
+    * `digger`: the ObjectRef that digs the node (can be `nil`)
+    * `pos`: the pos of the dug node (can be `nil`)
 * `core.get_craft_result(input)`: returns `output, decremented_input`
     * `input.method` = `"normal"` or `"cooking"` or `"fuel"`
     * `input.width` = for example `3`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6829,11 +6829,13 @@ Item handling
       given `param2` value.
     * Returns `nil` if the given `paramtype2` does not contain color
       information.
-* `core.get_node_drops(node, toolname)`
+* `core.get_node_drops(node, toolname[, tool, digger])`
     * Returns list of itemstrings that are dropped by `node` when dug
       with the item `toolname` (not limited to tools).
     * `node`: node as table or node name
     * `toolname`: name of the item used to dig (can be `nil`)
+    * `tool`: `ItemStack` used to dig (optional)
+    * `digger`: The ObjectRef that digs the node (optional)
 * `core.get_craft_result(input)`: returns `output, decremented_input`
     * `input.method` = `"normal"` or `"cooking"` or `"fuel"`
     * `input.width` = for example `3`


### PR DESCRIPTION
## Context

`core.node_dig(pos, node, digger)` uses `core.get_node_drops(node, toolname)` to determine the drops that should result from digging a node. The builtin implementation of `get_node_drops` uses a well documented not so simple algorithm to compute the drops from data recorded in the node and tool definition while builtin `node_dig` handles varied tasks like removing the node, applying wear to the wielded tool, and calling callbacks. For most games/mods it's not desirable to completely replace the builtin implementations, but rather hook into them to e.g. implement player abilities or tool enchantments that may modify yield. But since the builtin implementation of `get_node_drops` only needs the name of the tool and the node data, nothing more is available and while the other function related to drops, `core.handle_node_drops(pos, drops, digger)`, has access to the `digger` and therefore the wielded tool, that one is only called after wear is applied and the tool potentially destroyed. Workarounds are possible (e.g. overriding `node_dig` to add some fields to the `node` parameter that is currently passed unmodified to `get_node_drops` and then calling the original `node_dig` function), but a satisfying solution within the existing API at least isn't obvious.

## Proposed solution

The simple solution proposed in this PR is making `node_dig` also pass the `tool` itemstack ,the `digger` object reference, and the node `pos` to `get_node_drops`. These aren't used by the builtin implementation, therefore there is no functional change, but provide overrides with the access to relevant meta data. 

Initially the node `pos` wasn't passed, but @CandyFiend below made an IMO convincing argument that node context could be relevant when computing node drops, especially in an RPG like game.

## Related issues

This PR is perhaps a tiny little bit related to (closed) issue #13740 in so far as it opens more ways to modify node drops.

## Status

This PR is Ready for Review.

## How to test

Since this is mostly a documentation change, there should be no observable change at all as long as mods are not using the additional parameters provided to `core.get_node_drops`.