### PR TITLE
Draw node animation for items

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -134,7 +134,8 @@ void Camera::step(f32 dtime)
 
 	if (m_wield_change_timer >= 0 && was_under_zero) {
 		m_wieldnode->setItem(m_wield_item_next, m_client);
-		m_wieldnode->setNodeLightColor(m_player_light_color);
+		m_wieldnode->setLightColorAndAnimation(m_player_light_color,
+				m_client->getAnimationTime());
 	}
 
 	if (m_view_bobbing_state != 0)
@@ -537,7 +538,8 @@ void Camera::update(LocalPlayer* player, f32 frametime, f32 tool_reload_ratio)
 	m_wieldnode->setRotation(wield_rotation);
 
 	m_player_light_color = player->light_color;
-	m_wieldnode->setNodeLightColor(m_player_light_color);
+	m_wieldnode->setLightColorAndAnimation(m_player_light_color,
+			m_client->getAnimationTime());
 
 	// Set render distance
 	updateViewingRange();

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -942,7 +942,8 @@ void GenericCAO::setNodeLight(const video::SColor &light_color)
 {
 	if (m_prop.visual == OBJECTVISUAL_WIELDITEM || m_prop.visual == OBJECTVISUAL_ITEM) {
 		if (m_wield_meshnode)
-			m_wield_meshnode->setNodeLightColor(light_color);
+			m_wield_meshnode->setLightColorAndAnimation(light_color,
+					m_client->getAnimationTime());
 		return;
 	}
 

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -246,10 +246,6 @@ public:
 	}
 
 private:
-	struct AnimationInfo {
-		int frame; // last animation frame
-		TileLayer tile;
-	};
 
 	irr_ptr<scene::IMesh> m_mesh[MAX_TILE_LAYERS];
 	std::vector<MinimapMapblock*> m_minimap_mapblocks;

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -4,6 +4,17 @@
 
 #include "tile.h"
 
