### PR TITLE
Add support for static boxes in 'leveled' type

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1407,11 +1407,13 @@ The function of `param2` is determined by `paramtype2` in node definition.
 * `paramtype2 = "leveled"`
     * Only valid for "nodebox" with 'type = "leveled"', and "plantlike_rooted".
         * Leveled nodebox:
+            * Nodebox `type` must be set to `"leveled"`
             * The level of the top face of the nodebox is stored in `param2`.
             * The other faces are defined by 'fixed = {}' like 'type = "fixed"'
               nodeboxes.
             * The nodebox height is (`param2` / 64) nodes.
             * The maximum accepted value of `param2` is 127.
+            * Boxes in '`leveled_fixed = {}`' will never change.
         * Rooted plantlike:
             * The height of the 'plantlike' section is stored in `param2`.
             * The height is (`param2` / 16) nodes.
@@ -1615,8 +1617,10 @@ A nodebox is defined as any of:
     -- by the node parameter 'leveled = ', or if 'paramtype2 == "leveled"'
     -- by param2.
     -- Other faces are defined by 'fixed = {}' as with 'type = "fixed"'.
+    -- Optionally add 'leveled_fixed = {}' for static boxes.
     type = "leveled",
-    fixed = box OR {box1, box2, ...}
+    fixed = box OR {box1, box2, ...} -- top face is variable
+    leveled_fixed = box OR {box1, box2, ...} -- never changes
 }
 {
     -- A box like the selection box for torches

--- a/games/devtest/mods/testnodes/nodeboxes.lua
+++ b/games/devtest/mods/testnodes/nodeboxes.lua
@@ -62,6 +62,28 @@ core.register_node("testnodes:nodebox_leveled", {
 	groups = {dig_immediate=3},
 })
 
+-- Leveled nodebox that also contains a static nodebox
+minetest.register_node("testnodes:nodebox_leveled_fixed", {
+	description = S("Combined Leveled Nodebox Test Node").."\n"..
+		S("param2 = height of center box (0..127)").."\n"..
+		S("Other boxes are unaffected by param2"),
+	tiles = {"testnodes_nodebox.png^[colorize:#0F0:32"},
+	drawtype = "nodebox",
+	paramtype = "light",
+	paramtype2 = "leveled",
+	node_box = {
+		type = "leveled",
+		fixed = {-0.25, 0.0, -0.25, 0.25, -0.499, 0.25},
+		leveled_fixed = {
+			{-0.5, -0.5, -0.5, -0.25, 0.0, -0.25},
+			{0.25, -0.5, 0.25, 0.5, 0.0, 0.5},
+			{-0.5, -0.5, 0.25, -0.25, 0.0, 0.5},
+			{0.25, -0.5, -0.5, 0.5, 0.0, -0.25},
+		},
+	},
+
+	groups = {dig_immediate=3},
+})
 
 local nodebox_wall = {
 	type = "connected",

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -170,6 +170,144 @@ void MapNode::rotateAlongYAxis(const NodeDefManager *nodemgr, Rotation rot)
 	}
 }
 
