### PR TITLE
Add setting to disable damage flash

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -161,6 +161,8 @@ local function load()
 			{ heading = fgettext_ne("Movement") },
 			"arm_inertia",
 			"view_bobbing_amount",
+			{ heading = fgettext_ne("Damage") },
+			"hurt_flash_enabled"
 		},
 	})
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -332,6 +332,11 @@ arm_inertia (Arm inertia) bool true
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
 view_bobbing_amount (View bobbing factor) float 1.0 0.0 7.9
 
+[**Damage]
+
+#    Flashing of the screen when taking damage.
+hurt_flash_enabled (Damage flash) bool true
+
 [**Camera]
 
 #    Field of view in degrees.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2616,8 +2616,10 @@ void Game::handleClientEvent_PlayerDamage(ClientEvent *event, CameraOrientation 
 			player->getCAO()->getProperties().hp_max : PLAYER_MAX_HP_DEFAULT;
 		f32 damage_ratio = event->player_damage.amount / hp_max;
 
-		runData.damage_flash += 95.0f + 64.f * damage_ratio;
-		runData.damage_flash = MYMIN(runData.damage_flash, 127.0f);
+		if (g_settings->getBool("hurt_flash_enabled")) {
+			runData.damage_flash += 95.0f + 64.f * damage_ratio;
+			runData.damage_flash = MYMIN(runData.damage_flash, 127.0f);
+		}
 
 		player->hurt_tilt_timer = 1.5f;
 		player->hurt_tilt_strength =

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -306,6 +306,7 @@ void set_default_settings()
 	settings->setDefault("show_entity_selectionbox", "false");
 	settings->setDefault("ambient_occlusion_gamma", "1.8");
 	settings->setDefault("arm_inertia", "true");
+	settings->setDefault("hurt_flash_enabled", "true");
 	settings->setDefault("show_nametag_backgrounds", "true");
 	settings->setDefault("show_block_bounds_radius_near", "4");
 	settings->setDefault("transparency_sorting_group_by_buffers", "true");


### PR DESCRIPTION
**Goal:** Add a new boolean setting for the client under Accessibility in a new section called Damage

Partial progress towards resolving https://github.com/luanti-org/luanti/issues/15805. The 'Damage' section is intended to also hold a damage tilt setting (and potentially a damage flash color setting) from the same issue.

## How to test
- Build and launch Luanti
- Open a new Development Test world with Enable Damage turned on
- Find a damage source (I used lava)
- Take damage; notice that the screen flashes red as usual
- Open the Settings menu and under Accessibility scroll to the bottom of the options
- Toggle off 'Damage flash' and hit enter or click Set
- Return to the game and take damage; the screen still tilts but does not flash red