### PR TITLE
Fix off-by-one error for m_nearest_unsent_d plus an optimization

### DIFF
--- a/src/server/clientiface.h
+++ b/src/server/clientiface.h
@@ -393,16 +393,6 @@ private:
 	std::unordered_map<v3s16, float> m_blocks_sending;
 
 	/*
-		Blocks that have been modified since blocks were
-		sent to the client last (getNextBlocks()).
-		This is used to reset the unsent distance, so that
-		modified blocks are resent to the client.
-
-		List of block positions.
-	*/
-	std::unordered_set<v3s16> m_blocks_modified;
-
-	/*
 		Count of excess GotBlocks().
 		There is an excess amount because the client sometimes
 		gets a block so late that the server sends it again,


### PR DESCRIPTION
There is a off-on-one error when calculated the new nearest_unsent_d from modified blocks. In order to guarantee that those blocks are reconsidered we can start one block closer (as we might be looking from an angle).

Update: Actually it's off by two (sqrt(3) - as we might be looking towards a corner of a block)

What that means is that changed blocks are not transmitted to the client for while (up to 30s).
In the process I realize that we not need to materialize the set of modified block, they are only used to calculated the new nearest_unsent_d, and we can do that as we are notified of changed blocks).

- Goal of the PR

Fix the off-by-one error.

- How does the PR work?

Calculate nearest_unsent_d 2 blocks closer than the closest block changes, do that directly without materializing the 

- Does it resolve any reported issue?

No

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

## How to test

Use some way to make a distant change (like the rangedweapons mod), zoom to the point of change before the map is changed, notice that the change is not reflected from some time, but that it works correctly with this PR.

Or you can test with two clients. In any case the change needs to be far away to see this reliably... 500 or so.