### PR TITLE
Formspec: fix clamped scroll offset of 'scroll_container's larger than 1000 px

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -695,7 +695,9 @@ void GUIFormSpecMenu::parseScrollBar(parserData* data, const std::string &elemen
 	e->setMax(max);
 	e->setMin(min);
 
-	e->setPos(stoi(value));
+	// Preserve for min/max values defined by `scroll_container[]`.
+	spec.aux_f32 = stoi(value); // scroll position
+	e->setPos(spec.aux_f32);
 
 	e->setSmallStep(data->scrollbar_options.small_step);
 	e->setLargeStep(data->scrollbar_options.large_step);
@@ -2198,7 +2200,6 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 
 	spec_btn.ftype = f_Button;
 	rect += data->basepos-padding;
-	spec_btn.rect = rect;
 	m_fields.push_back(spec_btn);
 }
 
@@ -3235,6 +3236,8 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 		for (const std::pair<FieldSpec, GUIScrollBar *> &b : m_scrollbars) {
 			if (c.first == b.first.fname) {
 				c.second->setScrollBar(b.second);
+				b.second->setPos(b.first.aux_f32); // scroll position
+				c.second->updateScrolling();
 				break;
 			}
 		}

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -129,9 +129,9 @@ class GUIFormSpecMenu : public GUIModalMenu
 		bool is_exit;
 		// Draw priority for formspec version < 3
 		int priority;
-		core::rect<s32> rect;
 		gui::ECURSOR_ICON fcursor_icon;
 		std::string sound;
+		f32 aux_f32 = 0;
 	};
 
 	struct TooltipSpec

--- a/src/gui/guiScrollBar.cpp
+++ b/src/gui/guiScrollBar.cpp
@@ -249,7 +249,7 @@ void GUIScrollBar::updatePos()
 	setPosRaw(scroll_pos);
 }
 
-void GUIScrollBar::setPosRaw(const s32 &pos)
+void GUIScrollBar::setPosRaw(const s32 pos)
 {
 	s32 thumb_area = 0;
 	s32 thumb_min = 0;
@@ -275,7 +275,7 @@ void GUIScrollBar::setPosRaw(const s32 &pos)
 		border_size;
 }
 
-void GUIScrollBar::setPos(const s32 &pos)
+void GUIScrollBar::setPos(const s32 pos)
 {
 	setPosRaw(pos);
 	target_pos = std::nullopt;

--- a/src/gui/guiScrollBar.h
+++ b/src/gui/guiScrollBar.h
@@ -54,7 +54,7 @@ public:
 	void setLargeStep(const s32 &step);
 	//! Sets a position immediately, aborting any ongoing interpolation.
 	// setPos does not send EGET_SCROLL_BAR_CHANGED events for you.
-	void setPos(const s32 &pos);
+	void setPos(const s32 pos);
 	//! The same as setPos, but it takes care of sending EGET_SCROLL_BAR_CHANGED events.
 	void setPosAndSend(const s32 &pos);
 	//! Sets a target position for interpolation.
@@ -94,7 +94,7 @@ private:
 
 	ISimpleTextureSource *m_tsrc;
 
-	void setPosRaw(const s32 &pos);
+	void setPosRaw(const s32 pos);
 	void updatePos();
 	std::optional<s32> target_pos;
 	u32 last_time_ms = 0;

--- a/src/gui/guiScrollContainer.cpp
+++ b/src/gui/guiScrollContainer.cpp
@@ -92,8 +92,6 @@ void GUIScrollContainer::setScrollBar(GUIScrollBar *scrollbar)
 
 		m_scrollbar->setPageSize((total_content_px * scrollbar_px) / visible_content_px);
 	}
-
-	updateScrolling();
 }
 
 void GUIScrollContainer::updateScrolling()

--- a/src/gui/guiScrollContainer.h
+++ b/src/gui/guiScrollContainer.h
@@ -29,6 +29,7 @@ public:
 	}
 
 	void setScrollBar(GUIScrollBar *scrollbar);
+	void updateScrolling();
 
 private:
 	enum OrientationEnum
@@ -43,5 +44,4 @@ private:
 	f32 m_scrollfactor; //< scrollbar pos * scrollfactor = scroll offset in pixels
 	std::optional<s32> m_content_padding_px; //< in pixels
 
-	void updateScrolling();
 };


### PR DESCRIPTION
Fixes #15882

This PR reserves the `scrollbar[]` position to set the correct position after `scroll_container[]` finished its job. It's not the most beautiful solution but it works.

## To do

This PR is Ready for Review.

## How to test

Quoting #15882:

> 1. go to settings
> 2. check "show advanced" checkbox
> 3. go to "Advanced" -> "Advanced" category
> 4. scroll way down
> 5. press "Set" on any setting
> 6. observe the scrollbar jumping