### PR TITLE
Deprecate some legacy item registration logic

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -183,6 +183,8 @@ function core.register_item(name, itemdef)
 
 	-- BEGIN Legacy stuff
 	if itemdef.cookresult_itemstring ~= nil and itemdef.cookresult_itemstring ~= "" then
+		core.log("deprecated", "The `cookresult_itemstring` item definition " ..
+			"field is deprecated. Use `core.register_craft` instead.")
 		core.register_craft({
 			type="cooking",
 			output=itemdef.cookresult_itemstring,
@@ -191,6 +193,8 @@ function core.register_item(name, itemdef)
 		})
 	end
 	if itemdef.furnace_burntime ~= nil and itemdef.furnace_burntime >= 0 then
+		core.log("deprecated", "The `furnace_burntime` item definition " ..
+			"field is deprecated. Use `core.register_craft` instead.")
 		core.register_craft({
 			type="fuel",
 			recipe=itemdef.name,
@@ -204,7 +208,6 @@ function core.register_item(name, itemdef)
 	-- Ignore new keys as a failsafe to prevent mistakes
 	getmetatable(itemdef).__newindex = function() end
 
-	--core.log("Registering item: " .. itemdef.name)
 	core.registered_items[itemdef.name] = itemdef
 	core.registered_aliases[itemdef.name] = nil
 	register_item_raw(itemdef)
@@ -241,6 +244,8 @@ function core.register_craftitem(name, craftitemdef)
 
 	-- BEGIN Legacy stuff
 	if craftitemdef.inventory_image == nil and craftitemdef.image ~= nil then
+		core.log("deprecated", "The `image` field in craftitem definitions " ..
+			"is deprecated. Use `inventory_image` instead.")
 		craftitemdef.inventory_image = craftitemdef.image
 	end
 	-- END Legacy stuff
@@ -254,6 +259,8 @@ function core.register_tool(name, tooldef)
 
 	-- BEGIN Legacy stuff
 	if tooldef.inventory_image == nil and tooldef.image ~= nil then
+		core.log("deprecated", "The `image` field in tool definitions " ..
+			"is deprecated. Use `inventory_image` instead.")
 		tooldef.inventory_image = tooldef.image
 	end
 	if tooldef.tool_capabilities == nil and
@@ -268,6 +275,8 @@ function core.register_tool(name, tooldef)
 	    tooldef.dd_crackiness ~= nil or
 	    tooldef.dd_crumbliness ~= nil or
 	    tooldef.dd_cuttability ~= nil) then
+		core.log("deprecated", "Specifying tool capabilities directly in the tool " ..
+			"definition is deprecated. Use the `tool_capabilities` field instead.")
 		tooldef.tool_capabilities = {
 			full_punch_interval = tooldef.full_punch_interval,
 			basetime = tooldef.basetime,
@@ -307,7 +316,6 @@ function core.register_alias(name, convert_to)
 		core.log("warning", "Not registering alias, item with same name" ..
 			" is already defined: " .. name .. " -> " .. convert_to)
 	else
-		--core.log("Registering alias: " .. name .. " -> " .. convert_to)
 		core.registered_aliases[name] = convert_to
 		register_alias_raw(name, convert_to)
 	end
@@ -322,7 +330,6 @@ function core.register_alias_force(name, convert_to)
 		core.log("info", "Removed item " ..name..
 			" while attempting to force add an alias")
 	end
-	--core.log("Registering alias: " .. name .. " -> " .. convert_to)
 	core.registered_aliases[name] = convert_to
 	register_alias_raw(name, convert_to)
 end


### PR DESCRIPTION
Stumbled upon these things while reading some code.

Does what it says. The first commit is most likely fine: I'm yet to see content contain (most of) these strings. I can't easily grep for the latter for obvious reasons, but I'd expect it to be fine too.

All of the things removed here have been undocumented and obsolete legacy "features" for more than a decade.

Side note: There's also [this](https://github.com/luanti-org/luanti/blob/fbc525d683021d1e2cf3f7cc9d2c54419e0b0ff3/builtin/game/register.lua#L42-L55), which exists so that this

https://github.com/luanti-org/luanti/blob/fbc525d683021d1e2cf3f7cc9d2c54419e0b0ff3/src/inventory.cpp#L84-L178

 works correctly. I suppose that is technically not safe to remove, since someone might want to open an ancient world on recent Luanti (note: if the world was opened using newer, where newer means not more than a decade old, I believe these itemstrings should have been "upgraded"), and world compatibility is taken very seriously.
 
 Should we put it on the planned 6.0 breakages list or add an in-code TODO?