### PR TITLE
Optimize name-id-lookup for mapblock serialization

### DIFF
--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -291,8 +291,8 @@ static void getBlockNodeIdMapping(NameIdMapping *nimap, MapNode *nodes,
 		content_t id = CONTENT_IGNORE;
 
 		// Try to find an existing mapping
-		if (mapping.get(global_id) != 0xFFFF) {
-			id = mapping.get(global_id);
+		if (auto found = mapping.get(global_id); found != 0xFFFF) {
+			id = found;
 		} else {
 			// We have to assign a new mapping
 			id = id_counter++;

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -327,8 +327,8 @@ static void correctBlockNodeIds(const NameIdMapping *nimap, MapNode *nodes,
 	for (u32 i = 0; i < MapBlock::nodecount; i++) {
 		content_t local_id = nodes[i].getContent();
 
-		if (mapping_cache.get(local_id) != 0xFFFF) {
-			nodes[i].setContent(mapping_cache.get(local_id));
+		if (auto found = mapping_cache.get(local_id); found != 0xFFFF) {
+			nodes[i].setContent(found);
 			continue;
 		}
 


### PR DESCRIPTION
- Goal: Improve performance of mapblock de-/serialization.
- Commits should be self-explanatory.
- ~~Interesting side-node: It looks to me like loops over all nodes in a mapblock are completely rolled out. Idk if this is fine or not.~~ Edit: Oops, found the jmp now.

## To do

This PR is a Ready for Review.

## How to test

* `time luanti --server --recompress --worldname name_of_your_world`
* (For reproducibility, first do it once to make sure the blocks are all in newest format, and avoid differences due to caching of the db file.)
* Tested with a ca. 100MB block data db:
  * master: 
    * real	0m52,698s
user	0m43,924s
sys	0m2,004s
    * real	0m50,189s
user	0m44,164s
sys	0m1,665s
    * real	0m57,698s
user	0m50,291s
sys	0m1,936s
  * PR:
    * real	0m44,240s
       user	0m35,712s
       sys	0m1,894s
    * real	0m42,180s
user	0m36,517s
sys	0m1,686s
    * real	0m42,680s
user	0m37,303s
sys	0m1,793s