### PR TITLE
Minor refactor to the input handler

### DIFF
--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -143,18 +143,19 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	// Remember whether each key is down or up
 	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		const KeyPress keyCode(event.KeyInput);
-		if (keyCode && keysListenedFor[keyCode]) { // ignore key input that is invalid or irrelevant for the game.
+		// ignore key input that is invalid or irrelevant for the game.
+		if (keyCode && keysListenedFor.find(keyCode) != keysListenedFor.end()) {
 			if (event.KeyInput.PressedDown) {
 				if (!IsKeyDown(keyCode))
-					keyWasPressed.set(keyCode);
+					keyWasPressed.insert(keyCode);
 
-				keyIsDown.set(keyCode);
-				keyWasDown.set(keyCode);
+				keyIsDown.insert(keyCode);
+				keyWasDown.insert(keyCode);
 			} else {
 				if (IsKeyDown(keyCode))
-					keyWasReleased.set(keyCode);
+					keyWasReleased.insert(keyCode);
 
-				keyIsDown.unset(keyCode);
+				keyIsDown.erase(keyCode);
 			}
 
 			return true;
@@ -171,31 +172,31 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		// Handle mouse events
 		switch (event.MouseInput.Event) {
 		case EMIE_LMOUSE_PRESSED_DOWN:
-			keyIsDown.set(LMBKey);
-			keyWasDown.set(LMBKey);
-			keyWasPressed.set(LMBKey);
+			keyIsDown.insert(LMBKey);
+			keyWasDown.insert(LMBKey);
+			keyWasPressed.insert(LMBKey);
 			break;
 		case EMIE_MMOUSE_PRESSED_DOWN:
-			keyIsDown.set(MMBKey);
-			keyWasDown.set(MMBKey);
-			keyWasPressed.set(MMBKey);
+			keyIsDown.insert(MMBKey);
+			keyWasDown.insert(MMBKey);
+			keyWasPressed.insert(MMBKey);
 			break;
 		case EMIE_RMOUSE_PRESSED_DOWN:
-			keyIsDown.set(RMBKey);
-			keyWasDown.set(RMBKey);
-			keyWasPressed.set(RMBKey);
+			keyIsDown.insert(RMBKey);
+			keyWasDown.insert(RMBKey);
+			keyWasPressed.insert(RMBKey);
 			break;
 		case EMIE_LMOUSE_LEFT_UP:
-			keyIsDown.unset(LMBKey);
-			keyWasReleased.set(LMBKey);
+			keyIsDown.erase(LMBKey);
+			keyWasReleased.insert(LMBKey);
 			break;
 		case EMIE_MMOUSE_LEFT_UP:
-			keyIsDown.unset(MMBKey);
-			keyWasReleased.set(MMBKey);
+			keyIsDown.erase(MMBKey);
+			keyWasReleased.insert(MMBKey);
 			break;
 		case EMIE_RMOUSE_LEFT_UP:
-			keyIsDown.unset(RMBKey);
-			keyWasReleased.set(RMBKey);
+			keyIsDown.erase(RMBKey);
+			keyWasReleased.insert(RMBKey);
 			break;
 		case EMIE_MOUSE_WHEEL:
 			mouse_wheel += event.MouseInput.Wheel;

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -257,7 +257,7 @@ s32 RandomInputHandler::Rand(s32 min, s32 max)
 }
 
 struct RandomInputHandlerSimData {
-	std::string key;
+	GameKeyType key;
 	float counter;
 	int time_max;
 };
@@ -265,19 +265,19 @@ struct RandomInputHandlerSimData {
 void RandomInputHandler::step(float dtime)
 {
 	static RandomInputHandlerSimData rnd_data[] = {
-		{ "keymap_jump", 0.0f, 40 },
-		{ "keymap_aux1", 0.0f, 40 },
-		{ "keymap_forward", 0.0f, 40 },
-		{ "keymap_left", 0.0f, 40 },
-		{ "keymap_dig", 0.0f, 30 },
-		{ "keymap_place", 0.0f, 15 }
+		{ KeyType::JUMP, 0.0f, 40 },
+		{ KeyType::AUX1, 0.0f, 40 },
+		{ KeyType::FORWARD, 0.0f, 40 },
+		{ KeyType::LEFT, 0.0f, 40 },
+		{ KeyType::DIG, 0.0f, 30 },
+		{ KeyType::PLACE, 0.0f, 15 }
 	};
 
 	for (auto &i : rnd_data) {
 		i.counter -= dtime;
 		if (i.counter < 0.0) {
 			i.counter = 0.1 * Rand(1, i.time_max);
-			keydown.toggle(getKeySetting(i.key.c_str()));
+			keydown.flip(i.key);
 		}
 	}
 	{

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -360,7 +360,7 @@ public:
 		return true;
 	}
 
-	virtual bool isKeyDown(GameKeyType k) { return keydown[keycache.key[k]]; }
+	virtual bool isKeyDown(GameKeyType k) { return keydown[k]; }
 	virtual bool wasKeyDown(GameKeyType k) { return false; }
 	virtual bool wasKeyPressed(GameKeyType k) { return false; }
 	virtual bool wasKeyReleased(GameKeyType k) { return false; }
@@ -377,7 +377,7 @@ public:
 	s32 Rand(s32 min, s32 max);
 
 private:
-	KeyList keydown;
+	std::bitset<GameKeyType::INTERNAL_ENUM_COUNT> keydown;
 	v2s32 mousepos;
 	v2s32 mousespeed;
 	float joystickSpeed;

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -8,6 +8,7 @@
 #include "irr_v2d.h"
 #include "joystick_controller.h"
 #include <list>
+#include <unordered_set>
 #include "keycode.h"
 
 class InputHandler;
@@ -47,107 +48,34 @@ struct KeyCache
 	InputHandler *handler;
 };
 
-class KeyList : private std::list<KeyPress>
-{
-	typedef std::list<KeyPress> super;
-	typedef super::iterator iterator;
-	typedef super::const_iterator const_iterator;
-
-	virtual const_iterator find(const KeyPress &key) const
-	{
-		const_iterator f(begin());
-		const_iterator e(end());
-
-		while (f != e) {
-			if (*f == key)
-				return f;
-
-			++f;
-		}
-
-		return e;
-	}
-
-	virtual iterator find(const KeyPress &key)
-	{
-		iterator f(begin());
-		iterator e(end());
-
-		while (f != e) {
-			if (*f == key)
-				return f;
-
-			++f;
-		}
-
-		return e;
-	}
-
-public:
-	void clear() { super::clear(); }
-
-	void set(const KeyPress &key)
-	{
-		if (find(key) == end())
-			push_back(key);
-	}
-
-	void unset(const KeyPress &key)
-	{
-		iterator p(find(key));
-
-		if (p != end())
-			erase(p);
-	}
-
-	void toggle(const KeyPress &key)
-	{
-		iterator p(this->find(key));
-
-		if (p != end())
-			erase(p);
-		else
-			push_back(key);
-	}
-
-	void append(const KeyList &other)
-	{
-		for (const KeyPress &key : other) {
-			set(key);
-		}
-	}
-
-	bool operator[](const KeyPress &key) const { return find(key) != end(); }
-};
-
 class MyEventReceiver : public IEventReceiver
 {
 public:
 	// This is the one method that we have to implement
 	virtual bool OnEvent(const SEvent &event);
 
-	bool IsKeyDown(const KeyPress &keyCode) const { return keyIsDown[keyCode]; }
+	bool IsKeyDown(const KeyPress &keyCode) const { return keyIsDown.find(keyCode) != keyIsDown.end(); }
 
 	// Checks whether a key was down and resets the state
 	bool WasKeyDown(const KeyPress &keyCode)
 	{
-		bool b = keyWasDown[keyCode];
+		bool b = keyWasDown.find(keyCode) != keyWasDown.end();
 		if (b)
-			keyWasDown.unset(keyCode);
+			keyWasDown.erase(keyCode);
 		return b;
 	}
 
 	// Checks whether a key was just pressed. State will be cleared
 	// in the subsequent iteration of Game::processPlayerInteraction
-	bool WasKeyPressed(const KeyPress &keycode) const { return keyWasPressed[keycode]; }
+	bool WasKeyPressed(const KeyPress &keycode) const { return keyWasPressed.find(keycode) != keyWasPressed.end(); }
 
 	// Checks whether a key was just released. State will be cleared
 	// in the subsequent iteration of Game::processPlayerInteraction
-	bool WasKeyReleased(const KeyPress &keycode) const { return keyWasReleased[keycode]; }
+	bool WasKeyReleased(const KeyPress &keycode) const { return keyWasReleased.find(keycode) != keyWasReleased.end(); }
 
 	void listenForKey(const KeyPress &keyCode)
 	{
-		keysListenedFor.set(keyCode);
+		keysListenedFor.insert(keyCode);
 	}
 	void dontListenForKeys()
 	{
@@ -173,7 +101,7 @@ public:
 
 	void releaseAllKeys()
 	{
-		keyWasReleased.append(keyIsDown);
+		keyWasReleased.merge(keyIsDown);
 		keyIsDown.clear();
 	}
 
@@ -195,23 +123,19 @@ private:
 	s32 mouse_wheel = 0;
 
 	// The current state of keys
-	KeyList keyIsDown;
+	std::unordered_set<KeyPress> keyIsDown;
 
 	// Like keyIsDown but only reset when that key is read
-	KeyList keyWasDown;
+	std::unordered_set<KeyPress> keyWasDown;
 
 	// Whether a key has just been pressed
-	KeyList keyWasPressed;
+	std::unordered_set<KeyPress> keyWasPressed;
 
 	// Whether a key has just been released
-	KeyList keyWasReleased;
+	std::unordered_set<KeyPress> keyWasReleased;
 
 	// List of keys we listen for
-	// TODO perhaps the type of this is not really
-	// performant as KeyList is designed for few but
-	// often changing keys, and keysListenedFor is expected
-	// to change seldomly but contain lots of keys.
-	KeyList keysListenedFor;
+	std::unordered_set<KeyPress> keysListenedFor;
 
 	// Intentionally not reset by clearInput/releaseAllKeys.
 	bool fullscreen_is_down = false;

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -65,6 +65,19 @@ private:
 	std::variant<u32, irr::EKEY_CODE> scancode = irr::KEY_UNKNOWN;
 };
 
+template <>
+class std::hash<KeyPress>
+{
+public:
+	size_t operator()(const KeyPress &kp) const
+	{
+		// This should be mostly enough for SDL; the only time this yields
+		// zero is for invalid keys or mouse keys, where the collision with
+		// two elements should be acceptable.
+		return kp.getScancode();
+	}
+};
+
 // Global defines for convenience
 // This implementation defers creation of the objects to make sure that the
 // IrrlichtDevice is initialized.


### PR DESCRIPTION
- Goal of the PR
  This PR makes a minor refactor to the input handler to ease implementation for future PRs.
- How does the PR work?
  - Implements `std::hash<KeyPress>`.
  - `KeyList` is dropped in favor of its STL-based counterpart (i.e. `std::unordered_set`).
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  - 2.2 Internal code refactoring
- If not a bug fix, why is this PR needed? What usecases does it solve?
  It eases the implementation for #14874 and #15577.

## To do

This PR is Ready for Review.

## How to test

Manual testing: make sure that keyboard input works.