### PR TITLE
Document server texture pack in texture_packs.md

### DIFF
--- a/doc/texture_packs.md
+++ b/doc/texture_packs.md
@@ -21,6 +21,7 @@ Texture pack directory structure
 This is a directory containing the entire contents of a single texture pack.
 It can be chosen more or less freely and will also become the name of the
 texture pack. The name must not be “base”.
+Textures in the “server“ pack will be used by the server.
 
 ### `texture_pack.conf`
 A key-value config file with the following keys:


### PR DESCRIPTION
This documents what a texture pack named "server" does, in `texture_packs.md`.
Currently, it is only documented in `texture_packs_here.txt` and apparently hard to find.
See https://irc.luanti.org/luanti-dev/2025-03-22#i_6250427

