### PR TITLE
Check if a block is already in the emege queue before checking occlusion culling and trying to reemerge

### DIFF
--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -338,7 +338,11 @@ void RemoteClient::GetNextBlocks (
 				*/
 				if (d >= d_opt && block->isAir())
 						continue;
+			} else if (emerge->isBlockInQueue(p)) {
+				// if the block is already in the emerge queue we don't have to check again
+				continue;
 			}
+
 			/*
 				Check occlusion cache first.
 			 */

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -339,8 +339,11 @@ void RemoteClient::GetNextBlocks (
 				if (d >= d_opt && block->isAir())
 						continue;
 			}
-			if ((!block || !block->isGenerated()) && emerge->isBlockInQueue(p)) {
-				// if the block is already in the emerge queue we don't have to check again
+
+			const bool want_emerge = !block || !block->isGenerated();
+
+			// if the block is already in the emerge queue we don't have to check again
+			if (want_emerge && emerge->isBlockInQueue(p)) {
 				nearest_emerged_d = d;
 				continue;
 			}
@@ -363,7 +366,7 @@ void RemoteClient::GetNextBlocks (
 			/*
 				Add inexistent block to emerge queue.
 			*/
-			if (!block || !block->isGenerated()) {
+			if (want_emerge) {
 				if (emerge->enqueueBlockEmerge(peer_id, p, generate)) {
 					if (nearest_emerged_d == -1)
 						nearest_emerged_d = d;

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -338,8 +338,10 @@ void RemoteClient::GetNextBlocks (
 				*/
 				if (d >= d_opt && block->isAir())
 						continue;
-			} else if (emerge->isBlockInQueue(p)) {
+			}
+			if ((!block || !block->isGenerated()) && emerge->isBlockInQueue(p)) {
 				// if the block is already in the emerge queue we don't have to check again
+				nearest_emerged_d = d;
 				continue;
 			}
 


### PR DESCRIPTION
I was looking into why the server throughput is lower when `emergequeue_limit_diskonly`/`emergequeue_limit_generate` are set to large values. I found that in that case much time is spent in doing occlusion culling over and over again for the same blocks until they are finally loaded. For large queue sizes (5000 or 10000) this can reduce the server throughput by 25x (from 19k to 800 or less blocks/s) - and increase CPU load by the same.

The fix is to check whether the block is already enqueued. In that case occlusion culling is no longer performed.
No attempt is made to reenqueue the block either (the only possible bit we can loose is the `generate`, which has no impact in this case as the block is already on the queue.)

This is similar to checking blocks_sending and blocks_send before we attempt to handle them again.

Note that will be even worse if retrieving blocks from the DB takes longer (as might be the case with the Postgres backend.)

(With this I see throughput close to the theoretical maximum. On my machine it takes about 45us to load/deserialize a block, i.e. ~22k blocks/s, what I see is about 19k blocks/s... Pretty close!)

- Goal of the PR

Increase server loading throughput

- How does the PR work?

See description

- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

Load any world, dig around. Set `emergequeue_limit_diskonly`/`emergequeue_limit_generate`  to large values, notice that throughput is not reduced.