### PR TITLE
Formspec: Show a player inventory using core.show_formspec

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6873,10 +6873,14 @@ Formspec
     * `playername`: name of player to show formspec
     * `formname`: name passed to `on_player_receive_fields` callbacks.
         * It should follow the `"modname:<whatever>"` naming convention.
-        * If empty: Shows a custom, temporary inventory formspec. Use
-          `ObjectRef:set_inventory_formspec` to change it for future opens.
-          Supported if server AND client are both of version >= 5.13.0.
+        * If empty: Shows a custom, temporary inventory formspec.
+            * An inventory formspec shown this way will also be updated if
+              `ObjectRef:set_inventory_formspec` is called.
+            * Use `ObjectRef:set_inventory_formspec` to change the player's
+              inventory formspec for future opens.
+            * Supported if server AND client are both of version >= 5.13.0.
     * `formspec`: formspec to display
+    * See also: `core.register_on_player_receive_fields`
 * `core.close_formspec(playername, formname)`
     * `playername`: name of player to close formspec
     * `formname`: has to exactly match the one given in `show_formspec`, or the

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6873,7 +6873,7 @@ Formspec
     * `playername`: name of player to show formspec
     * `formname`: name passed to `on_player_receive_fields` callbacks.
         * It should follow the `"modname:<whatever>"` naming convention.
-        * If empty: Shows an inventory formspec. Use
+        * If empty: Shows a custom, temporary inventory formspec. Use
           `ObjectRef:set_inventory_formspec` to change it for future opens.
           Supported if server AND client are both of version >= 5.13.0.
     * `formspec`: formspec to display
@@ -8654,9 +8654,12 @@ child will follow movement and rotation of that bone.
     * Returns `nil` if no attribute found.
 * `get_meta()`: Returns metadata associated with the player (a PlayerMetaRef).
 * `set_inventory_formspec(formspec)`
-    * Redefine player's inventory form. This sends an update to the player.
-    * Should usually be called in `on_joinplayer`
+    * Redefines the player's inventory formspec.
+    * Should usually be called at least once in the `on_joinplayer` callback.
     * If `formspec` is `""`, the player's inventory is disabled.
+    * If the inventory formspec is currently open on the client, it is
+      updated immediately.
+    * See also: `core.register_on_player_receive_fields`
 * `get_inventory_formspec()`: returns a formspec string
 * `set_formspec_prepend(formspec)`:
     * the formspec string will be added to every formspec shown to the user,

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6873,9 +6873,9 @@ Formspec
     * `playername`: name of player to show formspec
     * `formname`: name passed to `on_player_receive_fields` callbacks.
         * It should follow the `"modname:<whatever>"` naming convention.
-        * If empty: Reshows the inventory formspec. Servers and
-          clients >= 5.13.0 will update the inventory formspec
-          (`ObjectRef:set_inventory_formspec`) for future opens.
+        * If empty: Shows an inventory formspec. Use
+          `ObjectRef:set_inventory_formspec` to change it for future opens.
+          Supported if server AND client are both of version >= 5.13.0.
     * `formspec`: formspec to display
 * `core.close_formspec(playername, formname)`
     * `playername`: name of player to close formspec
@@ -8654,7 +8654,7 @@ child will follow movement and rotation of that bone.
     * Returns `nil` if no attribute found.
 * `get_meta()`: Returns metadata associated with the player (a PlayerMetaRef).
 * `set_inventory_formspec(formspec)`
-    * Redefine player's inventory form
+    * Redefine player's inventory form. This sends an update to the player.
     * Should usually be called in `on_joinplayer`
     * If `formspec` is `""`, the player's inventory is disabled.
 * `get_inventory_formspec()`: returns a formspec string

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6872,9 +6872,10 @@ Formspec
 * `core.show_formspec(playername, formname, formspec)`
     * `playername`: name of player to show formspec
     * `formname`: name passed to `on_player_receive_fields` callbacks.
