### PR TITLE
TouchControls: Take FOV into account for camera movement

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2407,8 +2407,10 @@ f32 Game::getSensitivityScaleFactor() const
 void Game::updateCameraOrientation(CameraOrientation *cam, float dtime)
 {
 	if (g_touchcontrols) {
-		cam->camera_yaw   += g_touchcontrols->getYawChange();
-		cam->camera_pitch += g_touchcontrols->getPitchChange();
+		// User setting is already applied by TouchControls.
+		f32 sens_scale = getSensitivityScaleFactor();
+		cam->camera_yaw   += g_touchcontrols->getYawChange()   * sens_scale;
+		cam->camera_pitch += g_touchcontrols->getPitchChange() * sens_scale;
 	} else {
 		v2s32 center(driver->getScreenSize().Width / 2, driver->getScreenSize().Height / 2);
 		v2s32 dist = input->getMousePos() - center;


### PR DESCRIPTION
fixes #15935

This just applies #11007 to touchscreen as well. I don't know why this wasn't done there, probably because the author didn't want to bother with mobile (the bar was higher back then). This PR doesn't do anything additional like implementing a setting, but feel free to do so in another PR.

## To do

This PR is a Ready for Review.

## How to test

Test playing Luanti on mobile.

- Sensitivity should be the same as before with FOV = 72 (the default)
- Sensitivity should now be much more usable if zoomed in (try guns with scope, e.g. A.E.S. Block League)