### PR TITLE
Reload font manager in main thread to avoid a crash

### DIFF
--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -18,11 +18,9 @@
 /** reference to access font engine, has to be initialized by main */
 FontEngine *g_fontengine = nullptr;
 
-bool FontEngine::m_needs_reload = false;
-
 void FontEngine::fontSettingChanged(const std::string &name, void *userdata)
 {
-	m_needs_reload = true;
+	((FontEngine *)userdata)->m_needs_reload = true;
 }
 
 static const char *settings[] = {

--- a/src/client/fontengine.cpp
+++ b/src/client/fontengine.cpp
@@ -18,10 +18,11 @@
 /** reference to access font engine, has to be initialized by main */
 FontEngine *g_fontengine = nullptr;
 
-/** callback to be used on change of font size setting */
-static void font_setting_changed(const std::string &name, void *userdata)
+bool FontEngine::m_needs_reload = false;
+
+void FontEngine::fontSettingChanged(const std::string &name, void *userdata)
 {
-	static_cast<FontEngine *>(userdata)->readSettings();
+	m_needs_reload = true;
 }
 
 static const char *settings[] = {
@@ -49,7 +50,7 @@ FontEngine::FontEngine(gui::IGUIEnvironment* env) :
 	readSettings();
 
 	for (auto name : settings)
-		g_settings->registerChangedCallback(name, font_setting_changed, this);
+		g_settings->registerChangedCallback(name, fontSettingChanged, this);
 }
 
 FontEngine::~FontEngine()
@@ -160,6 +161,15 @@ void FontEngine::readSettings()
 	m_default_italic = g_settings->getBool("font_italic");
 
 	refresh();
+}
+
+void FontEngine::handleReload()
+{
+	if (!m_needs_reload)
+		return;
+
+	m_needs_reload = false;
+	readSettings();
 }
 
 void FontEngine::updateSkin()

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -170,7 +170,7 @@ private:
 	/** default font engine mode (fixed) */
 	static const FontMode m_currentMode = FM_Standard;
 
-	static bool m_needs_reload;
+	bool m_needs_reload = false;
 
 	DISABLE_CLASS_COPY(FontEngine);
 };

--- a/src/client/fontengine.h
+++ b/src/client/fontengine.h
@@ -121,6 +121,9 @@ public:
 	/** update internal parameters from settings */
 	void readSettings();
 
+	/** reload fonts if settings were changed */
+	void handleReload();
+
 	void setMediaFont(const std::string &name, const std::string &data);
 
 	void clearMediaFonts();
@@ -141,6 +144,9 @@ private:
 
 	/** refresh after fonts have been changed */
 	void refresh();
+
+	/** callback to be used on change of font size setting */
+	static void fontSettingChanged(const std::string &name, void *userdata);
 
 	/** pointer to irrlicht gui environment */
 	gui::IGUIEnvironment* m_env = nullptr;
@@ -163,6 +169,8 @@ private:
 
 	/** default font engine mode (fixed) */
 	static const FontMode m_currentMode = FM_Standard;
+
+	static bool m_needs_reload;
 
 	DISABLE_CLASS_COPY(FontEngine);
 };

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -970,6 +970,8 @@ void Game::run()
 
 		framemarker.start();
 
