### PR TITLE
Refactor input handler

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -885,7 +885,7 @@ bool Game::startup(bool *kill,
 	this->chat_backend        = chat_backend;
 	simple_singleplayer_mode  = start_data.isSinglePlayer();
 
-	input->keycache.populate();
+	input->reloadKeybindings();
 
 	driver = device->getVideoDriver();
 	smgr = m_rendering_engine->get_scene_manager();

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -554,7 +554,7 @@ bool GameFormSpec::handleCallbacks()
 	}
 
 	if (g_gamecallback->keyconfig_changed) {
-		m_input->keycache.populate(); // update the cache with new settings
+		m_input->reloadKeybindings(); // update the cache with new settings
 		g_gamecallback->keyconfig_changed = false;
 	}
 

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -90,18 +90,26 @@ bool MyEventReceiver::setKeyDown(KeyPress keyCode, bool is_down)
 	auto action = keysListenedFor[keyCode];
 	if (is_down) {
 		physicalKeyDown.insert(keyCode);
+		setKeyDown(action, true);
+	} else {
+		physicalKeyDown.erase(keyCode);
+		setKeyDown(action, false);
+	}
+	return true;
+}
+
+void MyEventReceiver::setKeyDown(GameKeyType action, bool is_down)
+{
+	if (is_down) {
 		if (!IsKeyDown(action))
 			keyWasPressed.set(action);
 		keyIsDown.set(action);
 		keyWasDown.set(action);
 	} else {
-		physicalKeyDown.erase(keyCode);
 		if (IsKeyDown(action))
 			keyWasReleased.set(action);
-
 		keyIsDown.reset(action);
 	}
-	return true;
 }
 
 bool MyEventReceiver::OnEvent(const SEvent &event)

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -143,18 +143,19 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	// Remember whether each key is down or up
 	if (event.EventType == irr::EET_KEY_INPUT_EVENT) {
 		KeyPress keyCode(event.KeyInput);
-		if (keyCode && keysListenedFor[keyCode]) { // ignore key input that is invalid or irrelevant for the game.
+		// ignore key input that is invalid or irrelevant for the game.
+		if (keyCode && keysListenedFor.find(keyCode) != keysListenedFor.end()) {
 			if (event.KeyInput.PressedDown) {
 				if (!IsKeyDown(keyCode))
-					keyWasPressed.set(keyCode);
+					keyWasPressed.insert(keyCode);
 
-				keyIsDown.set(keyCode);
-				keyWasDown.set(keyCode);
+				keyIsDown.insert(keyCode);
+				keyWasDown.insert(keyCode);
 			} else {
 				if (IsKeyDown(keyCode))
-					keyWasReleased.set(keyCode);
+					keyWasReleased.insert(keyCode);
 
-				keyIsDown.unset(keyCode);
+				keyIsDown.erase(keyCode);
 			}
 
 			return true;
@@ -171,31 +172,31 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 		// Handle mouse events
 		switch (event.MouseInput.Event) {
 		case EMIE_LMOUSE_PRESSED_DOWN:
-			keyIsDown.set(LMBKey);
-			keyWasDown.set(LMBKey);
-			keyWasPressed.set(LMBKey);
+			keyIsDown.insert(LMBKey);
+			keyWasDown.insert(LMBKey);
+			keyWasPressed.insert(LMBKey);
 			break;
 		case EMIE_MMOUSE_PRESSED_DOWN:
-			keyIsDown.set(MMBKey);
-			keyWasDown.set(MMBKey);
-			keyWasPressed.set(MMBKey);
+			keyIsDown.insert(MMBKey);
+			keyWasDown.insert(MMBKey);
+			keyWasPressed.insert(MMBKey);
 			break;
 		case EMIE_RMOUSE_PRESSED_DOWN:
-			keyIsDown.set(RMBKey);
-			keyWasDown.set(RMBKey);
-			keyWasPressed.set(RMBKey);
+			keyIsDown.insert(RMBKey);
+			keyWasDown.insert(RMBKey);
+			keyWasPressed.insert(RMBKey);
 			break;
 		case EMIE_LMOUSE_LEFT_UP:
-			keyIsDown.unset(LMBKey);
-			keyWasReleased.set(LMBKey);
+			keyIsDown.erase(LMBKey);
+			keyWasReleased.insert(LMBKey);
 			break;
 		case EMIE_MMOUSE_LEFT_UP:
-			keyIsDown.unset(MMBKey);
-			keyWasReleased.set(MMBKey);
+			keyIsDown.erase(MMBKey);
+			keyWasReleased.insert(MMBKey);
 			break;
 		case EMIE_RMOUSE_LEFT_UP:
-			keyIsDown.unset(RMBKey);
-			keyWasReleased.set(RMBKey);
+			keyIsDown.erase(RMBKey);
+			keyWasReleased.insert(RMBKey);
 			break;
 		case EMIE_MOUSE_WHEEL:
 			mouse_wheel += event.MouseInput.Wheel;

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -12,74 +12,69 @@
 #include "log_internal.h"
 #include "client/renderingengine.h"
 
-void KeyCache::populate_nonchanging()
+void MyEventReceiver::reloadKeybindings()
 {
-	key[KeyType::ESC] = EscapeKey;
-}
+	keybindings[KeyType::FORWARD] = getKeySetting("keymap_forward");
+	keybindings[KeyType::BACKWARD] = getKeySetting("keymap_backward");
+	keybindings[KeyType::LEFT] = getKeySetting("keymap_left");
+	keybindings[KeyType::RIGHT] = getKeySetting("keymap_right");
+	keybindings[KeyType::JUMP] = getKeySetting("keymap_jump");
+	keybindings[KeyType::AUX1] = getKeySetting("keymap_aux1");
+	keybindings[KeyType::SNEAK] = getKeySetting("keymap_sneak");
+	keybindings[KeyType::DIG] = getKeySetting("keymap_dig");
+	keybindings[KeyType::PLACE] = getKeySetting("keymap_place");
 
-void KeyCache::populate()
-{
-	key[KeyType::FORWARD] = getKeySetting("keymap_forward");
-	key[KeyType::BACKWARD] = getKeySetting("keymap_backward");
-	key[KeyType::LEFT] = getKeySetting("keymap_left");
-	key[KeyType::RIGHT] = getKeySetting("keymap_right");
-	key[KeyType::JUMP] = getKeySetting("keymap_jump");
-	key[KeyType::AUX1] = getKeySetting("keymap_aux1");
-	key[KeyType::SNEAK] = getKeySetting("keymap_sneak");
-	key[KeyType::DIG] = getKeySetting("keymap_dig");
-	key[KeyType::PLACE] = getKeySetting("keymap_place");
+	keybindings[KeyType::ESC] = EscapeKey;
 
-	key[KeyType::AUTOFORWARD] = getKeySetting("keymap_autoforward");
+	keybindings[KeyType::AUTOFORWARD] = getKeySetting("keymap_autoforward");
 
-	key[KeyType::DROP] = getKeySetting("keymap_drop");
-	key[KeyType::INVENTORY] = getKeySetting("keymap_inventory");
-	key[KeyType::CHAT] = getKeySetting("keymap_chat");
-	key[KeyType::CMD] = getKeySetting("keymap_cmd");
-	key[KeyType::CMD_LOCAL] = getKeySetting("keymap_cmd_local");
-	key[KeyType::CONSOLE] = getKeySetting("keymap_console");
-	key[KeyType::MINIMAP] = getKeySetting("keymap_minimap");
-	key[KeyType::FREEMOVE] = getKeySetting("keymap_freemove");
-	key[KeyType::PITCHMOVE] = getKeySetting("keymap_pitchmove");
-	key[KeyType::FASTMOVE] = getKeySetting("keymap_fastmove");
-	key[KeyType::NOCLIP] = getKeySetting("keymap_noclip");
-	key[KeyType::HOTBAR_PREV] = getKeySetting("keymap_hotbar_previous");
-	key[KeyType::HOTBAR_NEXT] = getKeySetting("keymap_hotbar_next");
-	key[KeyType::MUTE] = getKeySetting("keymap_mute");
-	key[KeyType::INC_VOLUME] = getKeySetting("keymap_increase_volume");
-	key[KeyType::DEC_VOLUME] = getKeySetting("keymap_decrease_volume");
-	key[KeyType::CINEMATIC] = getKeySetting("keymap_cinematic");
-	key[KeyType::SCREENSHOT] = getKeySetting("keymap_screenshot");
-	key[KeyType::TOGGLE_BLOCK_BOUNDS] = getKeySetting("keymap_toggle_block_bounds");
-	key[KeyType::TOGGLE_HUD] = getKeySetting("keymap_toggle_hud");
-	key[KeyType::TOGGLE_CHAT] = getKeySetting("keymap_toggle_chat");
-	key[KeyType::TOGGLE_FOG] = getKeySetting("keymap_toggle_fog");
-	key[KeyType::TOGGLE_UPDATE_CAMERA] = getKeySetting("keymap_toggle_update_camera");
-	key[KeyType::TOGGLE_DEBUG] = getKeySetting("keymap_toggle_debug");
-	key[KeyType::TOGGLE_PROFILER] = getKeySetting("keymap_toggle_profiler");
-	key[KeyType::CAMERA_MODE] = getKeySetting("keymap_camera_mode");
-	key[KeyType::INCREASE_VIEWING_RANGE] =
+	keybindings[KeyType::DROP] = getKeySetting("keymap_drop");
+	keybindings[KeyType::INVENTORY] = getKeySetting("keymap_inventory");
+	keybindings[KeyType::CHAT] = getKeySetting("keymap_chat");
+	keybindings[KeyType::CMD] = getKeySetting("keymap_cmd");
+	keybindings[KeyType::CMD_LOCAL] = getKeySetting("keymap_cmd_local");
+	keybindings[KeyType::CONSOLE] = getKeySetting("keymap_console");
+	keybindings[KeyType::MINIMAP] = getKeySetting("keymap_minimap");
+	keybindings[KeyType::FREEMOVE] = getKeySetting("keymap_freemove");
+	keybindings[KeyType::PITCHMOVE] = getKeySetting("keymap_pitchmove");
+	keybindings[KeyType::FASTMOVE] = getKeySetting("keymap_fastmove");
+	keybindings[KeyType::NOCLIP] = getKeySetting("keymap_noclip");
+	keybindings[KeyType::HOTBAR_PREV] = getKeySetting("keymap_hotbar_previous");
+	keybindings[KeyType::HOTBAR_NEXT] = getKeySetting("keymap_hotbar_next");
+	keybindings[KeyType::MUTE] = getKeySetting("keymap_mute");
+	keybindings[KeyType::INC_VOLUME] = getKeySetting("keymap_increase_volume");
+	keybindings[KeyType::DEC_VOLUME] = getKeySetting("keymap_decrease_volume");
+	keybindings[KeyType::CINEMATIC] = getKeySetting("keymap_cinematic");
+	keybindings[KeyType::SCREENSHOT] = getKeySetting("keymap_screenshot");
+	keybindings[KeyType::TOGGLE_BLOCK_BOUNDS] = getKeySetting("keymap_toggle_block_bounds");
+	keybindings[KeyType::TOGGLE_HUD] = getKeySetting("keymap_toggle_hud");
+	keybindings[KeyType::TOGGLE_CHAT] = getKeySetting("keymap_toggle_chat");
+	keybindings[KeyType::TOGGLE_FOG] = getKeySetting("keymap_toggle_fog");
+	keybindings[KeyType::TOGGLE_UPDATE_CAMERA] = getKeySetting("keymap_toggle_update_camera");
+	keybindings[KeyType::TOGGLE_DEBUG] = getKeySetting("keymap_toggle_debug");
+	keybindings[KeyType::TOGGLE_PROFILER] = getKeySetting("keymap_toggle_profiler");
+	keybindings[KeyType::CAMERA_MODE] = getKeySetting("keymap_camera_mode");
+	keybindings[KeyType::INCREASE_VIEWING_RANGE] =
 			getKeySetting("keymap_increase_viewing_range_min");
-	key[KeyType::DECREASE_VIEWING_RANGE] =
+	keybindings[KeyType::DECREASE_VIEWING_RANGE] =
 			getKeySetting("keymap_decrease_viewing_range_min");
-	key[KeyType::RANGESELECT] = getKeySetting("keymap_rangeselect");
-	key[KeyType::ZOOM] = getKeySetting("keymap_zoom");
+	keybindings[KeyType::RANGESELECT] = getKeySetting("keymap_rangeselect");
+	keybindings[KeyType::ZOOM] = getKeySetting("keymap_zoom");
 
-	key[KeyType::QUICKTUNE_NEXT] = getKeySetting("keymap_quicktune_next");
-	key[KeyType::QUICKTUNE_PREV] = getKeySetting("keymap_quicktune_prev");
-	key[KeyType::QUICKTUNE_INC] = getKeySetting("keymap_quicktune_inc");
-	key[KeyType::QUICKTUNE_DEC] = getKeySetting("keymap_quicktune_dec");
+	keybindings[KeyType::QUICKTUNE_NEXT] = getKeySetting("keymap_quicktune_next");
+	keybindings[KeyType::QUICKTUNE_PREV] = getKeySetting("keymap_quicktune_prev");
+	keybindings[KeyType::QUICKTUNE_INC] = getKeySetting("keymap_quicktune_inc");
+	keybindings[KeyType::QUICKTUNE_DEC] = getKeySetting("keymap_quicktune_dec");
 
 	for (int i = 0; i < HUD_HOTBAR_ITEMCOUNT_MAX; i++) {
 		std::string slot_key_name = "keymap_slot" + std::to_string(i + 1);
-		key[KeyType::SLOT_1 + i] = getKeySetting(slot_key_name.c_str());
+		keybindings[KeyType::SLOT_1 + i] = getKeySetting(slot_key_name.c_str());
 	}
 
-	if (handler) {
-		// First clear all keys, then re-add the ones we listen for
-		handler->dontListenForKeys();
-		for (int i = 0; i < KeyType::INTERNAL_ENUM_COUNT; i++) {
-			handler->listenForKey(key[i], static_cast<GameKeyType>(i));
-		}
+	// First clear all keys, then re-add the ones we listen for
+	keysListenedFor.clear();
+	for (int i = 0; i < KeyType::INTERNAL_ENUM_COUNT; i++) {
+		listenForKey(keybindings[i], static_cast<GameKeyType>(i));
 	}
 }
 

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -89,11 +89,13 @@ bool MyEventReceiver::setKeyDown(KeyPress keyCode, bool is_down)
 		return false;
 	auto action = keysListenedFor[keyCode];
 	if (is_down) {
+		physicalKeyDown.insert(keyCode);
 		if (!IsKeyDown(action))
 			keyWasPressed.set(action);
 		keyIsDown.set(action);
 		keyWasDown.set(action);
 	} else {
+		physicalKeyDown.erase(keyCode);
 		if (IsKeyDown(action))
 			keyWasReleased.set(action);
 

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -257,7 +257,7 @@ s32 RandomInputHandler::Rand(s32 min, s32 max)
 }
 
 struct RandomInputHandlerSimData {
-	std::string key;
+	GameKeyType key;
 	float counter;
 	int time_max;
 };
@@ -265,19 +265,19 @@ struct RandomInputHandlerSimData {
 void RandomInputHandler::step(float dtime)
 {
 	static RandomInputHandlerSimData rnd_data[] = {
-		{ "keymap_jump", 0.0f, 40 },
-		{ "keymap_aux1", 0.0f, 40 },
-		{ "keymap_forward", 0.0f, 40 },
-		{ "keymap_left", 0.0f, 40 },
-		{ "keymap_dig", 0.0f, 30 },
-		{ "keymap_place", 0.0f, 15 }
+		{ KeyType::JUMP, 0.0f, 40 },
+		{ KeyType::AUX1, 0.0f, 40 },
+		{ KeyType::FORWARD, 0.0f, 40 },
+		{ KeyType::LEFT, 0.0f, 40 },
+		{ KeyType::DIG, 0.0f, 30 },
+		{ KeyType::PLACE, 0.0f, 15 }
 	};
 
 	for (auto &i : rnd_data) {
 		i.counter -= dtime;
 		if (i.counter < 0.0) {
 			i.counter = 0.1 * Rand(1, i.time_max);
-			keydown.toggle(getKeySetting(i.key.c_str()));
+			keydown.flip(i.key);
 		}
 	}
 	{

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -360,7 +360,7 @@ public:
 		return true;
 	}
 
-	virtual bool isKeyDown(GameKeyType k) { return keydown[keycache.key[k]]; }
+	virtual bool isKeyDown(GameKeyType k) { return keydown[k]; }
 	virtual bool wasKeyDown(GameKeyType k) { return false; }
 	virtual bool wasKeyPressed(GameKeyType k) { return false; }
 	virtual bool wasKeyReleased(GameKeyType k) { return false; }
@@ -377,7 +377,7 @@ public:
 	s32 Rand(s32 min, s32 max);
 
 private:
-	KeyList keydown;
+	std::bitset<GameKeyType::INTERNAL_ENUM_COUNT> keydown;
 	v2s32 mousepos;
 	v2s32 mousespeed;
 	float joystickSpeed;

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -125,6 +125,7 @@ public:
 
 private:
 	bool setKeyDown(KeyPress keyCode, bool is_down);
+	void setKeyDown(GameKeyType action, bool is_down);
 
 	s32 mouse_wheel = 0;
 

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -8,7 +8,6 @@
 #include "irr_v2d.h"
 #include "joystick_controller.h"
 #include <list>
-#include <unordered_set>
 #include <unordered_map>
 #include "keycode.h"
 

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -100,7 +100,7 @@ private:
 	 * no error handling (for example bounds checking). This is useful here as the
 	 * faster (up to 10x faster) key lookup is an asset.
 	 */
-	KeyPress keybindings[KeyType::INTERNAL_ENUM_COUNT];
+	std::array<KeyPress, KeyType::INTERNAL_ENUM_COUNT> keybindings;
 
 	s32 mouse_wheel = 0;
 

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -8,6 +8,7 @@
 #include "irr_v2d.h"
 #include "joystick_controller.h"
 #include <list>
+#include <set>
 #include <unordered_map>
 #include "keycode.h"
 
@@ -92,6 +93,7 @@ public:
 
 	void clearInput()
 	{
+		physicalKeyDown.clear();
 		keyIsDown.reset();
 		keyWasDown.reset();
 		keyWasPressed.reset();
@@ -102,6 +104,7 @@ public:
 
 	void releaseAllKeys()
 	{
+		physicalKeyDown.clear();
 		keyWasReleased |= keyIsDown;
 		keyIsDown.reset();
 	}
@@ -124,6 +127,9 @@ private:
 	bool setKeyDown(KeyPress keyCode, bool is_down);
 
 	s32 mouse_wheel = 0;
+
+	// The current state of physical keys.
+	std::set<KeyPress> physicalKeyDown;
 
 	// The current state of keys
 	std::bitset<GameKeyType::INTERNAL_ENUM_COUNT> keyIsDown;

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -7,6 +7,7 @@
 #include "irrlichttypes.h"
 #include "irr_v2d.h"
 #include "joystick_controller.h"
+#include <array>
 #include <list>
 #include <set>
 #include <unordered_map>

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -60,11 +60,24 @@ public:
 	static KeyPress getSpecialKey(const std::string &name);
 
 private:
+	using value_type = std::variant<u32, irr::EKEY_CODE>;
 	bool loadFromScancode(const std::string &name);
 	void loadFromKey(irr::EKEY_CODE keycode, wchar_t keychar);
 	std::string formatScancode() const;
 
-	std::variant<u32, irr::EKEY_CODE> scancode = irr::KEY_UNKNOWN;
+	value_type scancode = irr::KEY_UNKNOWN;
+
+	friend std::hash<KeyPress>;
+};
+
+template <>
+class std::hash<KeyPress>: std::hash<KeyPress::value_type>
+{
+public:
+	size_t operator()(KeyPress kp) const
+	{
+		return std::hash<KeyPress::value_type>::operator()(kp.scancode);
+	}
 };
 
 // Global defines for convenience

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -76,12 +76,10 @@ private:
 };
 
 template <>
-class std::hash<KeyPress>: std::hash<KeyPress::value_type>
+struct std::hash<KeyPress>
 {
-public:
-	size_t operator()(KeyPress kp) const
-	{
-		return std::hash<KeyPress::value_type>::operator()(kp.scancode);
+	size_t operator()(const KeyPress &kp) const noexcept {
+		return std::hash<KeyPress::value_type>{}(kp.scancode);
 	}
 };
 

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -78,7 +78,7 @@ private:
 template <>
 struct std::hash<KeyPress>
 {
-	size_t operator()(const KeyPress &kp) const noexcept {
+	size_t operator()(KeyPress kp) const noexcept {
 		return std::hash<KeyPress::value_type>{}(kp.scancode);
 	}
 };

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -49,7 +49,7 @@ public:
 		return !(*this == o);
 	}
 
-	// Used for e.g. std::unordered_set
+	// Used for e.g. std::set
 	bool operator<(KeyPress o) const {
 		return scancode < o.scancode;
 	}

--- a/src/client/keycode.h
+++ b/src/client/keycode.h
@@ -49,6 +49,11 @@ public:
 		return !(*this == o);
 	}
 
+	// Used for e.g. std::unordered_set
+	bool operator<(KeyPress o) const {
+		return scancode < o.scancode;
+	}
+
 	// Check whether the keypress is valid
 	operator bool() const
 	{


### PR DESCRIPTION
Mostly preparations for allowing more complex keyboard-related features (e.g. secondary keybindings); largely based on #15918 (which turned out to be useful after all after some more changes). The main changes (later ones can be dropped if we want to put them into later PRs that actually need the commits):

- Implement `operator<` (for e.g. `std::set`) and `std::hash` (for `std::unordered_map`) for `KeyPress`. `KeyList` is dropped accordingly.
- The event receiver now stores keypress information into a bitset indexed using `GameKeyType`. This architecture is useful as it avoids future headaches around e.g. `wasKeyDown`.
- We continue to keep track of physical keys. This is useful for e.g. secondary keybindings, where (with the above change) we want to make sure that other keybindings are also unset before releasing a `GameKeyType` key (physical keys are still marked as relased when they are released, of course).
- `KeyCache` is dropped and integrated into the event receiver, as the changes around the event receiver makes it no longer necessary for the input handler to hold information on keybindings, while it can become useful in the future for the event receiver to quickly look up keypresses (see above point for example).

- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  The first two commits qualify for 2.2 Internal code refactoring. Other the entire PR also eases development for future feature PRs.

## To do
This PR is Ready for Review.

## How to test
Check that keyboard input still works.