### PR TITLE
[no squash] Fix for blocks sometimes not being updated on the client plus some RemoteClient improvements

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -47,6 +47,9 @@ struct MapEditEvent
 	MapNode n = CONTENT_AIR;
 	std::vector<v3s16> modified_blocks; // Represents a set
 	bool is_private_change = false;
+	// Setting low_priority to true allows the server
+	// to send this change to clients with some delay.
+	bool low_priority = false;
 
 	MapEditEvent() = default;
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -755,6 +755,7 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;
 			event.type = MEET_OTHER;
+			event.low_priority = true;
 			event.setModifiedBlocks(modified_blocks);
 			m_env->getMap().dispatchEvent(event);
 		}
@@ -1006,7 +1007,7 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 			}
 			case MEET_OTHER:
 				prof.add("MEET_OTHER", 1);
-				m_clients.markBlocksNotSent(event->modified_blocks);
+				m_clients.markBlocksNotSent(event->modified_blocks, event->low_priority);
 				break;
 			default:
 				prof.add("unknown", 1);
@@ -1022,7 +1023,7 @@ void Server::AsyncRunStep(float dtime, bool initial_step)
 			*/
 			for (const u16 far_player : far_players) {
 				if (RemoteClient *client = getClient(far_player))
-					client->SetBlocksNotSent(event->modified_blocks);
+					client->SetBlocksNotSent(event->modified_blocks, event->low_priority);
 			}
 
 			delete event;

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -429,7 +429,16 @@ void RemoteClient::SetBlockNotSent(v3s16 p)
 	// remove the block from sending and sent sets,
 	// and reset the scan loop if found
 	if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0) {
-		m_nearest_unsent_d = std::min(m_nearest_unsent_d, m_last_center.getDistanceFrom(p));
+		// Note that we do NOT use the euclidean distance here.
+		// getNextBlocks builds successive cube-surfaces in the send loop.
+		// This resets the distance to the maximum cube size that
+		// still guarantees that this block will be scanned again right away.
+		//
+		// Using m_last_center is OK, as a change in center
+		// will reset m_nearest_unsent_d to 0 anyway (see getNextBlocks).
+		p -= m_last_center;
+		s16 this_d = std::max({std::abs(p.X), std::abs(p.Y), std::abs(p.Z)});
+		m_nearest_unsent_d = std::min(m_nearest_unsent_d, this_d);
 	}
 }
 

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -422,30 +422,34 @@ void RemoteClient::SentBlock(v3s16 p)
 				" already in m_blocks_sending"<<std::endl;
 }
 
-void RemoteClient::SetBlockNotSent(v3s16 p)
+void RemoteClient::SetBlockNotSent(v3s16 p, bool low_priority)
 {
 	m_nothing_to_send_pause_timer = 0;
 
 	// remove the block from sending and sent sets,
 	// and reset the scan loop if found
 	if (m_blocks_sending.erase(p) + m_blocks_sent.erase(p) > 0) {
-		// Note that we do NOT use the euclidean distance here.
-		// getNextBlocks builds successive cube-surfaces in the send loop.
-		// This resets the distance to the maximum cube size that
-		// still guarantees that this block will be scanned again right away.
-		//
-		// Using m_last_center is OK, as a change in center
-		// will reset m_nearest_unsent_d to 0 anyway (see getNextBlocks).
-		p -= m_last_center;
-		s16 this_d = std::max({std::abs(p.X), std::abs(p.Y), std::abs(p.Z)});
-		m_nearest_unsent_d = std::min(m_nearest_unsent_d, this_d);
+		// If this is a low priority event, do not reset m_nearest_unsent_d.
+		// Instead, the send loop will get to the block in the next full loop iteration.
+		if (!low_priority) {
+			// Note that we do NOT use the euclidean distance here.
+			// getNextBlocks builds successive cube-surfaces in the send loop.
+			// This resets the distance to the maximum cube size that
+			// still guarantees that this block will be scanned again right away.
+			//
+			// Using m_last_center is OK, as a change in center
+			// will reset m_nearest_unsent_d to 0 anyway (see getNextBlocks).
+			p -= m_last_center;
+			s16 this_d = std::max({std::abs(p.X), std::abs(p.Y), std::abs(p.Z)});
+			m_nearest_unsent_d = std::min(m_nearest_unsent_d, this_d);
+		}
 	}
 }
 
