### PR TITLE
Add documentation for core.MAP_BLOCKSIZE constant

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1681,7 +1681,9 @@ roughly 1x1x1 meters in size.
 
 A 'mapblock' (often abbreviated to 'block') is 16x16x16 nodes and is the
 fundamental region of a world that is stored in the world database, sent to
-clients and handled by many parts of the engine.
+clients and handled by many parts of the engine. This size is defined by the constant
+`core.MAP_BLOCKSIZE` (=16).
+
 'mapblock' is preferred terminology to 'block' to help avoid confusion with
 'node', however 'block' often appears in the API.
 
@@ -1713,7 +1715,7 @@ node position (0,0,0) to node position (15,15,15).
 To calculate the blockpos of the mapblock that contains the node at 'nodepos',
 for each axis:
 
-* blockpos = math.floor(nodepos / 16)
+* blockpos = math.floor(nodepos / core.MAP_BLOCKSIZE)
 
 #### Converting blockpos to min/max node positions
 
@@ -1721,9 +1723,9 @@ To calculate the min/max node positions contained in the mapblock at 'blockpos',
 for each axis:
 
 * Minimum:
-  nodepos = blockpos * 16
+  nodepos = blockpos * core.MAP_BLOCKSIZE
 * Maximum:
-  nodepos = blockpos * 16 + 15
+  nodepos = blockpos * core.MAP_BLOCKSIZE + (core.MAP_BLOCKSIZE - 1)
 
 
 


### PR DESCRIPTION
Add documentation for core.MAP_BLOCKSIZE constant

- Goal of the PR: Document the previously undocumented `core.MAP_BLOCKSIZE` constant in the Lua API documentation
- How does the PR work?: Adds references to the constant in the "Map terminology and coordinates" section, specifically in mapblock descriptions and coordinate conversion formulas
- Does it resolve any reported issue?: Yes, fixes #15907
- Does this relate to a goal in the roadmap?: Yes, relates to "2.2 Internal code refactoring" as proper documentation improves sustainable development
- If not a bug fix, why is this PR needed? What usecases does it solve?: N/A (this is a bug fix for missing documentation)

## To do

This PR is Ready for Review.

- [x] Add reference to `core.MAP_BLOCKSIZE` in "Nodes, mapblocks, mapchunks" section
- [x] Update coordinate conversion formulas to use the constant
- [x] Ensure documentation is clear and follows existing style

## How to test

Check lua_api.md after changes to verify:
1. The constant is properly documented
2. The formulas for coordinate conversion use the constant
3. The documentation is clear and helpful to users
