### PR TITLE
Improve KeyPress handling

### DIFF
--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -77,7 +77,7 @@ void KeyCache::populate()
 	if (handler) {
 		// First clear all keys, then re-add the ones we listen for
 		handler->dontListenForKeys();
-		for (const KeyPress &k : key) {
+		for (auto k : key) {
 			handler->listenForKey(k);
 		}
 		handler->listenForKey(EscapeKey);
@@ -111,7 +111,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 
 	// This is separate from other keyboard handling so that it also works in menus.
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
-		const KeyPress keyCode(event.KeyInput);
+		KeyPress keyCode(event.KeyInput);
 		if (keyCode == getKeySetting("keymap_fullscreen")) {
 			if (event.KeyInput.PressedDown && !fullscreen_is_down) {
 				IrrlichtDevice *device = RenderingEngine::get_raw_device();
@@ -142,7 +142,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 
 	// Remember whether each key is down or up
 	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
-		const KeyPress keyCode(event.KeyInput);
+		KeyPress keyCode(event.KeyInput);
 		if (keyCode && keysListenedFor[keyCode]) { // ignore key input that is invalid or irrelevant for the game.
 			if (event.KeyInput.PressedDown) {
 				if (!IsKeyDown(keyCode))

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -53,7 +53,7 @@ class KeyList : private std::list<KeyPress>
 	typedef super::iterator iterator;
 	typedef super::const_iterator const_iterator;
 
-	virtual const_iterator find(const KeyPress &key) const
+	virtual const_iterator find(KeyPress key) const
 	{
 		const_iterator f(begin());
 		const_iterator e(end());
@@ -68,7 +68,7 @@ class KeyList : private std::list<KeyPress>
 		return e;
 	}
 
-	virtual iterator find(const KeyPress &key)
+	virtual iterator find(KeyPress key)
 	{
 		iterator f(begin());
 		iterator e(end());
@@ -86,13 +86,13 @@ class KeyList : private std::list<KeyPress>
 public:
 	void clear() { super::clear(); }
 
-	void set(const KeyPress &key)
+	void set(KeyPress key)
 	{
 		if (find(key) == end())
 			push_back(key);
 	}
 
-	void unset(const KeyPress &key)
+	void unset(KeyPress key)
 	{
 		iterator p(find(key));
 
@@ -100,7 +100,7 @@ public:
 			erase(p);
 	}
 
-	void toggle(const KeyPress &key)
+	void toggle(KeyPress key)
 	{
 		iterator p(this->find(key));
 
@@ -112,12 +112,12 @@ public:
 
 	void append(const KeyList &other)
 	{
-		for (const KeyPress &key : other) {
+		for (auto key : other) {
 			set(key);
 		}
 	}
 
-	bool operator[](const KeyPress &key) const { return find(key) != end(); }
+	bool operator[](KeyPress key) const { return find(key) != end(); }
 };
 
 class MyEventReceiver : public IEventReceiver
@@ -126,10 +126,10 @@ public:
 	// This is the one method that we have to implement
 	virtual bool OnEvent(const SEvent &event);
 
-	bool IsKeyDown(const KeyPress &keyCode) const { return keyIsDown[keyCode]; }
+	bool IsKeyDown(KeyPress keyCode) const { return keyIsDown[keyCode]; }
 
 	// Checks whether a key was down and resets the state
-	bool WasKeyDown(const KeyPress &keyCode)
+	bool WasKeyDown(KeyPress keyCode)
 	{
 		bool b = keyWasDown[keyCode];
 		if (b)
@@ -139,13 +139,13 @@ public:
 
 	// Checks whether a key was just pressed. State will be cleared
 	// in the subsequent iteration of Game::processPlayerInteraction
-	bool WasKeyPressed(const KeyPress &keycode) const { return keyWasPressed[keycode]; }
+	bool WasKeyPressed(KeyPress keycode) const { return keyWasPressed[keycode]; }
 
 	// Checks whether a key was just released. State will be cleared
 	// in the subsequent iteration of Game::processPlayerInteraction
-	bool WasKeyReleased(const KeyPress &keycode) const { return keyWasReleased[keycode]; }
+	bool WasKeyReleased(KeyPress keycode) const { return keyWasReleased[keycode]; }
 
-	void listenForKey(const KeyPress &keyCode)
+	void listenForKey(KeyPress keyCode)
 	{
 		keysListenedFor.set(keyCode);
 	}
@@ -247,7 +247,7 @@ public:
 	virtual void clearWasKeyPressed() {}
 	virtual void clearWasKeyReleased() {}
 
-	virtual void listenForKey(const KeyPress &keyCode) {}
+	virtual void listenForKey(KeyPress keyCode) {}
 	virtual void dontListenForKeys() {}
 
 	virtual v2s32 getMousePos() = 0;
@@ -316,7 +316,7 @@ public:
 		m_receiver->clearWasKeyReleased();
 	}
 
-	virtual void listenForKey(const KeyPress &keyCode)
+	virtual void listenForKey(KeyPress keyCode)
 	{
 		m_receiver->listenForKey(keyCode);
 	}

--- a/src/client/keycode.cpp
+++ b/src/client/keycode.cpp
@@ -367,7 +367,7 @@ bool KeyPress::loadFromScancode(const std::string &name)
 }
 
 std::unordered_map<std::string, KeyPress> specialKeyCache;
-const KeyPress &KeyPress::getSpecialKey(const std::string &name)
+KeyPress KeyPress::getSpecialKey(const std::string &name)
 {
 	auto &key = specialKeyCache[name];
 	if (!key)
@@ -382,7 +382,7 @@ const KeyPress &KeyPress::getSpecialKey(const std::string &name)
 // A simple cache for quicker lookup
 static std::unordered_map<std::string, KeyPress> g_key_setting_cache;
 
-const KeyPress &getKeySetting(const std::string &settingname)
+KeyPress getKeySetting(const std::string &settingname)
 {
 	auto n = g_key_setting_cache.find(settingname);
 	if (n != g_key_setting_cache.end())

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -10,7 +10,9 @@
 #include <string>
 #include <variant>
 
-/* A key press, consisting of a scancode or a keycode */
+/* A key press, consisting of a scancode or a keycode.
+ * This fits into 64 bits, so prefer passing this by value.
+*/
 class KeyPress
 {
 public:
@@ -40,10 +42,10 @@ public:
 		return 0;
 	}
 
-	bool operator==(const KeyPress &o) const {
+	bool operator==(KeyPress o) const {
 		return scancode == o.scancode;
 	}
-	bool operator!=(const KeyPress &o) const {
+	bool operator!=(KeyPress o) const {
 		return !(*this == o);
 	}
 
@@ -55,7 +57,7 @@ public:
 			std::get<u32>(scancode) != 0;
 	}
 
-	static const KeyPress &getSpecialKey(const std::string &name);
+	static KeyPress getSpecialKey(const std::string &name);
 
 private:
 	bool loadFromScancode(const std::string &name);
@@ -74,7 +76,7 @@ private:
 #define RMBKey KeyPress::getSpecialKey("KEY_RBUTTON")
 
 // Key configuration getter
-const KeyPress &getKeySetting(const std::string &settingname);
+KeyPress getKeySetting(const std::string &settingname);
 
 // Clear fast lookup cache
 void clearKeyCache();

--- a/src/gui/guiKeyChangeMenu.cpp
+++ b/src/gui/guiKeyChangeMenu.cpp
@@ -205,6 +205,8 @@ void GUIKeyChangeMenu::drawMenu()
 
 bool GUIKeyChangeMenu::acceptInput()
 {
+	clearKeyCache();
+
 	for (key_setting *k : key_settings) {
 		std::string default_key;
 		Settings::getLayer(SL_DEFAULTS)->getNoEx(k->setting_name, default_key);
@@ -230,8 +232,6 @@ bool GUIKeyChangeMenu::acceptInput()
 		if(e && e->getType() == gui::EGUIET_CHECK_BOX)
 			g_settings->setBool("autojump", ((gui::IGUICheckBox*)e)->isChecked());
 	}
-
-	clearKeyCache();
 
 	g_gamecallback->signalKeyConfigChange();
 

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -232,7 +232,7 @@ TouchControls::TouchControls(IrrlichtDevice *device, ISimpleTextureSource *tsrc)
 		g_settings->registerChangedCallback(name, settingChangedCallback, this);
 
 	// Also update layout when keybindings change (e.g. for convertibles)
-	for (int id = 0; id < touch_gui_button_id_END; id++)
+	for (u8 id = 0; id < touch_gui_button_id_END; id++)
 		if (auto name = id_to_setting((touch_gui_button_id)id); !name.empty())
 			g_settings->registerChangedCallback(name, settingChangedCallback, this);
 }

--- a/src/gui/touchcontrols.cpp
+++ b/src/gui/touchcontrols.cpp
@@ -30,7 +30,7 @@
 
 TouchControls *g_touchcontrols;
 
-void TouchControls::emitKeyboardEvent(const KeyPress &key, bool pressed)
+void TouchControls::emitKeyboardEvent(KeyPress key, bool pressed)
 {
 	SEvent e{};
 	e.EventType              = EET_KEY_INPUT_EVENT;
@@ -133,7 +133,7 @@ bool TouchControls::buttonsStep(std::vector<button_info> &buttons, float dtime)
 	return has_pointers;
 }
 
-static const KeyPress &id_to_keypress(touch_gui_button_id id)
+static KeyPress id_to_keypress(touch_gui_button_id id)
 {
 	// ESC isn't part of the keymap.
 	if (id == exit_id)
@@ -196,7 +196,7 @@ static const KeyPress &id_to_keypress(touch_gui_button_id id)
 			break;
 	}
 	assert(!key.empty());
-	auto &kp = getKeySetting("keymap_" + key);
+	auto kp = getKeySetting("keymap_" + key);
 	if (!kp)
 		warningstream << "TouchControls: Unbound or invalid key for"
 				<< key << ", hiding button." << std::endl;

--- a/src/gui/touchcontrols.h
+++ b/src/gui/touchcontrols.h
@@ -203,7 +203,7 @@ private:
 	// for its buttons. We only want static image display, not interactivity,
 	// from Irrlicht.
 
-	void emitKeyboardEvent(const KeyPress &keycode, bool pressed);
+	void emitKeyboardEvent(KeyPress keycode, bool pressed);
 
 	void loadButtonTexture(IGUIImage *gui_button, const std::string &path);
 	void buttonEmitAction(button_info &btn, bool action);


### PR DESCRIPTION
- Commit 1: fixes #15922; also replaces `const KeyPress` (without ref) with `KeyPress` for consistency.
- Commit 2: should be self-explanatory; this is apparently broken by the above commit (pass-by-value with outdated keypress values?) as I recall it working with #14964; also clears `KeyPress`' setting cache correctly (i.e. before new keys are set) in `guiKeyChangeMenu`

This PR is Ready for Review.

## How to test

- Commit 1: make sure keypress-related stuff still works.
- Commit 2: using a convertible (or a device with both keyboard and touchscreen input), change keybindings in-game and observe that touchscreen keys continue to work.