+void AnimationInfo::updateTexture(video::SMaterial &material, float animation_time)
+{
+	// Figure out current frame
+	u16 frame = (u16)(animation_time * 1000 / m_frame_length_ms) % m_frame_count;
+	// Only adjust if frame changed
+	if (frame != m_frame) {
+		m_frame = frame;
+		material.setTexture(0, (*m_frames)[m_frame].texture);
+	}
+};
+
 void TileLayer::applyMaterialOptions(video::SMaterial &material, int layer) const
 {
 	material.setTexture(0, texture);

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -11,6 +11,7 @@ void AnimationInfo::updateTexture(video::SMaterial &material, float animation_ti
 	// Only adjust if frame changed
 	if (frame != m_frame) {
 		m_frame = frame;
+		assert(m_frame < m_frames->size());
 		material.setTexture(0, (*m_frames)[m_frame].texture);
 	}
 };

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -3,6 +3,7 @@
 // Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 #include "tile.h"
+#include <cassert>
 
 void AnimationInfo::updateTexture(video::SMaterial &material, float animation_time)
 {

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -157,7 +157,6 @@ struct AnimationInfo {
 	AnimationInfo() = default;
 
 	AnimationInfo(const TileLayer &tile) :
-			m_frame(0),
 			m_frame_length_ms(tile.animation_frame_length_ms),
 			m_frame_count(tile.animation_frame_count),
 			m_frames(tile.frames)
@@ -171,7 +170,6 @@ private:
 	u16 m_frame_count = 1;
 
 	/// @note not owned by this struct
-	// The ContentFeatures class typically owns it
 	std::vector<FrameSpec> *m_frames = nullptr;
 };
 

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -151,6 +151,30 @@ struct TileLayer
 	bool has_color = false;
 };
 
+// Stores information for drawing an animated tile
+struct AnimationInfo {
+
+	AnimationInfo() = default;
+
+	AnimationInfo(const TileLayer &tile) :
+			m_frame(0),
+			m_frame_length_ms(tile.animation_frame_length_ms),
+			m_frame_count(tile.animation_frame_count),
+			m_frames(tile.frames)
+	{};
+
+	void updateTexture(video::SMaterial &material, float animation_time);
+
+private:
+	u16 m_frame = 0; // last animation frame
+	u16 m_frame_length_ms = 0;
+	u16 m_frame_count = 1;
+
+	/// @note not owned by this struct
+	// The ContentFeatures class typically owns it
+	std::vector<FrameSpec> *m_frames = nullptr;
+};
+
 enum class TileRotation: u8 {
 	None,
 	R90,

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -33,7 +33,7 @@
 ItemMeshBufferInfo::ItemMeshBufferInfo(const TileLayer &layer) :
 		override_color(layer.color),
 		override_color_set(layer.has_color),
-		animation_info(layer.material_flags & MATERIAL_FLAG_ANIMATION ?
+		animation_info((layer.material_flags & MATERIAL_FLAG_ANIMATION) ?
 			std::make_unique<std::pair<int, TileLayer>>(0, layer) :
 			nullptr)
 {}

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -30,6 +30,14 @@
 #define MIN_EXTRUSION_MESH_RESOLUTION 16
 #define MAX_EXTRUSION_MESH_RESOLUTION 512
 
+ItemMeshBufferInfo::ItemMeshBufferInfo(const TileLayer &layer) :
+		override_color(layer.color),
+		override_color_set(layer.has_color),
+		animation_info(layer.material_flags & MATERIAL_FLAG_ANIMATION ?
+			std::make_unique<std::pair<int, TileLayer>>(0, layer) :
+			nullptr)
+{}
+
 static scene::IMesh *createExtrusionMesh(int resolution_x, int resolution_y)
 {
 	const f32 r = 0.5;
@@ -285,7 +293,7 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 }
 
 static scene::SMesh *createGenericNodeMesh(Client *client, MapNode n,
-	std::vector<ItemPartColor> *colors, const ContentFeatures &f)
+	std::vector<ItemMeshBufferInfo> *buffer_info, const ContentFeatures &f)
 {
 	n.setParam1(0xff);
 	if (n.getParam2()) {
@@ -309,7 +317,7 @@ static scene::SMesh *createGenericNodeMesh(Client *client, MapNode n,
 		MapblockMeshGenerator(&mmd, &collector).generate();
 	}
 
-	colors->clear();
+	buffer_info->clear();
 	scene::SMesh *mesh = new scene::SMesh();
 	for (int layer = 0; layer < MAX_TILE_LAYERS; layer++) {
 		auto &prebuffers = collector.prebuffers[layer];
@@ -329,7 +337,7 @@ static scene::SMesh *createGenericNodeMesh(Client *client, MapNode n,
 			p.layer.applyMaterialOptions(buf->Material, layer);
 
 			mesh->addMeshBuffer(buf.get());
-			colors->emplace_back(p.layer.has_color, p.layer.color);
+			buffer_info->emplace_back(p.layer);
 		}
 	}
 	mesh->recalculateBoundingBox();
@@ -352,7 +360,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 	m_material_type = shdrsrc->getShaderInfo(shader_id).material;
 
 	// Color-related
-	m_colors.clear();
+	m_buffer_info.clear();
 	m_base_color = idef->getItemstackColor(item, client);
 
 	const std::string wield_image = item.getWieldImage(idef);
@@ -361,11 +369,10 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 
 	// If wield_image needs to be checked and is defined, it overrides everything else
 	if (!wield_image.empty() && check_wield_image) {
-		setExtruded(wield_image, wield_overlay, wield_scale, tsrc,
-			1);
-		m_colors.emplace_back();
+		setExtruded(wield_image, wield_overlay, wield_scale, tsrc, 1);
+		m_buffer_info.emplace_back();
 		// overlay is white, if present
-		m_colors.emplace_back(true, video::SColor(0xFFFFFFFF));
+		m_buffer_info.emplace_back(true, video::SColor(0xFFFFFFFF));
 		// initialize the color
 		setColor(video::SColor(0xFFFFFFFF));
 		return;
@@ -394,8 +401,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 				wscale, tsrc,
 				l0.animation_frame_count);
 			// Add color
-			m_colors.emplace_back(l0.has_color, l0.color);
-			m_colors.emplace_back(l1.has_color, l1.color);
+			m_buffer_info.emplace_back(l0);
+			m_buffer_info.emplace_back(l1);
 			break;
 		}
 		case NDT_PLANTLIKE_ROOTED: {
@@ -404,7 +411,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			setExtruded(tsrc->getTextureName(l0.texture_id),
 				"", wield_scale, tsrc,
 				l0.animation_frame_count);
-			m_colors.emplace_back(l0.has_color, l0.color);
+			m_buffer_info.emplace_back(l0);
 			break;
 		}
 		default: {
@@ -413,7 +420,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			if (def.place_param2)
 				n.setParam2(*def.place_param2);
 
-			mesh = createGenericNodeMesh(client, n, &m_colors, f);
+			mesh = createGenericNodeMesh(client, n, &m_buffer_info, f);
 			changeToMesh(mesh);
 			mesh->drop();
 			m_meshnode->setScale(
@@ -447,9 +454,9 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			setExtruded("no_texture.png", "", def.wield_scale, tsrc, 1);
 		}
 
-		m_colors.emplace_back();
+		m_buffer_info.emplace_back();
 		// overlay is white, if present
-		m_colors.emplace_back(true, video::SColor(0xFFFFFFFF));
+		m_buffer_info.emplace_back(true, video::SColor(0xFFFFFFFF));
 
 		// initialize the color
 		setColor(video::SColor(0xFFFFFFFF));
@@ -471,18 +478,18 @@ void WieldMeshSceneNode::setColor(video::SColor c)
 	u8 blue = c.getBlue();
 
 	const u32 mc = mesh->getMeshBufferCount();
-	if (mc > m_colors.size())
-		m_colors.resize(mc);
+	if (mc > m_buffer_info.size())
+		m_buffer_info.resize(mc);
 	for (u32 j = 0; j < mc; j++) {
 		video::SColor bc(m_base_color);
-		m_colors[j].applyOverride(bc);
+		m_buffer_info[j].applyOverride(bc);
 		video::SColor buffercolor(255,
 			bc.getRed() * red / 255,
 			bc.getGreen() * green / 255,
 			bc.getBlue() * blue / 255);
 		scene::IMeshBuffer *buf = mesh->getMeshBuffer(j);
 
-		if (m_colors[j].needColorize(buffercolor)) {
+		if (m_buffer_info[j].needColorize(buffercolor)) {
 			buf->setDirty(scene::EBT_VERTEX);
 			setMeshBufferColor(buf, buffercolor);
 		}
@@ -544,9 +551,9 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 	const std::string inventory_overlay = item.getInventoryOverlay(idef);
 	if (!inventory_image.empty()) {
 		mesh = getExtrudedMesh(tsrc, inventory_image, inventory_overlay);
-		result->buffer_colors.emplace_back();
+		result->buffer_info.emplace_back();
 		// overlay is white, if present
-		result->buffer_colors.emplace_back(true, video::SColor(0xFFFFFFFF));
+		result->buffer_info.emplace_back(true, video::SColor(0xFFFFFFFF));
 		// Items with inventory images do not need shading
 		result->needs_shading = false;
 	} else if (def.type == ITEM_NODE && f.drawtype == NDT_AIRLIKE) {
@@ -562,8 +569,8 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 				tsrc->getTextureName(l0.texture_id),
 				tsrc->getTextureName(l1.texture_id));
 			// Add color
-			result->buffer_colors.emplace_back(l0.has_color, l0.color);
-			result->buffer_colors.emplace_back(l1.has_color, l1.color);
+			result->buffer_info.emplace_back(l0);
+			result->buffer_info.emplace_back(l1);
 			break;
 		}
 		case NDT_PLANTLIKE_ROOTED: {
@@ -571,7 +578,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			const TileLayer &l0 = f.special_tiles[0].layers[0];
 			mesh = getExtrudedMesh(tsrc,
 				tsrc->getTextureName(l0.texture_id), "");
-			result->buffer_colors.emplace_back(l0.has_color, l0.color);
+			result->buffer_info.emplace_back(l0);
 			break;
 		}
 		default: {
@@ -580,7 +587,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			if (def.place_param2)
 				n.setParam2(*def.place_param2);
 
-			mesh = createGenericNodeMesh(client, n, &result->buffer_colors, f);
+			mesh = createGenericNodeMesh(client, n, &result->buffer_info, f);
 			scaleMesh(mesh, v3f(0.12, 0.12, 0.12));
 			break;
 		}

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -496,15 +496,31 @@ void WieldMeshSceneNode::setColor(video::SColor c)
 	}
 }
 
-void WieldMeshSceneNode::setNodeLightColor(video::SColor color)
+void WieldMeshSceneNode::setLightColorAndAnimation(video::SColor color, float animation_time)
 {
 	if (!m_meshnode)
 		return;
 
-	{
-		for (u32 i = 0; i < m_meshnode->getMaterialCount(); ++i) {
-			video::SMaterial &material = m_meshnode->getMaterial(i);
-			material.ColorParam = color;
+	for (u32 i = 0; i < m_meshnode->getMaterialCount(); ++i) {
+		// Color
+		video::SMaterial &material = m_meshnode->getMaterial(i);
+		material.ColorParam = color;
+
+		// Animation
+		const ItemMeshBufferInfo &buf_info = m_buffer_info[i];
+		if (buf_info.animation_info) {
+			const TileLayer &tile = buf_info.animation_info->tile;
+			// Figure out current frame
+			int frameno = (int)(animation_time * 1000 /
+					tile.animation_frame_length_ms) %
+					tile.animation_frame_count;
+			// Only adjust if frame changed
+			if (frameno != buf_info.animation_info->frame) {
+				buf_info.animation_info->frame = frameno;
+
+				const FrameSpec &frame = (*tile.frames)[frameno];
+				material.setTexture(0, frame.texture);
+			}
 		}
 	}
 }

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -34,7 +34,7 @@ ItemMeshBufferInfo::ItemMeshBufferInfo(const TileLayer &layer) :
 		override_color(layer.color),
 		override_color_set(layer.has_color),
 		animation_info((layer.material_flags & MATERIAL_FLAG_ANIMATION) ?
-			std::make_unique<std::pair<int, TileLayer>>(0, layer) :
+			new ItemMeshBufferInfo::AnimationInfo{0, layer} :
 			nullptr)
 {}
 

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -401,8 +401,8 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 				wscale, tsrc,
 				l0.animation_frame_count);
 			// Add color
-			m_buffer_info.emplace_back(l0);
-			m_buffer_info.emplace_back(l1);
+			m_buffer_info.emplace_back(l0.has_color, l0.color);
+			m_buffer_info.emplace_back(l1.has_color, l1.color);
 			break;
 		}
 		case NDT_PLANTLIKE_ROOTED: {
@@ -411,7 +411,7 @@ void WieldMeshSceneNode::setItem(const ItemStack &item, Client *client, bool che
 			setExtruded(tsrc->getTextureName(l0.texture_id),
 				"", wield_scale, tsrc,
 				l0.animation_frame_count);
-			m_buffer_info.emplace_back(l0);
+			m_buffer_info.emplace_back(l0.has_color, l0.color);
 			break;
 		}
 		default: {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -34,7 +34,7 @@ ItemMeshBufferInfo::ItemMeshBufferInfo(const TileLayer &layer) :
 		override_color(layer.color),
 		override_color_set(layer.has_color),
 		animation_info((layer.material_flags & MATERIAL_FLAG_ANIMATION) ?
-			new ItemMeshBufferInfo::AnimationInfo{0, layer} :
+			std::make_unique<AnimationInfo>(layer) :
 			nullptr)
 {}
 
@@ -509,18 +509,7 @@ void WieldMeshSceneNode::setLightColorAndAnimation(video::SColor color, float an
 		// Animation
 		const ItemMeshBufferInfo &buf_info = m_buffer_info[i];
 		if (buf_info.animation_info) {
-			const TileLayer &tile = buf_info.animation_info->tile;
-			// Figure out current frame
-			int frameno = (int)(animation_time * 1000 /
-					tile.animation_frame_length_ms) %
-					tile.animation_frame_count;
-			// Only adjust if frame changed
-			if (frameno != buf_info.animation_info->frame) {
-				buf_info.animation_info->frame = frameno;
-
-				const FrameSpec &frame = (*tile.frames)[frameno];
-				material.setTexture(0, frame.texture);
-			}
+			buf_info.animation_info->updateTexture(material, animation_time);
 		}
 	}
 }

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -574,8 +574,8 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 				tsrc->getTextureName(l0.texture_id),
 				tsrc->getTextureName(l1.texture_id));
 			// Add color
-			result->buffer_info.emplace_back(l0);
-			result->buffer_info.emplace_back(l1);
+			result->buffer_info.emplace_back(l0.has_color, l0.color);
+			result->buffer_info.emplace_back(l1.has_color, l1.color);
 			break;
 		}
 		case NDT_PLANTLIKE_ROOTED: {
@@ -583,7 +583,7 @@ void getItemMesh(Client *client, const ItemStack &item, ItemMesh *result)
 			const TileLayer &l0 = f.special_tiles[0].layers[0];
 			mesh = getExtrudedMesh(tsrc,
 				tsrc->getTextureName(l0.texture_id), "");
-			result->buffer_info.emplace_back(l0);
+			result->buffer_info.emplace_back(l0.has_color, l0.color);
 			break;
 		}
 		default: {

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -117,7 +117,7 @@ public:
 	// Must only be used if the constructor was called with lighting = false
 	void setColor(video::SColor color);
 
-	void setNodeLightColor(video::SColor color);
+	void setLightColorAndAnimation(video::SColor color, float animation_time);
 
 	scene::IMesh *getMesh() { return m_meshnode->getMesh(); }
 

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -12,6 +12,7 @@
 #include <IMeshSceneNode.h>
 #include <SColor.h>
 #include <memory>
+#include "tile.h"
 
 namespace irr::scene
 {
@@ -27,7 +28,6 @@ class Client;
 class ITextureSource;
 struct ContentFeatures;
 class ShadowRenderer;
-struct TileLayer;
 
 /*
  * Holds information of an item mesh's buffer.
@@ -71,8 +71,16 @@ public:
 		return true;
 	}
 
-	// Null for no animated parts, stores last animation frame and tile layer
-	std::unique_ptr<std::pair<int, TileLayer>> animation_info;
+	// TODO:
+	// This is the same as MapBlockMesh::AnimationInfo and should be declared somewhere else
+	// Also it doesn't a copy of the whole tile layer
+	struct AnimationInfo {
+		int frame; // last animation frame
+		TileLayer tile;
+	};
+
+	// Null for no animated parts
+	std::unique_ptr<AnimationInfo> animation_info;
 };
 
 struct ItemMesh

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -11,6 +11,7 @@
 #include <EMaterialTypes.h>
 #include <IMeshSceneNode.h>
 #include <SColor.h>
+#include <memory>
 
 namespace irr::scene
 {
@@ -26,11 +27,13 @@ class Client;
 class ITextureSource;
 struct ContentFeatures;
 class ShadowRenderer;
+struct TileLayer;
 
 /*
- * Holds color information of an item mesh's buffer.
+ * Holds information of an item mesh's buffer.
+ * Used for coloring and animation.
  */
-class ItemPartColor
+class ItemMeshBufferInfo
 {
 	/*
 	 * Optional color that overrides the global base color.
@@ -47,11 +50,13 @@ class ItemPartColor
 
 public:
 
-	ItemPartColor() = default;
+	ItemMeshBufferInfo() = default;
 
-	ItemPartColor(bool override, video::SColor color) :
+	ItemMeshBufferInfo(bool override, video::SColor color) :
 		override_color(color), override_color_set(override)
 	{}
+
+	ItemMeshBufferInfo(const TileLayer &layer);
 
 	void applyOverride(video::SColor &dest) const {
 		if (override_color_set)
@@ -65,15 +70,18 @@ public:
 		last_colorized = target;
 		return true;
 	}
+
+	// Null for no animated parts, stores last animation frame and tile layer
+	std::unique_ptr<std::pair<int, TileLayer>> animation_info;
 };
 
 struct ItemMesh
 {
 	scene::IMesh *mesh = nullptr;
 	/*
-	 * Stores the color of each mesh buffer.
+	 * Stores draw information of each mesh buffer.
 	 */
-	std::vector<ItemPartColor> buffer_colors;
+	std::vector<ItemMeshBufferInfo> buffer_info;
 	/*
 	 * If false, all faces of the item should have the same brightness.
 	 * Disables shading based on normal vectors.
@@ -120,10 +128,10 @@ private:
 	bool m_bilinear_filter;
 	bool m_trilinear_filter;
 	/*!
-	 * Stores the colors of the mesh's mesh buffers.
+	 * Stores the colors and animation data of the mesh's mesh buffers.
 	 * This does not include lighting.
 	 */
-	std::vector<ItemPartColor> m_colors;
+	std::vector<ItemMeshBufferInfo> m_buffer_info;
 	/*!
 	 * The base color of this mesh. This is the default
 	 * for all mesh buffers.

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -73,7 +73,7 @@ public:
 
 	// TODO:
 	// This is the same as MapBlockMesh::AnimationInfo and should be declared somewhere else
-	// Also it doesn't a copy of the whole tile layer
+	// Also it doesn't need a copy of the whole tile layer
 	struct AnimationInfo {
 		int frame; // last animation frame
 		TileLayer tile;

--- a/src/client/wieldmesh.h
+++ b/src/client/wieldmesh.h
@@ -71,14 +71,6 @@ public:
 		return true;
 	}
 
-	// TODO:
-	// This is the same as MapBlockMesh::AnimationInfo and should be declared somewhere else
-	// Also it doesn't need a copy of the whole tile layer
-	struct AnimationInfo {
-		int frame; // last animation frame
-		TileLayer tile;
-	};
-
 	// Null for no animated parts
 	std::unique_ptr<AnimationInfo> animation_info;
 };

--- a/src/gui/drawItemStack.cpp
+++ b/src/gui/drawItemStack.cpp
@@ -136,23 +136,13 @@ void drawItemStack(
 					setMeshBufferColor(buf, c);
 			}
 
+			video::SMaterial &material = buf->getMaterial();
+
 			// Texture animation
 			if (p.animation_info) {
-				const TileLayer &tile = p.animation_info->tile;
-				// Figure out current frame
-				int frameno = (int)(client->getAnimationTime() * 1000 /
-						tile.animation_frame_length_ms) %
-						tile.animation_frame_count;
-				// Only adjust if frame changed
-				if (frameno != p.animation_info->frame) {
-					p.animation_info->frame = frameno;
-
-					const FrameSpec &frame = (*tile.frames)[frameno];
-					buf->getMaterial().setTexture(0, frame.texture);
-				}
+				p.animation_info->updateTexture(material, client->getAnimationTime());
 			}
 
-			video::SMaterial &material = buf->getMaterial();
 			material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
 			driver->setMaterial(material);
 			driver->drawMeshBuffer(buf);

--- a/src/gui/drawItemStack.cpp
+++ b/src/gui/drawItemStack.cpp
@@ -137,7 +137,7 @@ void drawItemStack(
 			}
 
 			// Texture animation
-			if (enable_animations && p.animation_info) {
+			if (p.animation_info) {
 				const TileLayer &tile = p.animation_info->tile;
 				// Figure out current frame
 				int frameno = (int)(client->getAnimationTime() * 1000 /

--- a/src/gui/drawItemStack.cpp
+++ b/src/gui/drawItemStack.cpp
@@ -138,14 +138,14 @@ void drawItemStack(
 
 			// Texture animation
 			if (enable_animations && p.animation_info) {
-				const TileLayer &tile = p.animation_info->second;
+				const TileLayer &tile = p.animation_info->tile;
 				// Figure out current frame
 				int frameno = (int)(client->getAnimationTime() * 1000 /
 						tile.animation_frame_length_ms) %
 						tile.animation_frame_count;
 				// Only adjust if frame changed
-				if (frameno != p.animation_info->first) {
-					p.animation_info->first = frameno;
+				if (frameno != p.animation_info->frame) {
+					p.animation_info->frame = frameno;
 
 					const FrameSpec &frame = (*tile.frames)[frameno];
 					buf->getMaterial().setTexture(0, frame.texture);


### PR DESCRIPTION
- This is a step towards #4758
- It uses the existing node animation system, and applies it when drawing node items.
- ~Only active if the `inventory_items_animations` setting is on.~

~(It does not work for the wield mesh without flickering)~ solved

<details>
  <summary>Click me (Videos)</summary>

  https://github.com/user-attachments/assets/45911bc9-5eaf-46ed-ab37-10a57327c58a

  https://github.com/user-attachments/assets/5aa743a8-a2b1-46a6-97fc-7a8b974a694f

</details>


## To do

Ready for Review.

Maybe some refactoring.

## How to test

~Enable the `inventory_items_animations` setting.~
Start devtest and get some Animated Test Nodes.
