### PR TITLE
Client: Avoid touching all blocks in range every 0.2s

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3907,7 +3907,8 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	runData.update_draw_list_timer += dtime;
 	runData.touch_blocks_timer += dtime;
 
-	float update_draw_list_delta = 0.2f;
+	constexpr float update_draw_list_delta = 0.2f;
+	constexpr float touch_mapblock_delta = 4.0f;
 
 	v3f camera_direction = camera->getDirection();
 
@@ -3920,7 +3921,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		runData.update_draw_list_timer = 0;
 		client->getEnv().getClientMap().updateDrawList();
 		runData.update_draw_list_last_cam_dir = camera_direction;
-	} else if (runData.touch_blocks_timer > update_draw_list_delta) {
+	} else if (runData.touch_blocks_timer > touch_mapblock_delta) {
 		client->getEnv().getClientMap().touchMapBlocks();
 		runData.touch_blocks_timer = 0;
 	} else if (RenderingEngine::get_shadow_renderer()) {


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Currently we touch (reset the usage counter) every block in the viewing_range (the sphere not the cone) every 0.2s.
With larger viewing_range that becomes the largest part of non-rendering time. The default client block timeout is 600s (in that time we touched visible blocks 3000 times). We can reduce the frequency and thereby save CPU and increase average FPS.

- How does the PR work?
Only touch the blocks every every 1/10 of the client timeout (i.e. 60s by default).

- Does it resolve any reported issue?
Nope

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Nope

- If not a bug fix, why is this PR needed? What usecases does it solve?
Performance

## To do

This PR is Ready for Review.

## How to test

Just fly around. Make sure sure no visible mapblocks are unloaded.

Note that there in an "extreme" condition if:
1. Your client map cache is small
2. You fly in one direction for 20s, then fly back
3. Now fly past the point where you started

If the new blocks you loaded now filled your client cached, some of the blocks close to you might be expired from cache (rather then the farther ones), since they haven't been touched again.
Could fix that by tracking how far we have moved that since the last time, but I do not think that is needed.