-      It should follow the `"modname:<whatever>"` naming convention.
-    * `formname` must not be empty, unless you want to reshow
-      the inventory formspec without updating it for future opens.
+        * It should follow the `"modname:<whatever>"` naming convention.
+        * If empty: Reshows the inventory formspec. Servers and
+          clients >= 5.13.0 will update the inventory formspec
+          (`ObjectRef:set_inventory_formspec`) for future opens.
     * `formspec`: formspec to display
 * `core.close_formspec(playername, formname)`
     * `playername`: name of player to close formspec

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -1925,7 +1925,7 @@ void Game::processKeyInput()
 		if (g_settings->getBool("continuous_forward"))
 			toggleAutoforward();
 	} else if (wasKeyDown(KeyType::INVENTORY)) {
-		m_game_formspec.showPlayerInventory();
+		m_game_formspec.showPlayerInventory(nullptr);
 	} else if (input->cancelPressed()) {
 #ifdef __ANDROID__
 		m_android_chat_open = false;
@@ -2717,11 +2717,7 @@ void Game::handleClientEvent_ShowFormSpec(ClientEvent *event, CameraOrientation 
 	auto &fs = event->show_formspec;
 
 	if (fs.formname->empty() && !fs.formspec->empty()) {
-		// Overwrite the inventory formspec
-		LocalPlayer *player = client->getEnv().getLocalPlayer();
-		player->inventory_formspec = *fs.formspec;
-
-		m_game_formspec.showPlayerInventory();
+		m_game_formspec.showPlayerInventory(fs.formspec);
 	} else {
 		m_game_formspec.showFormSpec(*fs.formspec,
 			*fs.formname);

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2719,8 +2719,7 @@ void Game::handleClientEvent_ShowFormSpec(ClientEvent *event, CameraOrientation 
 	if (fs.formname->empty() && !fs.formspec->empty()) {
 		m_game_formspec.showPlayerInventory(fs.formspec);
 	} else {
-		m_game_formspec.showFormSpec(*fs.formspec,
-			*fs.formname);
+		m_game_formspec.showFormSpec(*fs.formspec, *fs.formname);
 	}
 
 	delete fs.formspec;

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2714,11 +2714,21 @@ void Game::handleClientEvent_DeathscreenLegacy(ClientEvent *event, CameraOrienta
 
 void Game::handleClientEvent_ShowFormSpec(ClientEvent *event, CameraOrientation *cam)
 {
-	m_game_formspec.showFormSpec(*event->show_formspec.formspec,
-		*event->show_formspec.formname);
+	auto &fs = event->show_formspec;
 
-	delete event->show_formspec.formspec;
-	delete event->show_formspec.formname;
+	if (fs.formname->empty() && !fs.formspec->empty()) {
+		// Overwrite the inventory formspec
+		LocalPlayer *player = client->getEnv().getLocalPlayer();
+		player->inventory_formspec = *fs.formspec;
+
+		m_game_formspec.showPlayerInventory();
+	} else {
+		m_game_formspec.showFormSpec(*fs.formspec,
+			*fs.formname);
+	}
+
+	delete fs.formspec;
+	delete fs.formname;
 }
 
 void Game::handleClientEvent_ShowCSMFormSpec(ClientEvent *event, CameraOrientation *cam)

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -334,7 +334,7 @@ void GameFormSpec::showPlayerInventory(const std::string *fs_override)
 		player->inventory_formspec_override.clear();
 	}
 
-	// If preventedd by Client-Side Mods
+	// If prevented by Client-Side Mods
 	if (m_client->modsLoaded() && m_client->getScript()->on_inventory_open(m_client->getInventory(inventoryloc)))
 		return;
 

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -326,18 +326,20 @@ void GameFormSpec::showPlayerInventory(const std::string *fs_override)
 	InventoryLocation inventoryloc;
 	inventoryloc.setCurrentPlayer();
 
+	if (fs_override)
+		player->inventory_formspec_override = *fs_override;
+	else
+		player->inventory_formspec_override.clear();
+
 	if (m_client->modsLoaded() && m_client->getScript()->on_inventory_open(m_client->getInventory(inventoryloc))) {
 		delete fs_src;
 		return;
 	}
 
-	const std::string &formspec = fs_override ? *fs_override : fs_src->getForm();
-	if (formspec.empty()) {
+	if (fs_src->getForm().empty() || (fs_override && fs_override->empty())) {
 		delete fs_src;
 		return;
 	}
-	if (fs_override)
-		player->inventory_formspec_override = *fs_override;
 
 	TextDest *txt_dst = new TextDestPlayerInventory(m_client);
 
@@ -345,7 +347,7 @@ void GameFormSpec::showPlayerInventory(const std::string *fs_override)
 		&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
 		m_client->getSoundManager());
 
-	m_formspec->setFormSpec(formspec, inventoryloc);
+	m_formspec->setFormSpec(fs_src->getForm(), inventoryloc);
 }
 
 #define SIZE_TAG "size[11,5.5,true]" // Fixed size (ignored in touchscreen mode)

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -178,6 +178,10 @@ public:
 	const std::string &getForm() const
 	{
 		LocalPlayer *player = m_client->getEnv().getLocalPlayer();
+
+		if (!player->inventory_formspec_override.empty())
+			return player->inventory_formspec_override;
+
 		return player->inventory_formspec;
 	}
 
@@ -304,7 +308,7 @@ void GameFormSpec::showNodeFormspec(const std::string &formspec, const v3s16 &no
 	m_formspec->setFormSpec(formspec, inventoryloc);
 }
 
-void GameFormSpec::showPlayerInventory()
+void GameFormSpec::showPlayerInventory(const std::string *fs_override)
 {
 	/*
 	 * Don't permit to open inventory is CAO or player doesn't exists.
@@ -327,10 +331,13 @@ void GameFormSpec::showPlayerInventory()
 		return;
 	}
 
-	if (fs_src->getForm().empty()) {
+	const std::string &formspec = fs_override ? *fs_override : fs_src->getForm();
+	if (formspec.empty()) {
 		delete fs_src;
 		return;
 	}
+	if (fs_override)
+		player->inventory_formspec_override = *fs_override;
 
 	TextDest *txt_dst = new TextDestPlayerInventory(m_client);
 
@@ -338,7 +345,7 @@ void GameFormSpec::showPlayerInventory()
 		&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
 		m_client->getSoundManager());
 
-	m_formspec->setFormSpec(fs_src->getForm(), inventoryloc);
+	m_formspec->setFormSpec(formspec, inventoryloc);
 }
 
 #define SIZE_TAG "size[11,5.5,true]" // Fixed size (ignored in touchscreen mode)

--- a/src/client/game_formspec.h
+++ b/src/client/game_formspec.h
@@ -34,8 +34,8 @@ struct GameFormSpec
 	// Currently only used for the in-game settings menu.
 	void showPauseMenuFormSpec(const std::string &formspec, const std::string &formname);
 	void showNodeFormspec(const std::string &formspec, const v3s16 &nodepos);
-	/// If ` fs_override`: Uses `player->inventory_formspec`.
-	/// If `!fs_override`: Uses a temporary formspec until an update is received.
+	/// If `!fs_override`: Uses `player->inventory_formspec`.
+	/// If ` fs_override`: Uses a temporary formspec until an update is received.
 	void showPlayerInventory(const std::string *fs_override);
 	void showDeathFormspecLegacy();
 	// Shows the hardcoded "main" pause menu.

--- a/src/client/game_formspec.h
+++ b/src/client/game_formspec.h
@@ -34,7 +34,9 @@ struct GameFormSpec
 	// Currently only used for the in-game settings menu.
 	void showPauseMenuFormSpec(const std::string &formspec, const std::string &formname);
 	void showNodeFormspec(const std::string &formspec, const v3s16 &nodepos);
-	void showPlayerInventory();
+	/// If ` fs_override`: Uses `player->inventory_formspec`.
+	/// If `!fs_override`: Uses a temporary formspec until an update is received.
+	void showPlayerInventory(const std::string *fs_override);
 	void showDeathFormspecLegacy();
 	// Shows the hardcoded "main" pause menu.
 	void showPauseMenu();

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -99,6 +99,7 @@ public:
 
 	std::string hotbar_image = "";
 	std::string hotbar_selected_image = "";
+	std::string inventory_formspec_override;
 
 	video::SColor light_color = video::SColor(255, 255, 255, 255);
 

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -99,6 +99,7 @@ public:
 
 	std::string hotbar_image = "";
 	std::string hotbar_selected_image = "";
+	/// Temporary player inventory formspec. Empty value = feature inactive.
 	std::string inventory_formspec_override;
 
 	video::SColor light_color = video::SColor(255, 255, 255, 255);

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -902,6 +902,7 @@ void Client::handleCommand_InventoryFormSpec(NetworkPacket* pkt)
 
 	// Store formspec in LocalPlayer
 	player->inventory_formspec = pkt->readLongString();
+	player->inventory_formspec_override.clear();
 }
 
 void Client::handleCommand_DetachedInventory(NetworkPacket* pkt)

--- a/src/network/serveropcodes.cpp
+++ b/src/network/serveropcodes.cpp
@@ -178,6 +178,7 @@ const ClientCommandFactory clientCommandFactoryTable[TOCLIENT_NUM_MSG_TYPES] =
 	{ "TOCLIENT_STOP_SOUND",               0, true }, // 0x40
 	{ "TOCLIENT_PRIVILEGES",               0, true }, // 0x41
 	{ "TOCLIENT_INVENTORY_FORMSPEC",       0, true }, // 0x42
+	// ^ `channel` MUST be the same as TOCLIENT_SHOW_FORMSPEC
 	{ "TOCLIENT_DETACHED_INVENTORY",       0, true }, // 0x43
 	{ "TOCLIENT_SHOW_FORMSPEC",            0, true }, // 0x44
 	{ "TOCLIENT_MOVEMENT",                 0, true }, // 0x45

--- a/src/remoteplayer.h
+++ b/src/remoteplayer.h
@@ -121,6 +121,8 @@ public:
 	u16 protocol_version = 0;
 	u16 formspec_version = 0;
 
+	bool inventory_formspec_overridden = false;
+
 	/// returns PEER_ID_INEXISTENT when PlayerSAO is not ready
 	session_t getPeerId() const { return m_peer_id; }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1574,7 +1574,9 @@ int ObjectRef::l_set_inventory_formspec(lua_State *L)
 
 	auto formspec = readParam<std::string_view>(L, 2);
 
-	if (formspec != player->inventory_formspec) {
+	if (player->inventory_formspec_overridden
+			|| formspec != player->inventory_formspec) {
+		player->inventory_formspec_overridden = false;
 		player->inventory_formspec = formspec;
 		getServer(L)->reportInventoryFormspecModified(player->getName());
 	}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3397,6 +3397,11 @@ bool Server::showFormspec(const char *playername, const std::string &formspec,
 	if (!player)
 		return false;
 
+	if (formname.empty() && !formspec.empty()) {
+		// Overwrite the inventory formspec
+		player->inventory_formspec = formspec;
+	}
+
 	SendShowFormspecMessage(player->getPeerId(), formspec, formname);
 	return true;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1595,11 +1595,10 @@ void Server::SendShowFormspecMessage(session_t peer_id, const std::string &forms
 				(it->second == formname || formname.empty())) {
 			m_formspec_state_data.erase(peer_id);
 		}
-		pkt.putLongString("");
 	} else {
 		m_formspec_state_data[peer_id] = formname;
-		pkt.putLongString(formspec);
 	}
+	pkt.putLongString(formspec);
 	pkt << formname;
 
 	Send(&pkt);
@@ -3397,10 +3396,8 @@ bool Server::showFormspec(const char *playername, const std::string &formspec,
 	if (!player)
 		return false;
 
-	if (formname.empty() && !formspec.empty()) {
-		// Overwrite the inventory formspec
-		player->inventory_formspec = formspec;
-	}
+	// To allow re-sending the same inventory formspec.
+	player->inventory_formspec_overridden = formname.empty() && !formspec.empty();
 
 	SendShowFormspecMessage(player->getPeerId(), formspec, formname);
 	return true;


### PR DESCRIPTION
'core.show_formspec' now shows a temporary inventory formspec as if it was opened using the hotkey on client-side.

Fixes https://github.com/luanti-org/minetest_game/issues/3188 as soon both server and client are >= 5.13.0.

## To do

This PR is Ready for Review.

## How to test

```lua
core.register_chatcommand("fs", {
	func = function(name, param)
		local player = core.get_player_by_name(name)
		if not player then return end -- ncurses

		if core.get_player_information(name).protocol_version < (core.protocol_versions["5.13.0"] or 0) then
			return false, "Not supported by client; formspec inputs are not sent to the server"
		end

		local fs = player:get_inventory_formspec()
		core.show_formspec(name, "", "size[8,8]button[4,4;5,1;x;I do nothing]")

		assert(fs == player:get_inventory_formspec(), "formspecs must still match")

		core.after(2, function()
			-- Force update to the regular inventory formspec
			core.chat_send_player(name, "*** PREVIOUS FORMSPEC RESTORED ***")
			player:set_inventory_formspec(fs)
		end)

		core.after(5, function()
			-- Force close
			core.chat_send_player(name, "*** FORCE CLOSE FORMSPEC TEST ***")
			core.show_formspec(name, "", "")
		end)
		return true
	end
})
```

1. Open the inventory. Navigate a bit
2. Use `/fs`. The formspec must show the same thing that you saw last
3. Navigate in the formspec before it closes after 5 seconds
4. Open the inventory using the hotkey. It must show the same formspec that you saw last.