### PR TITLE
Slight fix to #15949 to handle emerge queue full

### DIFF
--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -343,24 +343,21 @@ void RemoteClient::GetNextBlocks (
 			const bool want_emerge = !block || !block->isGenerated();
 
 			// if the block is already in the emerge queue we don't have to check again
-			if (want_emerge && emerge->isBlockInQueue(p)) {
-				nearest_emerged_d = d;
-				continue;
-			}
+			if (!want_emerge || !emerge->isBlockInQueue(p)) {
+				/*
+					Check occlusion cache first.
+				 */
+				if (m_blocks_occ.find(p) != m_blocks_occ.end())
+					continue;
 
-			/*
-				Check occlusion cache first.
-			 */
-			if (m_blocks_occ.find(p) != m_blocks_occ.end())
-				continue;
-
-			/*
-				Note that we do this even before the block is loaded as this does not depend on its contents.
-			 */
-			if (m_occ_cull &&
-					env->getMap().isBlockOccluded(p * MAP_BLOCKSIZE, cam_pos_nodes, d >= d_cull_opt)) {
-				m_blocks_occ.insert(p);
-				continue;
+				/*
+					Note that we do this even before the block is loaded as this does not depend on its contents.
+				 */
+				if (m_occ_cull &&
+						env->getMap().isBlockOccluded(p * MAP_BLOCKSIZE, cam_pos_nodes, d >= d_cull_opt)) {
+					m_blocks_occ.insert(p);
+					continue;
+				}
 			}
 
 			/*


### PR DESCRIPTION
I noticed #15949 has one corner condition... When the emerge queue is full (which is checked whether the block is being inserted or replaced). In that before #15949 we'd do not step the distance d past that, now we can step up to 2 past that, and sometimes that shows holes (that will be filled when we come around to the beginning, but until that happens a gap is visible.)

This changes #15949 such only the occlusion culling step is skipped and then the normal emerge logic happens (which checks for queue full et al)

That actually simplifies the logic as well.

This PR is Ready for Review.

## How to test

I sometime see this behavior with large `viewing_rang`'es (800+) and `max_block_generate_distance`,  `max_block_send_distance` set accordingly and `emergequeue_limit_generate` set to something between 1000 and 5000. When you fly up and wait for a scene to generate you can sometime see the gaps.