### PR TITLE
Break liquid reflow scan early for all-air blocks

### DIFF
--- a/src/reflowscan.cpp
+++ b/src/reflowscan.cpp
@@ -118,49 +118,51 @@ void ReflowScan::scanColumn(int x, int z)
 		was_ignore = true;
 		was_liquid = false;
 	}
-	// we can out early if there's no liquid above
-	// and the current block is all air
-	if (!was_liquid && block->isAir())
-		return;
-
 	bool was_checked = false;
 	bool was_pushed = false;
 
-	// Scan through the whole block
-	for (s16 y = MAP_BLOCKSIZE - 1; y >= 0; y--) {
-		MapNode node = block->getNodeNoCheck(dx, y, dz);
-		const ContentFeatures &f = m_ndef->get(node);
-		bool is_ignore = node.getContent() == CONTENT_IGNORE;
-		bool is_liquid = f.isLiquid();
+	// if there is no liquid above and the current block is air
+	// we can skip scanning the block
+	if (!was_liquid && block->isAir()) {
+		// continue after the block with air
+		was_ignore = false;
+	} else {
+		// Scan through the whole block
+		for (s16 y = MAP_BLOCKSIZE - 1; y >= 0; y--) {
+			MapNode node = block->getNodeNoCheck(dx, y, dz);
+			const ContentFeatures &f = m_ndef->get(node);
+			bool is_ignore = node.getContent() == CONTENT_IGNORE;
+			bool is_liquid = f.isLiquid();
 
-		if (is_ignore || was_ignore || is_liquid == was_liquid) {
-			// Neither topmost node of liquid column nor topmost node below column
-			was_checked = false;
-			was_pushed = false;
-		} else if (is_liquid) {
-			// This is the topmost node in the column
-			bool is_pushed = false;
-			if (f.liquid_type == LIQUID_FLOWING ||
-					isLiquidHorizontallyFlowable(x, y, z)) {
-				m_liquid_queue->push_back(m_rel_block_pos + v3s16(x, y, z));
-				is_pushed = true;
+			if (is_ignore || was_ignore || is_liquid == was_liquid) {
+				// Neither topmost node of liquid column nor topmost node below column
+				was_checked = false;
+				was_pushed = false;
+			} else if (is_liquid) {
+				// This is the topmost node in the column
+				bool is_pushed = false;
+				if (f.liquid_type == LIQUID_FLOWING ||
+						isLiquidHorizontallyFlowable(x, y, z)) {
+					m_liquid_queue->push_back(m_rel_block_pos + v3s16(x, y, z));
+					is_pushed = true;
+				}
+				// Remember waschecked and waspushed to avoid repeated
+				// checks/pushes in case the column consists of only this node
+				was_checked = true;
+				was_pushed = is_pushed;
+			} else {
+				// This is the topmost node below a liquid column
+				if (!was_pushed && (f.floodable ||
+						(!was_checked && isLiquidHorizontallyFlowable(x, y + 1, z)))) {
+					// Activate the lowest node in the column which is one
+					// node above this one
+					m_liquid_queue->push_back(m_rel_block_pos + v3s16(x, y + 1, z));
+				}
 			}
-			// Remember waschecked and waspushed to avoid repeated
-			// checks/pushes in case the column consists of only this node
-			was_checked = true;
-			was_pushed = is_pushed;
-		} else {
-			// This is the topmost node below a liquid column
-			if (!was_pushed && (f.floodable ||
-					(!was_checked && isLiquidHorizontallyFlowable(x, y + 1, z)))) {
-				// Activate the lowest node in the column which is one
-				// node above this one
-				m_liquid_queue->push_back(m_rel_block_pos + v3s16(x, y + 1, z));
-			}
+
+			was_liquid = is_liquid;
+			was_ignore = is_ignore;
 		}
-
-		was_liquid = is_liquid;
-		was_ignore = is_ignore;
 	}
 
 	// Check the node below the current block

--- a/src/reflowscan.cpp
+++ b/src/reflowscan.cpp
@@ -118,6 +118,11 @@ void ReflowScan::scanColumn(int x, int z)
 		was_ignore = true;
 		was_liquid = false;
 	}
+	// we can out early if there's no liquid above
+	// and the current block is all air
+	if (!was_liquid && block->isAir())
+		return;
+
 	bool was_checked = false;
 	bool was_pushed = false;
 


### PR DESCRIPTION
After #15949/#15960 the reflow scanner is now the take a large percentage of loading time.
Most scenes have a lot of all-air blocks and we optimize by breaking the column scans early.

In my tests this given another 20% boost in loading times for large maps. (23600 blocks/s from 19000 blocks/s)

- Goal of the PR

Further improve map load speed

- If not a bug fix, why is this PR needed? What usecases does it solve?

Perf

## To do

This PR is Ready for Review.

## How to test

Large 'viewing_range' (1000) and 'max_block_generate_distance', 'max_block_send_distance' set accordingly (63) and emergequeue_limit_generate/diskonly set to something between 500 and 1000, `max_simultaneous_block_sends_per_client` set to 500 or more.
