### PR TITLE
Restore behavior of emergequeue_limit_total

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -106,9 +106,9 @@ EmergeManager::EmergeManager(Server *server, MetricsBackend *mb)
 		m_qlimit_generate = nthreads + 1;
 
 	// don't trust user input for something very important like this
+	m_qlimit_total = rangelim(m_qlimit_total, 2, 1000000);
 	m_qlimit_diskonly = rangelim(m_qlimit_diskonly, 2, 1000000);
 	m_qlimit_generate = rangelim(m_qlimit_generate, 1, 1000000);
-	m_qlimit_total = std::max(m_qlimit_diskonly, m_qlimit_generate);
 
 	for (s16 i = 0; i < nthreads; i++)
 		m_threads.push_back(new EmergeThread(server, i));

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -106,9 +106,9 @@ EmergeManager::EmergeManager(Server *server, MetricsBackend *mb)
 		m_qlimit_generate = nthreads + 1;
 
 	// don't trust user input for something very important like this
-	m_qlimit_total = rangelim(m_qlimit_total, 2, 1000000);
 	m_qlimit_diskonly = rangelim(m_qlimit_diskonly, 2, 1000000);
 	m_qlimit_generate = rangelim(m_qlimit_generate, 1, 1000000);
+	m_qlimit_total = std::max(m_qlimit_total, std::max(m_qlimit_diskonly, m_qlimit_generate));
 
 	for (s16 i = 0; i < nthreads; i++)
 		m_threads.push_back(new EmergeThread(server, i));


### PR DESCRIPTION
#15851 incorrectly sets the server's total emerge queue limit to the maximum of the **per-player** disk/generate queue limits. @sfan5 

- Goal of the PR/How does the PR work?

Restore the old behavior.

- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

This PR Ready for Review.

## How to test

Test with multiple clients... Or just look at the code, it's pretty obvious.