### PR TITLE
Echo DMs sent with /msg

### DIFF
--- a/builtin/game/chat.lua
+++ b/builtin/game/chat.lua
@@ -1275,7 +1275,7 @@ core.register_chatcommand("msg", {
 		core.log("action", "DM from " .. name .. " to " .. sendto
 				.. ": " .. message)
 		core.chat_send_player(sendto, S("DM from @1: @2", name, message))
-		return true, S("Message sent.")
+		return true, S("DM sent to @1: @2", sendto, message)
 	end,
 })
 


### PR DESCRIPTION
Command echos were removed a while back to clean up chat, but with that went the record of DMs you send out. I've changed the command response to echo your sent DM back to you so conversation continuity is preserved. Uses `DM` instead of `Message` to be consistent with `DM from`, and `sent to` instead of just `to` for visual clarity.