+		g_fontengine->handleReload();
+
 		const auto current_dynamic_info = ClientDynamicInfo::getCurrent();
 		if (!current_dynamic_info.equal(client_display_info)) {
 			client_display_info = current_dynamic_info;

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -337,6 +337,8 @@ void GUIEngine::run()
 		fps_control.limit(device, &dtime);
 		framemarker.start();
 
+		g_fontengine->handleReload();
+
 		if (device->isWindowVisible()) {
 			// check if we need to update the "upper left corner"-text
 			if (text_height != g_fontengine->getTextHeight()) {


### PR DESCRIPTION
Currently, when I use
```
/set gui_scaling 1.5
```
during game in chat console I get a crash:

```
#0  0x00007ffff600bf69 in ?? () from /lib/x86_64-linux-gnu/libGLdispatch.so.0
#1  0x0000555555fe4c3f in irr::video::COpenGLCoreTexture<irr::video::COpenGLDriver>::~COpenGLCoreTexture (this=0x55555acd8e50, __in_chrg=<optimized out>, 
    __vtt_parm=<optimized out>)
    at /mnt/data/prg/minetest-deve/irr/src/COpenGLCoreTexture.h:267
#2  0x0000555555fe4d82 in irr::video::COpenGLCoreTexture<irr::video::COpenGLDriver>::~COpenGLCoreTexture (this=0x55555acd8e50, __in_chrg=<optimized out>, 
    __vtt_parm=<optimized out>)
    at /mnt/data/prg/minetest-deve/irr/src/COpenGLCoreTexture.h:274
#3  0x000055555568aef9 in irr::IReferenceCounted::drop (this=0x55555acd8f30)
    at /mnt/data/prg/minetest-deve/irr/include/IReferenceCounted.h:125
#4  0x0000555555fbc14b in irr::video::CNullDriver::removeTexture (
    this=0x555556ffc310, texture=0x55555acd8e50)
    at /mnt/data/prg/minetest-deve/irr/src/CNullDriver.cpp:275
#5  0x0000555555fd8f18 in irr::video::COpenGLDriver::removeTexture (
    this=0x555556ffc310, texture=0x55555acd8e50)
    at /mnt/data/prg/minetest-deve/irr/src/COpenGLDriver.cpp:2503
#6  0x000055555595afe3 in irr::gui::CGUITTGlyphPage::~CGUITTGlyphPage (
    this=0x55555acc7040, __in_chrg=<optimized out>)
    at /mnt/data/prg/minetest-deve/src/irrlicht_changes/CGUITTFont.h:157
#7  0x00005555559586ad in irr::gui::CGUITTFont::reset_images (
--Type <RET> for more, q to quit, c to continue without paging--
    this=0x55555a9e6e40)
    at /mnt/data/prg/minetest-deve/src/irrlicht_changes/CGUITTFont.cpp:361
#8  0x0000555555958520 in irr::gui::CGUITTFont::~CGUITTFont (
    this=0x55555a9e6e40, __in_chrg=<optimized out>, __vtt_parm=<optimized out>)
    at /mnt/data/prg/minetest-deve/src/irrlicht_changes/CGUITTFont.cpp:345
#9  0x0000555555958602 in irr::gui::CGUITTFont::~CGUITTFont (
    this=0x55555a9e6e40, __in_chrg=<optimized out>, __vtt_parm=<optimized out>)
    at /mnt/data/prg/minetest-deve/src/irrlicht_changes/CGUITTFont.cpp:351
#10 0x000055555568aef9 in irr::IReferenceCounted::drop (this=0x55555a9e6f50)
    at /mnt/data/prg/minetest-deve/irr/include/IReferenceCounted.h:125
#11 0x000055555574dd72 in FontEngine::clearCache (this=0x555556a86ef0)
    at /mnt/data/prg/minetest-deve/src/client/fontengine.cpp:69
#12 0x000055555574e5cc in FontEngine::refresh (this=0x555556a86ef0)
    at /mnt/data/prg/minetest-deve/src/client/fontengine.cpp:181
#13 0x000055555574e3ac in FontEngine::readSettings (this=0x555556a86ef0)
    at /mnt/data/prg/minetest-deve/src/client/fontengine.cpp:162
#14 0x000055555574d8df in font_setting_changed (name="gui_scaling", 
    userdata=0x555556a86ef0)
    at /mnt/data/prg/minetest-deve/src/client/fontengine.cpp:24
--Type <RET> for more, q to quit, c to continue without paging--
#15 0x0000555555dca0df in Settings::doCallbacks (this=0x5555566d7cb0, 
    name="gui_scaling")
    at /mnt/data/prg/minetest-deve/src/settings.cpp:1079
#16 0x0000555555dc8616 in Settings::set (this=0x5555566d7cb0, 
    name="gui_scaling", value="1.5")
    at /mnt/data/prg/minetest-deve/src/settings.cpp:856
#17 0x0000555555a9f3f7 in LuaSettings::l_set (L=0x7fffe5f20380)
    at /mnt/data/prg/minetest-deve/src/script/lua_api/l_settings.cpp:208
#18 0x0000555555a041df in script_exception_wrapper (L=0x7fffe5f20380, 
    f=0x555555a9f2c4 <LuaSettings::l_set(lua_State*)>)
    at /mnt/data/prg/minetest-deve/src/script/common/c_internal.cpp:28
#19 0x00007ffff7aeb4fb in ?? () from /lib/x86_64-linux-gnu/libluajit-5.1.so.2
#20 0x00007ffff7afee50 in lua_pcall ()
   from /lib/x86_64-linux-gnu/libluajit-5.1.so.2
#21 0x0000555555a15c3e in ScriptApiBase::runCallbacksRaw (this=0x7fffbc0104d8, 
    nargs=2, mode=RUN_CALLBACKS_MODE_OR_SC, 
    fxn=0x55555619845a "on_chat_message")
    at /mnt/data/prg/minetest-deve/src/script/cpp_api/s_base.cpp:343
#22 0x0000555555a34728 in ScriptApiServer::on_chat_message (
    this=0x7fffbc010328, name="test", message="/set gui_scaling 1.5")
    at /mnt/data/prg/minetest-deve/src/script/cpp_api/s_server.cpp:13--Type <RET> for more, q to quit, c to continue without paging--
7
#23 0x0000555555ceaaf3 in Server::handleChat (this=0x555559a2ed60, 
    name="test", wmessage=L"/set gui_scaling 1.5", check_shout_priv=true, 
    player=0x7fffb003a510)
    at /mnt/data/prg/minetest-deve/src/server.cpp:3155
#24 0x00005555559d552b in Server::handleCommand_ChatMessage (
    this=0x555559a2ed60, pkt=0x7fffc3dfc0d0)
    at /mnt/data/prg/minetest-deve/src/network/serverpackethandler.cpp:756
#25 0x0000555555cf7a73 in Server::handleCommand (this=0x555559a2ed60, 
    pkt=0x7fffc3dfc0d0)
    at /mnt/data/prg/minetest-deve/src/server.cpp:1271
#26 0x0000555555cdd5cb in Server::ProcessData (this=0x555559a2ed60, 
    pkt=0x7fffc3dfc0d0)
    at /mnt/data/prg/minetest-deve/src/server.cpp:1322
#27 0x0000555555cdc3ac in Server::Receive (this=0x555559a2ed60, 
    min_time=0.0154766673)
    at /mnt/data/prg/minetest-deve/src/server.cpp:1119
#28 0x0000555555cd44e8 in ServerThread::run (this=0x555558744ca0)
    at /mnt/data/prg/minetest-deve/src/server.cpp:145
#29 0x0000555555e462ab in Thread::threadProc (thr=0x555558744ca0)
    at /mnt/data/prg/minetest-deve/src/threading/thread.cpp:194
#30 0x0000555555e46fb6 in std::__invoke_impl<void, void (*)(Thread*), Thread*>
--Type <RET> for more, q to quit, c to continue without paging--
    (__f=@0x7fffbc10f690: 0x555555e46200 <Thread::threadProc(Thread*)>)
    at /usr/include/c++/14/bits/invoke.h:61
#31 0x0000555555e46f29 in std::__invoke<void (*)(Thread*), Thread*> (
    __fn=@0x7fffbc10f690: 0x555555e46200 <Thread::threadProc(Thread*)>)
    at /usr/include/c++/14/bits/invoke.h:96
#32 0x0000555555e46e89 in std::thread::_Invoker<std::tuple<void (*)(Thread*), Thread*> >::_M_invoke<0ul, 1ul> (this=0x7fffbc10f688)
    at /usr/include/c++/14/bits/std_thread.h:301
#33 0x0000555555e46e3e in std::thread::_Invoker<std::tuple<void (*)(Thread*), Thread*> >::operator() (this=0x7fffbc10f688)
    at /usr/include/c++/14/bits/std_thread.h:308
#34 0x0000555555e46e1e in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(Thread*), Thread*> > >::_M_run (this=0x7fffbc10f680)
    at /usr/include/c++/14/bits/std_thread.h:253
#35 0x00007ffff6aecdb4 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
#36 0x00007ffff66a1e2e in start_thread (arg=<optimized out>)
    at ./nptl/pthread_create.c:447
#37 0x00007ffff6733a4c in __GI___clone3 ()
    at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```

The patch is to make sure that fonts are reloaded always in main thread.