### PR TITLE
[no sq] Increase strictness for item registration / overrides

### DIFF
--- a/builtin/async/game.lua
+++ b/builtin/async/game.lua
@@ -59,6 +59,9 @@ end
 local alias_metatable = {
 	__index = function(t, name)
 		return rawget(t, core.registered_aliases[name])
+	end,
+	__newindex = function()
+		error("table is read-only")
 	end
 }
 setmetatable(core.registered_items, alias_metatable)

--- a/builtin/async/game.lua
+++ b/builtin/async/game.lua
@@ -32,8 +32,8 @@ do
 	all.registered_craftitems = {}
 	all.registered_tools = {}
 	for k, v in pairs(all.registered_items) do
-		-- Disable further modification
-		setmetatable(v, {__newindex = {}})
+		-- Ignore new keys
+		setmetatable(v, {__newindex = function() end})
 		-- Reassemble the other tables
 		if v.type == "node" then
 			getmetatable(v).__index = all.nodedef_default

--- a/builtin/emerge/register.lua
+++ b/builtin/emerge/register.lua
@@ -9,8 +9,8 @@ do
 	all.registered_craftitems = {}
 	all.registered_tools = {}
 	for k, v in pairs(all.registered_items) do
-		-- Disable further modification
-		setmetatable(v, {__newindex = {}})
+		-- Ignore new keys
+		setmetatable(v, {__newindex = function() end})
 		-- Reassemble the other tables
 		if v.type == "node" then
 			getmetatable(v).__index = all.nodedef_default

--- a/builtin/emerge/register.lua
+++ b/builtin/emerge/register.lua
@@ -36,6 +36,9 @@ end
 local alias_metatable = {
 	__index = function(t, name)
 		return rawget(t, core.registered_aliases[name])
+	end,
+	__newindex = function()
+		error("table is read-only")
 	end
 }
 setmetatable(core.registered_items, alias_metatable)

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -139,6 +139,12 @@ function core.register_item(name, itemdef)
 	end
 	itemdef.name = name
 
+	local mt = getmetatable(itemdef)
+	if mt ~= nil and next(mt) ~= nil then
+		core.log("warning", "Item definition has a metatable, this is "..
+			"unsupported and it will be overwritten: " .. name)
+	end
+
 	-- Apply defaults and add to registered_* table
 	if itemdef.type == "node" then
 		-- Use the nodebox as selection box if it's not set manually
@@ -194,8 +200,8 @@ function core.register_item(name, itemdef)
 
 	itemdef.mod_origin = core.get_current_modname() or "??"
 
-	-- Disable all further modifications
-	getmetatable(itemdef).__newindex = {}
+	-- Ignore new keys as a failsafe to prevent mistakes
+	getmetatable(itemdef).__newindex = function() end
 
 	--core.log("Registering item: " .. itemdef.name)
 	core.registered_items[itemdef.name] = itemdef


### PR DESCRIPTION
see #15091
also: the discussion in #15910 and [on IRC](https://irc.minetest.net/luanti-dev/2025-03-16#i_6249427)

Note: this breaks Voxelibre, because they try to register aliases a few seconds after the game starts.

## To do

This PR is Ready for Review.