-void RemoteClient::SetBlocksNotSent(const std::vector<v3s16> &blocks)
+void RemoteClient::SetBlocksNotSent(const std::vector<v3s16> &blocks, bool low_priority)
 {
 	for (v3s16 p : blocks) {
-		SetBlockNotSent(p);
+		SetBlockNotSent(p, low_priority);
 	}
 }
 
@@ -664,12 +668,12 @@ std::vector<session_t> ClientInterface::getClientIDs(ClientState min_state)
 	return reply;
 }
 
-void ClientInterface::markBlocksNotSent(const std::vector<v3s16> &positions)
+void ClientInterface::markBlocksNotSent(const std::vector<v3s16> &positions, bool low_priority)
 {
 	RecursiveMutexAutoLock clientslock(m_clients_mutex);
 	for (const auto &client : m_clients) {
 		if (client.second->getState() >= CS_Active)
-			client.second->SetBlocksNotSent(positions);
+			client.second->SetBlocksNotSent(positions, low_priority);
 	}
 }
 

--- a/src/server/clientiface.h
+++ b/src/server/clientiface.h
@@ -251,8 +251,8 @@ public:
 
 	void SentBlock(v3s16 p);
 
-	void SetBlockNotSent(v3s16 p);
-	void SetBlocksNotSent(const std::vector<v3s16> &blocks);
+	void SetBlockNotSent(v3s16 p, bool low_priority = false);
+	void SetBlocksNotSent(const std::vector<v3s16> &blocks, bool low_priority = false);
 
 	/**
 	 * tell client about this block being modified right now.
@@ -443,7 +443,7 @@ public:
 	std::vector<session_t> getClientIDs(ClientState min_state=CS_Active);
 
 	/* mark blocks as not sent on all active clients */
-	void markBlocksNotSent(const std::vector<v3s16> &positions);
+	void markBlocksNotSent(const std::vector<v3s16> &positions, bool low_priority = false);
 
 	/* verify is server user limit was reached */
 	bool isUserLimitReached();

--- a/src/server/clientiface.h
+++ b/src/server/clientiface.h
@@ -388,19 +388,8 @@ private:
 		- The size of this list is limited to some value
 		Block is added when it is sent with BLOCKDATA.
 		Block is removed when GOTBLOCKS is received.
-		Value is time from sending. (not used at the moment)
 	*/
-	std::unordered_map<v3s16, float> m_blocks_sending;
-
-	/*
-		Blocks that have been modified since blocks were
-		sent to the client last (getNextBlocks()).
-		This is used to reset the unsent distance, so that
-		modified blocks are resent to the client.
-
-		List of block positions.
-	*/
-	std::unordered_set<v3s16> m_blocks_modified;
+	std::unordered_set<v3s16> m_blocks_sending;
 
 	/*
 		Count of excess GotBlocks().

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -714,6 +714,7 @@ MapBlock *ServerMap::loadBlock(const std::string &blob, v3s16 p3d, bool save_aft
 		if (!modified_blocks.empty()) {
 			MapEditEvent event;
 			event.type = MEET_OTHER;
+			event.low_priority = true;
 			event.setModifiedBlocks(modified_blocks);
 			dispatchEvent(event);
 		}


### PR DESCRIPTION
Real fix for #16008...

It turns out that #10537 was based on the assumption that `d` in `RemoteClient::getNextBlock(...)` is an euclidean distance. From code it is clear that it is not. Instead `d` is the distance to the next cube-surface (which is then filtered with isBlockInSight to only blocks in a sphere).

Before this PR changes made at some distance to a client would not be reflected for a while (something up to 30s).

Unfortunately this slows down _initial_ block loading, especially with large viewing_rang'es, somewhat (about 10-20%), as the server resets the nearest_unsent_d to closer values than before. I think that is not avoidable in order to be correct. (Still much faster than before #10537, though)
To regain the performance, this marks liquid and light updates as low_priority, for these kind of evens the server loop is not reset - with that initial loading is even faster then before.

This PR also include some improvements and simplifications to the code. 

- Goal of the PR

Fix visual glitches.

- How does the PR work?

See description above.

- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

Related: #10537

## To do

This PR Ready for Review.

## How to test

This is easiest to test with two clients. Place player A to face in ordinal direction, let's say -Z. Place the player B into the lower-left of the visible cone of the player A, at some distance away. Now have player B mine a block. Notice that without this change it takes a while for the change to be reflected in player A's view, whereas with this PR it is near instance.

You can also test this with the ranged_weapons mod. Shot a rocket towards the a corner of your sight, and zoom into the location where the rocket would strike. Notice that without the PR the changed blocks will take a while to load.