### PR TITLE
Improve some warning messages 

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -156,7 +156,8 @@ local function preprocess_craft(itemdef)
 	-- BEGIN Legacy stuff
 	if itemdef.inventory_image == nil and itemdef.image ~= nil then
 		core.log("deprecated", "The `image` field in craftitem definitions " ..
-			"is deprecated. Use `inventory_image` instead.")
+			"is deprecated. Use `inventory_image` instead. " ..
+			"Craftitem name: " .. itemdef.name)
 		itemdef.inventory_image = itemdef.image
 	end
 	-- END Legacy stuff
@@ -168,7 +169,8 @@ local function preprocess_tool(tooldef)
 	-- BEGIN Legacy stuff
 	if tooldef.inventory_image == nil and tooldef.image ~= nil then
 		core.log("deprecated", "The `image` field in tool definitions " ..
-			"is deprecated. Use `inventory_image` instead.")
+			"is deprecated. Use `inventory_image` instead. " ..
+			"Tool name: " .. tooldef.name)
 		tooldef.inventory_image = tooldef.image
 	end
 
@@ -185,7 +187,8 @@ local function preprocess_tool(tooldef)
 	    tooldef.dd_crumbliness ~= nil or
 	    tooldef.dd_cuttability ~= nil) then
 		core.log("deprecated", "Specifying tool capabilities directly in the tool " ..
-			"definition is deprecated. Use the `tool_capabilities` field instead.")
+			"definition is deprecated. Use the `tool_capabilities` field instead. " ..
+			"Tool name: " .. tooldef.name)
 		tooldef.tool_capabilities = {
 			full_punch_interval = tooldef.full_punch_interval,
 			basetime = tooldef.basetime,
@@ -269,7 +272,8 @@ function core.register_item(name, itemdef)
 	-- BEGIN Legacy stuff
 	if itemdef.cookresult_itemstring ~= nil and itemdef.cookresult_itemstring ~= "" then
 		core.log("deprecated", "The `cookresult_itemstring` item definition " ..
-			"field is deprecated. Use `core.register_craft` instead.")
+			"field is deprecated. Use `core.register_craft` instead. " ..
+			"Item name: " .. itemdef.name)
 		core.register_craft({
 			type="cooking",
 			output=itemdef.cookresult_itemstring,
@@ -279,7 +283,8 @@ function core.register_item(name, itemdef)
 	end
 	if itemdef.furnace_burntime ~= nil and itemdef.furnace_burntime >= 0 then
 		core.log("deprecated", "The `furnace_burntime` item definition " ..
-			"field is deprecated. Use `core.register_craft` instead.")
+			"field is deprecated. Use `core.register_craft` instead. " ..
+			"Item name: " .. itemdef.name)
 		core.register_craft({
 			type="fuel",
 			recipe=itemdef.name,

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -157,7 +157,7 @@ local function preprocess_craft(itemdef)
 	if itemdef.inventory_image == nil and itemdef.image ~= nil then
 		core.log("deprecated", "The `image` field in craftitem definitions " ..
 			"is deprecated. Use `inventory_image` instead. " ..
-			"Craftitem name: " .. itemdef.name)
+			"Craftitem name: " .. itemdef.name, 3)
 		itemdef.inventory_image = itemdef.image
 	end
 	-- END Legacy stuff
@@ -170,7 +170,7 @@ local function preprocess_tool(tooldef)
 	if tooldef.inventory_image == nil and tooldef.image ~= nil then
 		core.log("deprecated", "The `image` field in tool definitions " ..
 			"is deprecated. Use `inventory_image` instead. " ..
-			"Tool name: " .. tooldef.name)
+			"Tool name: " .. tooldef.name, 3)
 		tooldef.inventory_image = tooldef.image
 	end
 
@@ -188,7 +188,7 @@ local function preprocess_tool(tooldef)
 	    tooldef.dd_cuttability ~= nil) then
 		core.log("deprecated", "Specifying tool capabilities directly in the tool " ..
 			"definition is deprecated. Use the `tool_capabilities` field instead. " ..
-			"Tool name: " .. tooldef.name)
+			"Tool name: " .. tooldef.name, 3)
 		tooldef.tool_capabilities = {
 			full_punch_interval = tooldef.full_punch_interval,
 			basetime = tooldef.basetime,
@@ -273,7 +273,7 @@ function core.register_item(name, itemdef)
 	if itemdef.cookresult_itemstring ~= nil and itemdef.cookresult_itemstring ~= "" then
 		core.log("deprecated", "The `cookresult_itemstring` item definition " ..
 			"field is deprecated. Use `core.register_craft` instead. " ..
-			"Item name: " .. itemdef.name)
+			"Item name: " .. itemdef.name, 2)
 		core.register_craft({
 			type="cooking",
 			output=itemdef.cookresult_itemstring,
@@ -284,7 +284,7 @@ function core.register_item(name, itemdef)
 	if itemdef.furnace_burntime ~= nil and itemdef.furnace_burntime >= 0 then
 		core.log("deprecated", "The `furnace_burntime` item definition " ..
 			"field is deprecated. Use `core.register_craft` instead. " ..
-			"Item name: " .. itemdef.name)
+			"Item name: " .. itemdef.name, 2)
 		core.register_craft({
 			type="fuel",
 			recipe=itemdef.name,

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -364,7 +364,8 @@ int ModApiMainMenu::l_get_content_info(lua_State *L)
 		// being able to return type "unknown".
 		// TODO inspect call sites and make sure this is handled, then we can
 		// likely remove the warning.
-		warningstream << "Requested content info has type \"unknown\"" << std::endl;
+		warningstream << "Requested content info has type \"unknown\" "
+				<< "(at " << path << ")" << std::endl;
 	}
 
 	lua_newtable(L);

--- a/src/script/lua_api/l_util.cpp
+++ b/src/script/lua_api/l_util.cpp
@@ -54,7 +54,13 @@ int ModApiUtil::l_log(lua_State *L)
 		auto name = readParam<std::string_view>(L, 1);
 		text = readParam<std::string_view>(L, 2);
 		if (name == "deprecated") {
-			log_deprecated(L, text, 2);
+			// core.log("deprecated", message [, stack_level])
+			// Level 1 - immediate caller of core.log (probably engine code);
+			// Level 2 - caller of the function that called core.log, and so on
+			int stack_level = readParam<int>(L, 3, 2);
+			if (stack_level < 1)
+				throw LuaError("invalid stack level");
+			log_deprecated(L, text, stack_level);
 			return 0;
 		}
 		level = Logger::stringToLevel(name);


### PR DESCRIPTION
See https://github.com/luanti-org/luanti/pull/15950#issuecomment-2781527082, also deals with #15945 (at least the helpfulness part).

(I'm a bit wary of the stack levels - as said, they are error-prone: Someone introduces another function in the chain and they are wrong again. Someone refactors away a function and they are wrong. Someone changes a tail call into a non-tail-call and they are wrong. But for now they should work and this code isn't touched a lot. Also there are item names. [^1])

[^1]: A bit of a cleaner approach, now that I think about it, might be to have some sort of way to identify the public API boundary (by function reference equality), then look for that on the stack as a point of reference. But I don't want to overengineer this just yet.

## How to test

1. do all the bad things

```bash
mkdir mods/empty
```

```diff
diff --git a/games/devtest/mods/unittests/misc.lua b/games/devtest/mods/unittests/misc.lua
index 65dc3259e..4beea7f27 100644
--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -353,3 +353,14 @@ local function test_ipc_poll(cb)
        print("delta: " .. (core.get_us_time() - t0) .. "us")
 end
 unittests.register("test_ipc_poll", test_ipc_poll)
+
+core.register_craftitem("unittests:bad_item", {
+       image = "bad",
+       cookresult_itemstring = "unittests:item", -- bad
+       furnace_burntime = 42, -- bad
+})
+
+core.register_tool("unittests:bad_tool", {
+       image = "bad",
+       full_punch_interval = 42, -- bad
+})
```

2. get all the good warnings

```
2025-04-07 01:14:45: WARNING[Main]: Requested content info has type "unknown" (at /home/lars/luanti/mods/empty)
[...]
2025-04-07 01:14:46: WARNING[ServerStart]: The `image` field in craftitem definitions is deprecated. Use `inventory_image` instead. Craftitem name: unittests:bad_item (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:357)
2025-04-07 01:14:46: WARNING[ServerStart]: The `cookresult_itemstring` item definition field is deprecated. Use `core.register_craft` instead. Item name: unittests:bad_item (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:357)
2025-04-07 01:14:46: WARNING[ServerStart]: The `furnace_burntime` item definition field is deprecated. Use `core.register_craft` instead. Item name: unittests:bad_item (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:357)
2025-04-07 01:14:46: WARNING[ServerStart]: The `image` field in tool definitions is deprecated. Use `inventory_image` instead. Tool name: unittests:bad_tool (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:363)
2025-04-07 01:14:46: WARNING[ServerStart]: Specifying tool capabilities directly in the tool definition is deprecated. Use the `tool_capabilities` field instead. Tool name: unittests:bad_tool (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:363)