### PR TITLE
Array textures proof-of-concept

### DIFF
--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -1,4 +1,4 @@
-uniform sampler2D baseTexture;
+uniform sampler2DArray baseTexture;
 
 uniform vec3 dayLight;
 uniform lowp vec4 fogColor;
@@ -416,7 +416,7 @@ void main(void)
 	vec3 color;
 	vec2 uv = varTexCoord.st;
 
-	vec4 base = texture2D(baseTexture, uv).rgba;
+	vec4 base = texture(baseTexture, vec3(uv, 0)).rgba;
 	// If alpha is zero, we can just discard the pixel. This fixes transparency
 	// on GPUs like GC7000L, where GL_ALPHA_TEST is not implemented in mesa,
 	// and also on GLES 2, where GL_ALPHA_TEST is missing entirely.

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -414,9 +414,11 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 void main(void)
 {
 	vec3 color;
-	vec2 uv = varTexCoord.st;
+	vec3 uv = varTexCoord.sts;
+	uv.s = mod(uv.s, 1.0);
+	uv.p = floor(uv.p); // layer
 
-	vec4 base = texture(baseTexture, vec3(uv, 0)).rgba;
+	vec4 base = texture(baseTexture, uv).rgba;
 	// If alpha is zero, we can just discard the pixel. This fixes transparency
 	// on GPUs like GC7000L, where GL_ALPHA_TEST is not implemented in mesa,
 	// and also on GLES 2, where GL_ALPHA_TEST is missing entirely.

--- a/client/shaders/nodes_shader/opengl_vertex.glsl
+++ b/client/shaders/nodes_shader/opengl_vertex.glsl
@@ -44,8 +44,6 @@ centroid varying float nightRatio;
 	varying float perspective_factor;
 #endif
 
-varying float area_enable_parallax;
-
 varying highp vec3 eyeVec;
 // Color of the light emitted by the light sources.
 const vec3 artificialLight = vec3(1.04, 1.04, 1.04);

--- a/irr/include/ITexture.h
+++ b/irr/include/ITexture.h
@@ -160,7 +160,9 @@ enum E_TEXTURE_TYPE
 	ETT_2D_MS,
 
 	//! Cubemap texture.
-	ETT_CUBEMAP
+	ETT_CUBEMAP,
+
+	ETT_2D_ARRAY,
 };
 
 //! Interface of a Video Driver dependent Texture.

--- a/irr/include/IVideoDriver.h
+++ b/irr/include/IVideoDriver.h
@@ -232,6 +232,8 @@ public:
 	information. */
 	virtual ITexture *addTexture(const io::path &name, IImage *image) = 0;
 
