### PR TITLE
Do not discover mod directories that fail parsing

### DIFF
--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -55,7 +55,6 @@ bool parseDependsString(std::string &dep, std::unordered_set<char> &symbols)
 	return !dep.empty();
 }
 
-[[nodiscard]]
 bool parseModContents(ModSpec &spec)
 {
 	// NOTE: this function works in mutual recursion with getModsInPath

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -55,6 +55,7 @@ bool parseDependsString(std::string &dep, std::unordered_set<char> &symbols)
 	return !dep.empty();
 }
 
+[[nodiscard]]
 bool parseModContents(ModSpec &spec)
 {
 	// NOTE: this function works in mutual recursion with getModsInPath
@@ -175,8 +176,9 @@ std::map<std::string, ModSpec> getModsInPath(
 		mod_virtual_path.append(virtual_path).append("/").append(modname);
 
 		ModSpec spec(modname, mod_path, part_of_modpack, mod_virtual_path);
-		parseModContents(spec);
-		result[modname] = std::move(spec);
+		if (parseModContents(spec)) {
+			result[modname] = std::move(spec);
+		}
 	}
 	return result;
 }

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -78,7 +78,7 @@ struct ModSpec
  *
  * @returns false if not a mod
  */
-bool parseModContents(ModSpec &mod);
+[[nodiscard]] bool parseModContents(ModSpec &mod);
 
 /**
  * Gets a list of all mods and modpacks in path

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -385,7 +385,8 @@ int ModApiMainMenu::l_get_content_info(lua_State *L)
 	if (spec.type == "mod") {
 		ModSpec spec;
 		spec.path = path;
-		parseModContents(spec);
+		// TODO return nothing on failure (needs callers to handle it)
+		static_cast<void>(parseModContents(spec));
 
 		// Dependencies
 		lua_newtable(L);


### PR DESCRIPTION
Fixes #15914

The root issue of the unit test failure is that all directories that are found in the mod search are counted as mods, even if they are detected to be invalid as such by the parser. For example, the presence of an init.lua file is required, and the parser will return false if one is not found. This return value was completely ignored. Simply counting the mod conditionally on the parsing success makes the modserver tests pass on MSVC. I have also added the nodiscard attribute to the parse function as a preventive measure for regressions.

## To do

Ready for Review

- [X] ~~Reenable the test in CI now that it passes.~~ We don't ignore the failures on an individual basis. We have to fix the other three failing modules first.

## How to test

See that the servermod unittests pass on all systems including MSVC now.
