### PR TITLE
lua_api.md: More info in LBM run_at_every_load documentation

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9503,9 +9503,9 @@ that all given positions contain a matching node.
     run_at_every_load = false,
     -- If `true`: The LBM runs whenever a mapblock is activated.
     --
-    -- If `false`: The LBM only runs for a mapblock when it is activated for
+    -- If `false`: The LBM only runs on a mapblock when it is activated for
     -- the first time after the LBM was introduced.
-    -- It never runs for mapblocks generated after the LBM's introduction.
+    -- It never runs on mapblocks generated after the LBM's introduction.
     --
     -- For this, each LBM's introduction timestamp is stored in the world data,
     -- identified by `name`. When a LBM is removed, the corresponding timestamp

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9486,6 +9486,23 @@ That means if an LBM callback adds a node, it won't be taken into account.
 However the engine guarantees that at the point in time when the callback is called
 that all given positions contain a matching node.
 
+For `run_at_every_load = false`, both mapblocks and LBMs have timestamps
+associated with them:
+
+* Each mapblock has a "last active" timestamp. It is also updated when the
+  mapblock is generated.
+* For each LBM, an introduction timestamp is stored in the world data, identified
+  by the LBM's `name` field. If an LBM disappears, the corresponding timestamp
+  is cleared.
+
+When a mapblock is activated, only LBMs whose introduction timestamp is newer
+than the mapblock's timestamp are run.
+
+*Note*: For maps generated in 5.11.0 or older, many newly generated blocks did not
+get a timestamp set. This means LBMs introduced between generation time and
+time of first activation will never run.
+Currently the only workaround is to use `run_at_every_load = true`.
+
 ```lua
 {
     label = "Upgrade legacy doors",
@@ -9501,20 +9518,11 @@ that all given positions contain a matching node.
     -- will work as well.
 
     run_at_every_load = false,
-    -- If `true`: The LBM runs whenever a mapblock is activated.
-    --
     -- If `false`: The LBM only runs on mapblocks when they are activated for
     -- the first time after the LBM was introduced.
     -- It never runs on mapblocks generated after the LBM's introduction.
     --
-    -- For this, each LBM's introduction timestamp is stored in the world data,
-    -- identified by `name`. If an LBM disappears, the corresponding timestamp
-    -- is cleared.
-    --
-    -- *Note*: For maps generated in 5.11.0 or older, many newly generated
-    -- mapblocks did not get a timestamp set. This means LBMs introduced between
-    -- generation time and time of first activation will never run.
-    -- Currently the only workaround is to use `true`.
+    -- If `true`: The LBM runs whenever a mapblock is activated.
 
     action = function(pos, node, dtime_s) end,
     -- Function triggered for each qualifying node.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9479,7 +9479,7 @@ Used by `core.register_lbm`.
 
 A loading block modifier (LBM) is used to define a function that is called for
 specific nodes (defined by `nodenames`) when a mapblock which contains such nodes
-gets activated (**not loaded!**).
+gets **activated** (**not loaded!**).
 
 *Note*: LBMs operate on a "snapshot" of node positions taken once before they are triggered.
 That means if an LBM callback adds a node, it won't be taken into account.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9503,7 +9503,7 @@ that all given positions contain a matching node.
     run_at_every_load = false,
     -- If `true`: The LBM runs whenever a mapblock is activated.
     --
-    -- If `false`: The LBM only runs on a mapblock when it is activated for
+    -- If `false`: The LBM only runs on mapblocks when they are activated for
     -- the first time after the LBM was introduced.
     -- It never runs on mapblocks generated after the LBM's introduction.
     --

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9508,7 +9508,7 @@ that all given positions contain a matching node.
     -- It never runs on mapblocks generated after the LBM's introduction.
     --
     -- For this, each LBM's introduction timestamp is stored in the world data,
-    -- identified by `name`. When a LBM is removed, the corresponding timestamp
+    -- identified by `name`. If an LBM disappears, the corresponding timestamp
     -- is cleared.
     --
     -- *Note*: For maps generated in 5.11.0 or older, many newly generated

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9486,11 +9486,6 @@ That means if an LBM callback adds a node, it won't be taken into account.
 However the engine guarantees that at the point in time when the callback is called
 that all given positions contain a matching node.
 
-*Note*: For maps generated in 5.11.0 or older, many newly generated blocks did not
-get a timestamp set. This means LBMs introduced between generation time and
-time of first activation will never run.
-Currently the only workaround is to use `run_at_every_load`.
-
 ```lua
 {
     label = "Upgrade legacy doors",
@@ -9506,13 +9501,24 @@ Currently the only workaround is to use `run_at_every_load`.
     -- will work as well.
 
     run_at_every_load = false,
-    -- Whether to run the LBM's action every time a block gets activated,
-    -- and not only the first time the block gets activated after the LBM
-    -- was introduced.
+    -- If `true`: The LBM runs whenever a mapblock is activated.
+    --
+    -- If `false`: The LBM only runs for a mapblock when it is activated for
+    -- the first time after the LBM was introduced.
+    -- It never runs for mapblocks generated after the LBM's introduction.
+    --
+    -- For this, each LBM's introduction timestamp is stored in the world data,
+    -- identified by `name`. When a LBM is removed, the corresponding timestamp
+    -- is cleared.
+    --
+    -- *Note*: For maps generated in 5.11.0 or older, many newly generated
+    -- mapblocks did not get a timestamp set. This means LBMs introduced between
+    -- generation time and time of first activation will never run.
+    -- Currently the only workaround is to use `true`.
 
     action = function(pos, node, dtime_s) end,
     -- Function triggered for each qualifying node.
-    -- `dtime_s` is the in-game time (in seconds) elapsed since the block
+    -- `dtime_s` is the in-game time (in seconds) elapsed since the mapblock
     -- was last active (available since 5.7.0).
 
     bulk_action = function(pos_list, dtime_s) end,

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9486,7 +9486,7 @@ That means if an LBM callback adds a node, it won't be taken into account.
 However the engine guarantees that at the point in time when the callback is called
 that all given positions contain a matching node.
 
-For `run_at_every_load = false`, both mapblocks and LBMs have timestamps
+For `run_at_every_load = false` to work, both mapblocks and LBMs have timestamps
 associated with them:
 
 * Each mapblock has a "last active" timestamp. It is also updated when the
@@ -9498,9 +9498,9 @@ associated with them:
 When a mapblock is activated, only LBMs whose introduction timestamp is newer
 than the mapblock's timestamp are run.
 
-*Note*: For maps generated in 5.11.0 or older, many newly generated blocks did not
-get a timestamp set. This means LBMs introduced between generation time and
-time of first activation will never run.
+*Note*: For maps generated in 5.11.0 or older, many newly generated mapblocks
+did not get a timestamp set. This means LBMs introduced between generation time
+and time of first activation will never run.
 Currently the only workaround is to use `run_at_every_load = true`.
 
 ```lua
@@ -9518,11 +9518,12 @@ Currently the only workaround is to use `run_at_every_load = true`.
     -- will work as well.
 
     run_at_every_load = false,
-    -- If `false`: The LBM only runs on mapblocks when they are activated for
-    -- the first time after the LBM was introduced.
+    -- If `false`: The LBM only runs on mapblocks the first time they are
+    -- activated after the LBM was introduced.
     -- It never runs on mapblocks generated after the LBM's introduction.
+    -- See above for details.
     --
-    -- If `true`: The LBM runs whenever a mapblock is activated.
+    -- If `true`: The LBM runs every time a mapblock is activated.
 
     action = function(pos, node, dtime_s) end,
     -- Function triggered for each qualifying node.


### PR DESCRIPTION
after seeing the recent LBM discussions, I looked at lua_api.md and found it lacking, especially regarding newly generated mapblocks

interesting PRs: #3677 and #8878

## To do

This PR is a Ready for Review.

## How to test

Read, check if what I wrote is correct