+void buildFixedNodeBox(const MapNode &n, const NodeBox &nodebox, const NodeDefManager *nodemgr,
+		std::vector<aabb3f> &boxes, std::vector<aabb3f> input_boxes,
+		enum NodeBoxType nbt) {
+	u8 facedir = n.getFaceDir(nodemgr, true);
+	u8 axisdir = facedir>>2;
+	facedir &= 0x03;
+	for (aabb3f box : input_boxes) {
+		switch (nbt) {
+			case NODEBOX_LEVELED: {
+				box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
+				break;
+			}
+			default: {
+				break;
+			}
+		}
+
+		switch (axisdir) {
+		case 0:
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXZBy(-90);
+				box.MaxEdge.rotateXZBy(-90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXZBy(180);
+				box.MaxEdge.rotateXZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXZBy(90);
+				box.MaxEdge.rotateXZBy(90);
+			}
+			break;
+		case 1: // z+
+			box.MinEdge.rotateYZBy(90);
+			box.MaxEdge.rotateYZBy(90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXYBy(90);
+				box.MaxEdge.rotateXYBy(90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXYBy(180);
+				box.MaxEdge.rotateXYBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXYBy(-90);
+				box.MaxEdge.rotateXYBy(-90);
+			}
+			break;
+		case 2: //z-
+			box.MinEdge.rotateYZBy(-90);
+			box.MaxEdge.rotateYZBy(-90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXYBy(-90);
+				box.MaxEdge.rotateXYBy(-90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXYBy(180);
+				box.MaxEdge.rotateXYBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXYBy(90);
+				box.MaxEdge.rotateXYBy(90);
+			}
+			break;
+		case 3:  //x+
+			box.MinEdge.rotateXYBy(-90);
+			box.MaxEdge.rotateXYBy(-90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateYZBy(90);
+				box.MaxEdge.rotateYZBy(90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateYZBy(180);
+				box.MaxEdge.rotateYZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateYZBy(-90);
+				box.MaxEdge.rotateYZBy(-90);
+			}
+			break;
+		case 4:  //x-
+			box.MinEdge.rotateXYBy(90);
+			box.MaxEdge.rotateXYBy(90);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateYZBy(-90);
+				box.MaxEdge.rotateYZBy(-90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateYZBy(180);
+				box.MaxEdge.rotateYZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateYZBy(90);
+				box.MaxEdge.rotateYZBy(90);
+			}
+			break;
+		case 5:
+			box.MinEdge.rotateXYBy(-180);
+			box.MaxEdge.rotateXYBy(-180);
+			if(facedir == 1)
+			{
+				box.MinEdge.rotateXZBy(90);
+				box.MaxEdge.rotateXZBy(90);
+			}
+			else if(facedir == 2)
+			{
+				box.MinEdge.rotateXZBy(180);
+				box.MaxEdge.rotateXZBy(180);
+			}
+			else if(facedir == 3)
+			{
+				box.MinEdge.rotateXZBy(-90);
+				box.MaxEdge.rotateXZBy(-90);
+			}
+			break;
+		default:
+			break;
+		}
+		box.repair();
+		boxes.push_back(box);
+	}
+}
+
 void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 	const NodeDefManager *nodemgr, std::vector<aabb3f> *p_boxes,
 	u8 neighbors = 0)
@@ -177,57 +315,13 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 	std::vector<aabb3f> &boxes = *p_boxes;
 
 	if (nodebox.type == NODEBOX_FIXED || nodebox.type == NODEBOX_LEVELED) {
-		const auto &fixed = nodebox.fixed;
-		int facedir = n.getFaceDir(nodemgr, true);
-		u8 axisdir = facedir >> 2;
-		facedir &= 0x03;
-
-		boxes.reserve(boxes.size() + fixed.size());
-		for (aabb3f box : fixed) {
-			if (nodebox.type == NODEBOX_LEVELED)
-				box.MaxEdge.Y = (-0.5f + n.getLevel(nodemgr) / 64.0f) * BS;
-
-			if(facedir == 1) {
-				box.MinEdge.rotateXZBy(-90);
-				box.MaxEdge.rotateXZBy(-90);
-			} else if(facedir == 2) {
-				box.MinEdge.rotateXZBy(180);
-				box.MaxEdge.rotateXZBy(180);
-			} else if(facedir == 3) {
-				box.MinEdge.rotateXZBy(90);
-				box.MaxEdge.rotateXZBy(90);
-			}
-
-			switch (axisdir) {
-			case 0:
-				break;
-			case 1: // z+
-				box.MinEdge.rotateYZBy(90);
-				box.MaxEdge.rotateYZBy(90);
-				break;
-			case 2: //z-
-				box.MinEdge.rotateYZBy(-90);
-				box.MaxEdge.rotateYZBy(-90);
-				break;
-			case 3:  //x+
-				box.MinEdge.rotateXYBy(-90);
-				box.MaxEdge.rotateXYBy(-90);
-				break;
-			case 4:  //x-
-				box.MinEdge.rotateXYBy(90);
-				box.MaxEdge.rotateXYBy(90);
-				break;
-			case 5:
-				box.MinEdge.rotateXYBy(-180);
-				box.MaxEdge.rotateXYBy(-180);
-				break;
-			default:
-				break;
-			}
-
-			box.repair();
-			boxes.push_back(box);
+		const std::vector<aabb3f> &fixed = nodebox.fixed;
+		const std::vector<aabb3f> &leveled_fixed = nodebox.leveled_fixed;
+		enum NodeBoxType nbt = nodebox.type;
+		if (nbt == NODEBOX_LEVELED){
+			buildFixedNodeBox(n, nodebox, nodemgr, boxes, leveled_fixed, NODEBOX_FIXED);
 		}
+		buildFixedNodeBox(n, nodebox, nodemgr, boxes, fixed, nbt);
 	}
 	else if(nodebox.type == NODEBOX_WALLMOUNTED)
 	{
@@ -341,47 +435,57 @@ void transformNodeBox(const MapNode &n, const NodeBox &nodebox,
 
 		boxes.reserve(boxes_size);
 
-		auto boxes_insert = [&](const std::vector<aabb3f> &boxes_src) {
-			boxes.insert(boxes.end(), boxes_src.begin(), boxes_src.end());
-		};
+#define BOXESPUSHBACK(c) \
+		for (std::vector<aabb3f>::const_iterator \
+				it = (c).begin(); \
+				it != (c).end(); ++it) \
+			(boxes).push_back(*it);
 
-		boxes_insert(nodebox.fixed);
+		BOXESPUSHBACK(nodebox.fixed);
 
-		if (neighbors & 1)
-			boxes_insert(c.connect_top);
-		else
-			boxes_insert(c.disconnected_top);
+		if (neighbors & 1) {
+			BOXESPUSHBACK(c.connect_top);
+		} else {
+			BOXESPUSHBACK(c.disconnected_top);
+		}
 
-		if (neighbors & 2)
-			boxes_insert(c.connect_bottom);
-		else
-			boxes_insert(c.disconnected_bottom);
+		if (neighbors & 2) {
+			BOXESPUSHBACK(c.connect_bottom);
+		} else {
+			BOXESPUSHBACK(c.disconnected_bottom);
+		}
 
-		if (neighbors & 4)
-			boxes_insert(c.connect_front);
-		else
-			boxes_insert(c.disconnected_front);
+		if (neighbors & 4) {
+			BOXESPUSHBACK(c.connect_front);
+		} else {
+			BOXESPUSHBACK(c.disconnected_front);
+		}
 
-		if (neighbors & 8)
-			boxes_insert(c.connect_left);
-		else
-			boxes_insert(c.disconnected_left);
+		if (neighbors & 8) {
+			BOXESPUSHBACK(c.connect_left);
+		} else {
+			BOXESPUSHBACK(c.disconnected_left);
+		}
 
-		if (neighbors & 16)
-			boxes_insert(c.connect_back);
-		else
-			boxes_insert(c.disconnected_back);
+		if (neighbors & 16) {
+			BOXESPUSHBACK(c.connect_back);
+		} else {
+			BOXESPUSHBACK(c.disconnected_back);
+		}
 
-		if (neighbors & 32)
-			boxes_insert(c.connect_right);
-		else
-			boxes_insert(c.disconnected_right);
+		if (neighbors & 32) {
+			BOXESPUSHBACK(c.connect_right);
+		} else {
+			BOXESPUSHBACK(c.disconnected_right);
+		}
 
-		if (neighbors == 0)
-			boxes_insert(c.disconnected);
+		if (neighbors == 0) {
+			BOXESPUSHBACK(c.disconnected);
+		}
 
-		if (neighbors < 4)
-			boxes_insert(c.disconnected_sides);
+		if (neighbors < 4) {
+			BOXESPUSHBACK(c.disconnected_sides);
+		}
 
 	}
 	else // NODEBOX_REGULAR

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -38,6 +38,7 @@ void NodeBox::reset()
 	type = NODEBOX_REGULAR;
 	// default is empty
 	fixed.clear();
+	leveled_fixed.clear();
 	// default is sign/ladder-like
 	wall_top = aabb3f(-BS/2, BS/2-BS/16., -BS/2, BS/2, BS/2, BS/2);
 	wall_bottom = aabb3f(-BS/2, -BS/2, -BS/2, BS/2, -BS/2+BS/16., BS/2);
@@ -51,8 +52,8 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 	writeU8(os, 6); // version. Protocol >= 36
 
 	switch (type) {
-	case NODEBOX_LEVELED:
 	case NODEBOX_FIXED:
+	case NODEBOX_LEVELED: {
 		writeU8(os, type);
 
 		writeU16(os, fixed.size());
@@ -60,7 +61,15 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 			writeV3F32(os, nodebox.MinEdge);
 			writeV3F32(os, nodebox.MaxEdge);
 		}
+		if (type == NODEBOX_LEVELED) {
+			writeU16(os, leveled_fixed.size());
+			for (const aabb3f &nodebox : leveled_fixed) {
+				writeV3F32(os, nodebox.MinEdge);
+				writeV3F32(os, nodebox.MaxEdge);
+			}
+		}
 		break;
+	}
 	case NODEBOX_WALLMOUNTED:
 		writeU8(os, type);
 
@@ -98,6 +107,7 @@ void NodeBox::serialize(std::ostream &os, u16 protocol_version) const
 		WRITEBOX(c.disconnected_right);
 		WRITEBOX(c.disconnected);
 		WRITEBOX(c.disconnected_sides);
+		WRITEBOX(leveled_fixed);
 		break;
 	}
 	default:
@@ -125,6 +135,19 @@ void NodeBox::deSerialize(std::istream &is)
 				box.MinEdge = readV3F32(is);
 				box.MaxEdge = readV3F32(is);
 				fixed.push_back(box);
+			}
+			if (type == NODEBOX_LEVELED) {
+				u16 leveled_fixed_count = readU16(is);
+				if (is.eof()) {
+					leveled_fixed_count = 0;
+				}
+				while(leveled_fixed_count--)
+				{
+					aabb3f box{{0.0f, 0.0f, 0.0f}};
+					box.MinEdge = readV3F32(is);
+					box.MaxEdge = readV3F32(is);
+					leveled_fixed.push_back(box);
+				}
 			}
 			break;
 		}
@@ -164,6 +187,7 @@ void NodeBox::deSerialize(std::istream &is)
 			READBOXES(c.disconnected_right);
 			READBOXES(c.disconnected);
 			READBOXES(c.disconnected_sides);
+			READBOXES(leveled_fixed);
 			break;
 		}
 		default:

