### PR TITLE
Fix possible nullptr dereference in serverpackethandler.cpp

### DIFF
--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -416,6 +416,8 @@ void Server::handleCommand_GotBlocks(NetworkPacket* pkt)
 
 	ClientInterface::AutoLock lock(m_clients);
 	RemoteClient *client = m_clients.lockedGetClientNoEx(pkt->getPeerId());
+	if (!client)
+		return;
 
 	for (u16 i = 0; i < count; i++) {
 		v3s16 p;
@@ -538,6 +540,8 @@ void Server::handleCommand_DeletedBlocks(NetworkPacket* pkt)
 
 	ClientInterface::AutoLock lock(m_clients);
 	RemoteClient *client = m_clients.lockedGetClientNoEx(pkt->getPeerId());
+	if (!client)
+		return;
 
 	for (u16 i = 0; i < count; i++) {
 		v3s16 p;


### PR DESCRIPTION
The `lockedGetClientNoEx` function can return a nullptr, since it is the "no exception" version of GetClient. These two places are not checking for a valid `client` pointer and can result in a segfault when dereferencing it a few lines below.