+	virtual ITexture *addArrayTexture(const io::path &name, IImage **images, u32 count) = 0;
+
 	//! Creates a cubemap texture from loaded IImages.
 	/** \param name A name for the texture. Later calls of getTexture() with this name will return this texture.
 	The name can _not_ be empty.

--- a/irr/src/CNullDriver.h
+++ b/irr/src/CNullDriver.h
@@ -84,6 +84,10 @@ public:
 
 	ITexture *addTexture(const io::path &name, IImage *image) override;
 
+	ITexture *addArrayTexture(const io::path &name, IImage **images, u32 count) override {
+		return 0;
+	}
+
 	virtual ITexture *addTextureCubemap(const io::path &name, IImage *imagePosX, IImage *imageNegX, IImage *imagePosY,
 			IImage *imageNegY, IImage *imagePosZ, IImage *imageNegZ) override;
 

--- a/irr/src/OpenGL/Driver.cpp
+++ b/irr/src/OpenGL/Driver.cpp
@@ -1088,6 +1088,17 @@ ITexture *COpenGL3DriverBase::createDeviceDependentTextureCubemap(const io::path
 	return texture;
 }
 
+ITexture *COpenGL3DriverBase::addArrayTexture(const io::path &name, IImage **images, u32 count)
+{
+	std::vector<IImage*> tmp;
+	// stupid but who cares
+	tmp.resize(count);
+	for (u32 i = 0; i < count; i++)
+		tmp[i] = images[i];
+
+	return new COpenGL3Texture(name, tmp, ETT_2D_ARRAY, this);
+}
+
 // Same as COpenGLDriver::TextureFlipMatrix
 static const core::matrix4 s_texture_flip_matrix = {
 	1,  0, 0, 0,

--- a/irr/src/OpenGL/Driver.h
+++ b/irr/src/OpenGL/Driver.h
@@ -208,6 +208,8 @@ public:
 	//! Returns the maximum amount of primitives
 	u32 getMaximalPrimitiveCount() const override;
 
+	ITexture *addArrayTexture(const io::path &name, IImage **images, u32 count) override;
+
 	virtual ITexture *addRenderTargetTexture(const core::dimension2d<u32> &size,
 			const io::path &name, const ECOLOR_FORMAT format = ECF_UNKNOWN) override;
 

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -103,7 +103,7 @@ void MapblockMeshGenerator::getSpecialTile(int index, TileSpec *tile_ret, bool a
 
 	for (auto &layernum : tile_ret->layers) {
 		TileLayer *layer = &layernum;
-		if (layer->texture_id == 0)
+		if (layer->empty())
 			continue;
 		top_layer = layer;
 		if (!layer->has_color)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -349,12 +349,12 @@ void MapblockMeshGenerator::drawAutoLightedCuboid(aabb3f box,
 		box.MinEdge *= cur_node.f->visual_scale;
 		box.MaxEdge *= cur_node.f->visual_scale;
 	}
-	box.MinEdge += cur_node.origin;
-	box.MaxEdge += cur_node.origin;
 	if (!txc) {
 		generateCuboidTextureCoords(box, texture_coord_buf);
 		txc = texture_coord_buf;
 	}
+	box.MinEdge += cur_node.origin;
+	box.MaxEdge += cur_node.origin;
 	if (data->m_smooth_lighting) {
 		LightInfo lights[8];
 		for (int j = 0; j < 8; ++j) {
@@ -443,9 +443,9 @@ void MapblockMeshGenerator::drawSolidNode()
 	cur_node.origin = intToFloat(cur_node.p, BS);
 	auto box = aabb3f(v3f(-0.5 * BS), v3f(0.5 * BS));
 	f32 texture_coord_buf[24];
+	generateCuboidTextureCoords(box, texture_coord_buf);
 	box.MinEdge += cur_node.origin;
 	box.MaxEdge += cur_node.origin;
-	generateCuboidTextureCoords(box, texture_coord_buf);
 	if (data->m_smooth_lighting) {
 		LightPair lights[6][4];
 		for (int face = 0; face < 6; ++face) {

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -347,7 +347,7 @@ void getNodeTileN(MapNode mn, const v3s16 &p, u8 tileindex, MeshMakeData *data, 
 	tile = f.tiles[tileindex];
 	bool has_crack = p == data->m_crack_pos_relative;
 	for (TileLayer &layer : tile.layers) {
-		if (layer.texture_id == 0)
+		if (layer.empty())
 			continue;
 		if (!layer.has_color)
 			mn.getColor(f, &(layer.color));

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -12,7 +12,7 @@ void MeshCollector::append(const TileSpec &tile, const video::S3DVertex *vertice
 {
 	for (int layernum = 0; layernum < MAX_TILE_LAYERS; layernum++) {
 		const TileLayer *layer = &tile.layers[layernum];
-		if (layer->texture_id == 0)
+		if (layer->empty())
 			continue;
 		append(*layer, vertices, numVertices, indices, numIndices, layernum,
 				tile.world_aligned);

--- a/src/client/meshgen/collector.cpp
+++ b/src/client/meshgen/collector.cpp
@@ -29,10 +29,13 @@ void MeshCollector::append(const TileLayer &layer, const video::S3DVertex *verti
 	if (use_scale)
 		scale = 1.0f / layer.scale;
 
+	v2f uv_offset;
+	uv_offset.X = layer.texture_layer_idx;
+
 	u32 vertex_count = p.vertices.size();
 	for (u32 i = 0; i < numVertices; i++) {
 		p.vertices.emplace_back(vertices[i].Pos + offset, vertices[i].Normal,
-				vertices[i].Color, scale * vertices[i].TCoords);
+				vertices[i].Color, scale * vertices[i].TCoords + uv_offset);
 		m_bounding_radius_sq = std::max(m_bounding_radius_sq,
 				(vertices[i].Pos - m_center_pos).getLengthSQ());
 	}

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -288,7 +288,10 @@ u32 TextureSource::generateTexture(const std::string &name)
 	if (img) {
 		img = Align2Npot2(img, driver);
 		// Create texture from resulting image
-		tex = driver->addTexture(name.c_str(), img);
+		if (name.find("applyfiltersformesh") != std::string::npos)
+			tex = driver->addArrayTexture(name.c_str(), &img, 1);
+		else
+			tex = driver->addTexture(name.c_str(), img);
 		guiScalingCache(io::path(name.c_str()), driver, img);
 		img->drop();
 	}
@@ -474,7 +477,10 @@ void TextureSource::rebuildTexture(video::IVideoDriver *driver, TextureInfo &ti)
 	// Create texture from resulting image
 	video::ITexture *t = nullptr;
 	if (img) {
-		t = driver->addTexture(ti.name.c_str(), img);
+		if (ti.name.find("applyfiltersformesh") != std::string::npos)
+			t = driver->addArrayTexture(ti.name.c_str(), &img, 1);
+		else
+			t = driver->addTexture(ti.name.c_str(), img);
 		guiScalingCache(io::path(ti.name.c_str()), driver, img);
 		img->drop();
 	}

--- a/src/client/tile.h
+++ b/src/client/tile.h
@@ -125,6 +125,8 @@ struct TileLayer
 	u16 animation_frame_length_ms = 0;
 	u16 animation_frame_count = 1;
 
+	u16 texture_layer_idx = 0;
+
 	MaterialType material_type = TILE_MATERIAL_BASIC;
 	u8 material_flags =
 		//0 // <- DEBUG, Use the one below


### PR DESCRIPTION
This PR demonstrates the use of [array textures](https://www.khronos.org/opengl/wiki/Array_Texture) to further reduce the drawcall amount, by allowing one draw operation to use different logical textures at the same time.
For example it would allow a grass node to *not* be split up into three mesh buffers (it has three unique textures).
it implements this idea: https://irc.luanti.org/luanti-dev/2025-03-30#i_6252315

poc limitations:
* no global "texture atlas"-like functionality: merging happens for the 6 node tiles at most
* no care for texture sizes, might randomly down or upscale if tiles mismatch
* quick and dirty approach leaves CAOs and inventory rendering broken
* skips animated nodes, breaks crack animation

how to test:
1. **use `video_driver = opengl3`**
2. due to hardcoded assumptions you need to enable mipmap, trilinear, bilinear *or* aniso
3. place some rails (including curves) and verify that all rails of the same type are rendered in a single draw call (-> renderdoc)

what will happen to this PR?:
because properly doing everything requires some rearchitecting and is laborious work I'll probably convert this PR to just have the GL driver support code and other cleanups but not the feature itself.

open questions:
* crack animation is best reworked to accommodate this, but how?
* keep using the "pack into UV" hack or add new vertex format (+2 bytes)?
  * `generateCuboidTextureCoords` was probably this way for a reason :thinking:  