--- a/src/nodedef.h
+++ b/src/nodedef.h
@@ -121,6 +121,8 @@ struct NodeBox
 	// NODEBOX_CONNECTED
 	// (kept externally to not bloat the structure)
 	std::shared_ptr<NodeBoxConnected> connected;
+	// NODEBOX_LEVELED
+	std::vector<aabb3f> leveled_fixed;
 
 	NodeBox()
 	{ reset(); }

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1134,12 +1134,19 @@ void push_nodebox(lua_State *L, const NodeBox &box)
 			lua_pushstring(L, "regular");
 			lua_setfield(L, -2, "type");
 			break;
-		case NODEBOX_LEVELED:
 		case NODEBOX_FIXED:
 			lua_pushstring(L, "fixed");
 			lua_setfield(L, -2, "type");
 			push_aabb3f_vector(L, box.fixed);
 			lua_setfield(L, -2, "fixed");
+			break;
+		case NODEBOX_LEVELED:
+			lua_pushstring(L, "leveled");
+			lua_setfield(L, -2, "type");
+			push_aabb3f_vector(L, box.fixed);
+			lua_setfield(L, -2, "fixed");
+			push_aabb3f_vector(L, box.leveled_fixed);
+			lua_setfield(L, -2, "leveled_fixed");
 			break;
 		case NODEBOX_WALLMOUNTED:
 			lua_pushstring(L, "wallmounted");
