### PR TITLE
Add delay between punching and digging node

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3635,6 +3635,7 @@ void Game::handlePointingAtObject(const PointedThing &pointed, const ItemStack &
 		if (do_punch) {
 			infostream << "Punched object" << std::endl;
 			runData.punching = true;
+			runData.nodig_delay_timer = std::max(0.15f, m_repeat_dig_time);
 		}
 
 		if (do_punch_damage) {


### PR DESCRIPTION
Currently there is no delay between punching an entity and starting to dig a node. If the digging time for the node behind it is instant, it is practically impossible to kill an entity and not accidentally dig the node behind it.

This adds a delay of `max(0.15, m_repeat_dig_time)` after punching an entity to avoid this. Because `m_repeat_dig_time` defaults to `0` clamping it to a minimum value is necessary. I used `0.15` because that is the hardcoded digging delay between breaking nodes with instant digging time.

## How to test

1. Play Mineclonia and play on a world which has creative mode (which has instant digging with hand)
2. Give yourself a netherite sword
3. Punch the rabbit
    - On main the block behind it will be immediately broken
    - On this branch it will not be immediately broken
4. Try increasing the `repeat_dig_time`
    - Punch rabbit and hold dig button
    - Notice that the delay between killing the entity and digging the node behind it is increased