### PR TITLE
Don't close Luanti when escape is pressed

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -66,14 +66,6 @@ local tabs = {
 }
 
 --------------------------------------------------------------------------------
-local function main_event_handler(tabview, event)
-	if event == "MenuQuit" then
-		core.close()
-	end
-	return true
-end
-
---------------------------------------------------------------------------------
 local function init_globals()
 	-- Init gamedata
 	gamedata.worldindex = 0
@@ -106,7 +98,6 @@ local function init_globals()
 	tv_main:add(tabs.content)
 	tv_main:add(tabs.about)
 
-	tv_main:set_global_event_handler(main_event_handler)
 	tv_main:set_fixed_size(false)
 
 	local last_tab = core.settings:get("maintab_LAST")


### PR DESCRIPTION
I think this is an antifeature and it's trivial to remove. Rationale:

* It's easy to accidentally close Luanti when you're escaping some dialogs via <kbd>Esc</kbd>.
* I don't expect <kbd>Esc</kbd> to close an application completely. I struggle to find another serious example of this.
* People can still use their platform-specific WM keybinds (e.g. <kbd>Alt</kbd> <kbd>F4</kbd>). Why have a redundant Luanti-specific one?

See also: https://ux.stackexchange.com/questions/103220/should-escape-immediately-close-an-application

This PR is ready for discussion.
