### PR TITLE
ImageSource: restrict max dimensions to protect from integer overflows

### DIFF
--- a/src/client/imagesource.cpp
+++ b/src/client/imagesource.cpp
@@ -949,9 +949,10 @@ static void imageTransform(u32 transform, video::IImage *src, video::IImage *dst
 
 #define CHECK_DIM(w, h) \
 	do { \
-		if ((w) <= 0 || (h) <= 0 || (w) >= 0xffff || (h) >= 0xffff) { \
-			COMPLAIN_INVALID("width or height"); \
-		} \
+		if ((w) <= 0 || (w) > MAX_IMAGE_DIMENSION) \
+			COMPLAIN_INVALID("width"); \
+		if ((h) <= 0 || (h) > MAX_IMAGE_DIMENSION) \
+			COMPLAIN_INVALID("height"); \
 	} while(0)
 
 bool ImageSource::generateImagePart(std::string_view part_of_name,
@@ -1350,6 +1351,8 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 
 			v2u32 frame_size = baseimg->getDimension();
 			frame_size.Y /= frame_count;
+			if (frame_size.Y == 0)
+				frame_size.Y = 1;
 
 			video::IImage *img = driver->createImage(video::ECF_A8R8G8B8,
 					frame_size);
@@ -1498,11 +1501,13 @@ bool ImageSource::generateImagePart(std::string_view part_of_name,
 					u32 w = scale * dim.Width;
 					u32 h = scale * dim.Height;
 					const core::dimension2d<u32> newdim(w, h);
-					video::IImage *newimg = driver->createImage(
-							baseimg->getColorFormat(), newdim);
-					baseimg->copyToScaling(newimg);
-					baseimg->drop();
-					baseimg = newimg;
+					if (w <= MAX_IMAGE_DIMENSION && h <= MAX_IMAGE_DIMENSION) {
+						video::IImage *newimg = driver->createImage(
+								baseimg->getColorFormat(), newdim);
+						baseimg->copyToScaling(newimg);
+						baseimg->drop();
+						baseimg = newimg;
+					}
 				}
 			}
 		}

--- a/src/client/imagesource.h
+++ b/src/client/imagesource.h
@@ -45,6 +45,12 @@ struct ImageSource {
 	// Insert a source image into the cache without touching the filesystem.
 	void insertSourceImage(const std::string &name, video::IImage *img, bool prefer_local);
 
+	// This was picked so that the image buffer size fits in an s32 (assuming 32bpp).
+	// The exact value is 23170 but this provides some leeway.
+	// In theory something like 33333x123 could be allowed, but there is no strong
+	// need or argument. Irrlicht also has the same limit.
+	static constexpr int MAX_IMAGE_DIMENSION = 23000;
+
 private:
 
 	// Generate image based on a string like "stone.png" or "[crack:1:0".


### PR DESCRIPTION
The test code at the bottom segfaults because Irrlicht's code writes or reads out of bounds, who knows what else could happen.

## To do

This PR is Ready for Review.

## How to test

1. try
```lua
core.after(1, function()
	core.get_player_by_name("singleplayer"):hud_add({
			hud_elem_type = "image",
			position = {x = 0.5, y = 0.5},
			scale = {x = 1, y = 1},
			text = "[fill:512x512:red^[resize:24000x24000"
		})
end)
```
nothing should happen

2. you can change it to `22999x22999` and it will lag the client for a while (and consume lots of memory) but not crash
