### PR TITLE
Make remote media exclusively use GET for hash set

### DIFF
--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -253,9 +253,9 @@ void ClientMediaDownloader::initialStep(Client *client)
 		// requests, so if there are lots of remote servers that are
 		// not responding, those will stall new media file transfers.
 
-		assert(m_httpfetch_next_id == 0);
-
 		for (u32 i = 0; i < m_remotes.size(); ++i) {
+			assert(m_httpfetch_next_id == i);
+
 			RemoteServerStatus *remote = m_remotes[i];
 			actionstream << "Client: Contacting remote server \""
 				<< remote->baseurl << "\"" << std::endl;

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -238,11 +238,12 @@ void ClientMediaDownloader::initialStep(Client *client)
 
 		// Note: we used to use a POST request that contained the set of
 		// hashes we needed here, but this use was discontinued in 5.12.0 as
-		// it's not CDN-friendly. Even with a large repository of media (think 60k files),
-		// you would be looking at just 1.1 MB for the index file.
+		// it's not CDN/static hosting-friendly.
+		// Even with a large repository of media (think 60k files), you would be
+		// looking at only 1.1 MB for the index file.
 		// If it becomes a problem we can always still introduce a v2 of the
-		// hash set format and truncate the hashes to 8 bytes -- at the cost of
-		// a false-positive rate of 2^-64 -- which is 60% less space.
+		// hash set format and truncate the hashes to 6 bytes -- at the cost of
+		// a false-positive rate of 2^-48 -- which is 70% less space.
 
 		// minor fixme: this loop ignores m_httpfetch_active_limit
 

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -255,7 +255,7 @@ void ClientMediaDownloader::initialStep(Client *client)
 		assert(m_httpfetch_next_id == 0);
 
 		for (u32 i = 0; i < m_remotes.size(); ++i) {
-			auto *remote = m_remotes[i];
+			RemoteServerStatus *remote = m_remotes[i];
 			actionstream << "Client: Contacting remote server \""
 				<< remote->baseurl << "\"" << std::endl;
 

--- a/src/client/clientmedia.cpp
+++ b/src/client/clientmedia.cpp
@@ -154,7 +154,7 @@ void ClientMediaDownloader::step(Client *client)
 			startRemoteMediaTransfers();
 
 		// Did all remote transfers end and no new ones can be started?
-		// If so, request still missing files from the minetest server
+		// If so, request still missing files from the server
 		// (Or report that we have all files.)
 		if (m_httpfetch_active == 0) {
 			if (m_uncached_received_count < m_uncached_count) {
@@ -236,9 +236,13 @@ void ClientMediaDownloader::initialStep(Client *client)
 		m_httpfetch_active_limit = g_settings->getS32("curl_parallel_limit");
 		m_httpfetch_active_limit = MYMAX(m_httpfetch_active_limit, 84);
 
-		// Write a list of hashes that we need. This will be POSTed
-		// to the server using Content-Type: application/octet-stream
-		std::string required_hash_set = serializeRequiredHashSet();
+		// Note: we used to use a POST request that contained the set of
+		// hashes we needed here, but this use was discontinued in 5.12.0 as
+		// it's not CDN-friendly. Even with a large repository of media (think 60k files),
+		// you would be looking at just 1.1 MB for the index file.
+		// If it becomes a problem we can always still introduce a v2 of the
+		// hash set format and truncate the hashes to 8 bytes -- at the cost of
+		// a false-positive rate of 2^-64 -- which is 60% less space.
 
 		// minor fixme: this loop ignores m_httpfetch_active_limit
 
@@ -260,10 +264,6 @@ void ClientMediaDownloader::initialStep(Client *client)
 				remote->baseurl + MTHASHSET_FILE_NAME;
 			fetch_request.caller = m_httpfetch_caller;
 			fetch_request.request_id = m_httpfetch_next_id; // == i
-			fetch_request.method = HTTP_POST;
-			fetch_request.raw_data = required_hash_set;
-			fetch_request.extra_headers.emplace_back(
-				"Content-Type: application/octet-stream");
 			fetch_request.extra_headers.emplace_back(
 				"Referer: " + makeReferer(client));
 
@@ -586,25 +586,6 @@ bool IClientMediaDownloader::checkAndLoad(
 	Version changes:
 	1 - Initial version
 */
-
-std::string ClientMediaDownloader::serializeRequiredHashSet()
-{
-	std::ostringstream os(std::ios::binary);
-
-	writeU32(os, MTHASHSET_FILE_SIGNATURE); // signature
-	writeU16(os, 1);                        // version
-
-	// Write list of hashes of files that have not been
-	// received (found in cache) yet
-	for (const auto &it : m_files) {
-		if (!it.second->received) {
-			sanity_check(it.second->sha1.size() != 20);
-			os << it.second->sha1;
-		}
-	}
-
-	return os.str();
-}
 
 void ClientMediaDownloader::deSerializeHashSet(const std::string &data,
 		std::set<std::string> &result)

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -144,7 +144,6 @@ private:
 
 	static void deSerializeHashSet(const std::string &data,
 			std::set<std::string> &result);
-	std::string serializeRequiredHashSet();
 
 	// Maps filename to file status
 	std::map<std::string, FileStatus*> m_files;

--- a/src/client/clientmedia.h
+++ b/src/client/clientmedia.h
@@ -119,6 +119,8 @@ protected:
 	bool loadMedia(Client *client, const std::string &data,
 			const std::string &name) override;
 
+	static std::string makeReferer(Client *client);
+
 private:
 	struct FileStatus {
 		bool received;


### PR DESCRIPTION
cc @rubenwardy I vaguely remember this being talked about

EDIT (wsor4035): https://irc.minetest.net/minetest-dev/2025-01-26#i_6237890

I originally set out to make the code try GET after POST but it would introduce lots of additional complexity (as well as some latency) so I chose the eaiser path.

This is a breaking change in how remote media works, *however* a remote media server can easily support both ways.

## To do

This PR is Ready for Review.

## How to test

Try to set a remote media server, clear your client cache, join and see how it behaves.