@@ -1308,6 +1315,7 @@ NodeBox read_nodebox(lua_State *L, int index)
 		NODEBOXREADVEC(c.disconnected, "disconnected");
 		NODEBOXREADVEC(c.disconnected_sides, "disconnected_sides");
 	}
+	NODEBOXREADVEC(nodebox.leveled_fixed, "leveled_fixed");
 
 	return nodebox;
 }


### PR DESCRIPTION
## The problem

Currently, 'leveled' boxes will allways have their upper face change with param2. So this only allows you to do fairly simple things. If you need a fully static box as part of a leveled nodebox, you are out of luck.

## The PR

This PR adds a new field '`leveled_fixed`' for the nodebox type 'leveled'. This is an optional box (or boxes) for leveled-type nodeboxes, but it will be fully static.

## Use cases
* Cauldron with water of variable height (`leveled_fixed` is the cauldron (which is static), `fixed` is the water box (which varies in height))
* Trash can with something inside
* Some kind of simple ice spike

## Please note

Unfortunately, the naming is a little bit weird for `leveled` nodeboxes. For some reason, the `fixed` box is actually NOT fixed, since it varies in height. The new nodebox field `leveled_fixed` is the box (or boxes) that is ACTUALLY fixed.

It has been like that before, I cannot change that trivially w/o breaking compability. I think it is best to just keep the naming for the sake of compability, which is MUCH more important.

## How to test

Use the following test node in DevTest. Try them together with the Param2 Tool:

* `testnodes:nodebox_leveled_fixed` (new node)

## Additional notes

This PR is a revival of #11391, but with only the `leveled_fixed` feature; the nodebox types `leveled_plantlike` and `leveled_plantlike_rooted` have been removed since those have created the most disagreement.