### PR TITLE
Remove Irrlicht GUI gradients

### DIFF
--- a/irr/include/IGUIEnvironment.h
+++ b/irr/include/IGUIEnvironment.h
@@ -130,26 +130,18 @@ public:
 
 	//! Sets a new GUI Skin
 	/** You can use this to change the appearance of the whole GUI
-	Environment. You can set one of the built-in skins or implement your
-	own class derived from IGUISkin and enable it using this method.
-	To set for example the built-in Windows classic skin, use the following
-	code:
-	\code
-	gui::IGUISkin* newskin = environment->createSkin(gui::EGST_WINDOWS_CLASSIC);
-	environment->setSkin(newskin);
-	newskin->drop();
-	\endcode
+	Environment.
 	\param skin New skin to use.
 	*/
 	virtual void setSkin(IGUISkin *skin) = 0;
 
-	//! Creates a new GUI Skin based on a template.
+	//! Creates a new GUI Skin.
 	/** Use setSkin() to set the created skin.
 	\param type The type of the new skin.
 	\return Pointer to the created skin.
 	If you no longer need it, you should call IGUISkin::drop().
 	See IReferenceCounted::drop() for more information. */
-	virtual IGUISkin *createSkin(EGUI_SKIN_TYPE type) = 0;
+	virtual IGUISkin *createSkin() = 0;
 
 	//! Creates the image list from the given texture.
 	/** \param texture Texture to split into images

--- a/irr/include/IGUISkin.h
+++ b/irr/include/IGUISkin.h
@@ -17,42 +17,6 @@ class IGUIFont;
 class IGUISpriteBank;
 class IGUIElement;
 
-//! Enumeration of available default skins.
-/** To set one of the skins, use the following code, for example to set
-the Windows classic skin:
-\code
-gui::IGUISkin* newskin = environment->createSkin(gui::EGST_WINDOWS_CLASSIC);
-environment->setSkin(newskin);
-newskin->drop();
-\endcode
-*/
-enum EGUI_SKIN_TYPE
-{
-	//! Default windows look and feel
-	EGST_WINDOWS_CLASSIC = 0,
-
-	//! Like EGST_WINDOWS_CLASSIC, but with metallic shaded windows and buttons
-	EGST_WINDOWS_METALLIC,
-
-	//! Burning's skin
-	EGST_BURNING_SKIN,
-
-	//! An unknown skin, not serializable at present
-	EGST_UNKNOWN,
-
-	//! this value is not used, it only specifies the number of skin types
-	EGST_COUNT
-};
-
-//! Names for gui element types
-const c8 *const GUISkinTypeNames[EGST_COUNT + 1] = {
-		"windowsClassic",
-		"windowsMetallic",
-		"burning",
-		"unknown",
-		0,
-	};
-
 //! Enumeration for skin colors
 enum EGUI_DEFAULT_COLOR
 {
@@ -570,9 +534,6 @@ public:
 	If the pointer is null, no clipping will be performed. */
 	virtual void draw2DRectangle(IGUIElement *element, const video::SColor &color,
 			const core::rect<s32> &pos, const core::rect<s32> *clip = 0) = 0;
-
-	//! get the type of this skin
-	virtual EGUI_SKIN_TYPE getType() const { return EGST_UNKNOWN; }
 };
 
 } // end namespace gui

--- a/irr/src/CGUIEnvironment.cpp
+++ b/irr/src/CGUIEnvironment.cpp
@@ -52,7 +52,7 @@ CGUIEnvironment::CGUIEnvironment(io::IFileSystem *fs, video::IVideoDriver *drive
 
 	loadBuiltInFont();
 
-	IGUISkin *skin = createSkin(gui::EGST_WINDOWS_METALLIC);
+	IGUISkin *skin = createSkin();
 	setSkin(skin);
 	skin->drop();
 
@@ -584,13 +584,13 @@ void CGUIEnvironment::setSkin(IGUISkin *skin)
 		CurrentSkin->grab();
 }
 
-//! Creates a new GUI Skin based on a template.
+//! Creates a new GUI Skin.
 /** \return Returns a pointer to the created skin.
 If you no longer need the skin, you should call IGUISkin::drop().
 See IReferenceCounted::drop() for more information. */
-IGUISkin *CGUIEnvironment::createSkin(EGUI_SKIN_TYPE type)
+IGUISkin *CGUIEnvironment::createSkin()
 {
-	IGUISkin *skin = new CGUISkin(type, Driver);
+	IGUISkin *skin = new CGUISkin(Driver);
 
 	IGUIFont *builtinfont = getBuiltInFont();
 	IGUIFontBitmap *bitfont = 0;

--- a/irr/src/CGUIEnvironment.h
+++ b/irr/src/CGUIEnvironment.h
@@ -56,11 +56,11 @@ public:
 	//! Sets a new GUI Skin
 	void setSkin(IGUISkin *skin) override;
 
-	//! Creates a new GUI Skin based on a template.
+	//! Creates a new GUI Skin.
 	/** \return Returns a pointer to the created skin.
 	If you no longer need the skin, you should call IGUISkin::drop().
 	See IReferenceCounted::drop() for more information. */
-	IGUISkin *createSkin(EGUI_SKIN_TYPE type) override;
+	IGUISkin *createSkin() override;
 
 	//! Creates the image list from the given texture.
 	virtual IGUIImageList *createImageList(video::ITexture *texture,

--- a/irr/src/CGUISkin.cpp
+++ b/irr/src/CGUISkin.cpp
@@ -17,99 +17,50 @@ namespace irr
 namespace gui
 {
 
-CGUISkin::CGUISkin(EGUI_SKIN_TYPE type, video::IVideoDriver* driver)
-: SpriteBank(0), Driver(driver), Type(type)
+CGUISkin::CGUISkin(video::IVideoDriver* driver)
+: SpriteBank(0), Driver(driver)
 {
-	if ((Type == EGST_WINDOWS_CLASSIC) || (Type == EGST_WINDOWS_METALLIC))
-	{
-		Colors[EGDC_3D_DARK_SHADOW]     = video::SColor(101,50,50,50);
-		Colors[EGDC_3D_SHADOW]          = video::SColor(101,130,130,130);
-		Colors[EGDC_3D_FACE]            = video::SColor(220,100,100,100);
-		Colors[EGDC_3D_HIGH_LIGHT]      = video::SColor(101,255,255,255);
-		Colors[EGDC_3D_LIGHT]           = video::SColor(101,210,210,210);
-		Colors[EGDC_ACTIVE_BORDER]      = video::SColor(101,16,14,115);
-		Colors[EGDC_ACTIVE_CAPTION]     = video::SColor(255,255,255,255);
-		Colors[EGDC_APP_WORKSPACE]      = video::SColor(101,100,100,100);
-		Colors[EGDC_BUTTON_TEXT]        = video::SColor(240,10,10,10);
-		Colors[EGDC_GRAY_TEXT]          = video::SColor(240,130,130,130);
-		Colors[EGDC_HIGH_LIGHT]         = video::SColor(101,8,36,107);
-		Colors[EGDC_HIGH_LIGHT_TEXT]    = video::SColor(240,255,255,255);
-		Colors[EGDC_INACTIVE_BORDER]    = video::SColor(101,165,165,165);
-		Colors[EGDC_INACTIVE_CAPTION]   = video::SColor(255,30,30,30);
-		Colors[EGDC_TOOLTIP]            = video::SColor(200,0,0,0);
-		Colors[EGDC_TOOLTIP_BACKGROUND] = video::SColor(200,255,255,225);
-		Colors[EGDC_SCROLLBAR]          = video::SColor(101,230,230,230);
-		Colors[EGDC_WINDOW]             = video::SColor(101,255,255,255);
-		Colors[EGDC_WINDOW_SYMBOL]      = video::SColor(200,10,10,10);
-		Colors[EGDC_ICON]               = video::SColor(200,255,255,255);
-		Colors[EGDC_ICON_HIGH_LIGHT]    = video::SColor(200,8,36,107);
-		Colors[EGDC_GRAY_WINDOW_SYMBOL] = video::SColor(240,100,100,100);
-		Colors[EGDC_EDITABLE] 			= video::SColor(255,255,255,255);
-		Colors[EGDC_GRAY_EDITABLE]		= video::SColor(255,120,120,120);
-		Colors[EGDC_FOCUSED_EDITABLE]	= video::SColor(255,240,240,255);
+	Colors[EGDC_3D_DARK_SHADOW]     = video::SColor(101,50,50,50);
+	Colors[EGDC_3D_SHADOW]          = video::SColor(101,130,130,130);
+	Colors[EGDC_3D_FACE]            = video::SColor(185,85,85,85);
+	Colors[EGDC_3D_HIGH_LIGHT]      = video::SColor(101,255,255,255);
+	Colors[EGDC_3D_LIGHT]           = video::SColor(101,210,210,210);
+	Colors[EGDC_ACTIVE_BORDER]      = video::SColor(101,16,14,115);
+	Colors[EGDC_ACTIVE_CAPTION]     = video::SColor(255,255,255,255);
+	Colors[EGDC_APP_WORKSPACE]      = video::SColor(101,100,100,100);
+	Colors[EGDC_BUTTON_TEXT]        = video::SColor(240,10,10,10);
+	Colors[EGDC_GRAY_TEXT]          = video::SColor(240,130,130,130);
+	Colors[EGDC_HIGH_LIGHT]         = video::SColor(101,8,36,107);
+	Colors[EGDC_HIGH_LIGHT_TEXT]    = video::SColor(240,255,255,255);
+	Colors[EGDC_INACTIVE_BORDER]    = video::SColor(101,165,165,165);
+	Colors[EGDC_INACTIVE_CAPTION]   = video::SColor(255,30,30,30);
+	Colors[EGDC_TOOLTIP]            = video::SColor(200,0,0,0);
+	Colors[EGDC_TOOLTIP_BACKGROUND] = video::SColor(200,255,255,225);
+	Colors[EGDC_SCROLLBAR]          = video::SColor(101,230,230,230);
+	Colors[EGDC_WINDOW]             = video::SColor(101,255,255,255);
+	Colors[EGDC_WINDOW_SYMBOL]      = video::SColor(200,10,10,10);
+	Colors[EGDC_ICON]               = video::SColor(200,255,255,255);
+	Colors[EGDC_ICON_HIGH_LIGHT]    = video::SColor(200,8,36,107);
+	Colors[EGDC_GRAY_WINDOW_SYMBOL] = video::SColor(240,100,100,100);
+	Colors[EGDC_EDITABLE] 			= video::SColor(255,255,255,255);
+	Colors[EGDC_GRAY_EDITABLE]		= video::SColor(255,120,120,120);
+	Colors[EGDC_FOCUSED_EDITABLE]	= video::SColor(255,240,240,255);
 
 
-		Sizes[EGDS_SCROLLBAR_SIZE] = 14;
-		Sizes[EGDS_MENU_HEIGHT] = 30;
-		Sizes[EGDS_WINDOW_BUTTON_WIDTH] = 15;
-		Sizes[EGDS_CHECK_BOX_WIDTH] = 18;
-		Sizes[EGDS_MESSAGE_BOX_WIDTH] = 500;
-		Sizes[EGDS_MESSAGE_BOX_HEIGHT] = 200;
-		Sizes[EGDS_BUTTON_WIDTH] = 80;
-		Sizes[EGDS_BUTTON_HEIGHT] = 30;
+	Sizes[EGDS_SCROLLBAR_SIZE] = 14;
+	Sizes[EGDS_MENU_HEIGHT] = 30;
+	Sizes[EGDS_WINDOW_BUTTON_WIDTH] = 15;
+	Sizes[EGDS_CHECK_BOX_WIDTH] = 18;
+	Sizes[EGDS_MESSAGE_BOX_WIDTH] = 500;
+	Sizes[EGDS_MESSAGE_BOX_HEIGHT] = 200;
+	Sizes[EGDS_BUTTON_WIDTH] = 80;
+	Sizes[EGDS_BUTTON_HEIGHT] = 30;
 
-		Sizes[EGDS_TEXT_DISTANCE_X] = 2;
-		Sizes[EGDS_TEXT_DISTANCE_Y] = 0;
+	Sizes[EGDS_TEXT_DISTANCE_X] = 2;
+	Sizes[EGDS_TEXT_DISTANCE_Y] = 0;
 
-		Sizes[EGDS_TITLEBARTEXT_DISTANCE_X] = 2;
-		Sizes[EGDS_TITLEBARTEXT_DISTANCE_Y] = 0;
-	}
-	else
-	{
-		//0x80a6a8af
-		Colors[EGDC_3D_DARK_SHADOW] 	=	0x60767982;
-		//Colors[EGDC_3D_FACE]			=	0xc0c9ccd4;		// tab background
-		Colors[EGDC_3D_FACE]			=	0xc0cbd2d9;		// tab background
-		Colors[EGDC_3D_SHADOW]			=	0x50e4e8f1;		// tab background, and left-top highlight
-		Colors[EGDC_3D_HIGH_LIGHT]		=	0x40c7ccdc;
-		Colors[EGDC_3D_LIGHT]			=	0x802e313a;
-		Colors[EGDC_ACTIVE_BORDER]		=	0x80404040;		// window title
-		Colors[EGDC_ACTIVE_CAPTION] 	=	0xffd0d0d0;
-		Colors[EGDC_APP_WORKSPACE]		=	0xc0646464;		// unused
-		Colors[EGDC_BUTTON_TEXT]		=	0xd0161616;
-		Colors[EGDC_GRAY_TEXT]			=	0x3c141414;
-		Colors[EGDC_HIGH_LIGHT]			=	0x6c606060;
-		Colors[EGDC_HIGH_LIGHT_TEXT]	=	0xd0e0e0e0;
-		Colors[EGDC_INACTIVE_BORDER]	=	0xf0a5a5a5;
-		Colors[EGDC_INACTIVE_CAPTION]	=	0xffd2d2d2;
-		Colors[EGDC_TOOLTIP]			=	0xf00f2033;
-		Colors[EGDC_TOOLTIP_BACKGROUND]	= 	0xc0cbd2d9;
-		Colors[EGDC_SCROLLBAR]			= 	0xf0e0e0e0;
-		Colors[EGDC_WINDOW]				= 	0xf0f0f0f0;
-		Colors[EGDC_WINDOW_SYMBOL]		= 	0xd0161616;
-		Colors[EGDC_ICON]				= 	0xd0161616;
-		Colors[EGDC_ICON_HIGH_LIGHT]	= 	0xd0606060;
-		Colors[EGDC_GRAY_WINDOW_SYMBOL] = 	0x3c101010;
-		Colors[EGDC_EDITABLE] 			= 	0xf0ffffff;
-		Colors[EGDC_GRAY_EDITABLE]		= 	0xf0cccccc;
-		Colors[EGDC_FOCUSED_EDITABLE]	= 	0xf0fffff0;
-
-		Sizes[EGDS_SCROLLBAR_SIZE] = 14;
-		Sizes[EGDS_MENU_HEIGHT] = 48;
-		Sizes[EGDS_WINDOW_BUTTON_WIDTH] = 15;
-		Sizes[EGDS_CHECK_BOX_WIDTH] = 18;
-		Sizes[EGDS_MESSAGE_BOX_WIDTH] = 500;
-		Sizes[EGDS_MESSAGE_BOX_HEIGHT] = 200;
-		Sizes[EGDS_BUTTON_WIDTH] = 80;
-		Sizes[EGDS_BUTTON_HEIGHT] = 30;
-
-		Sizes[EGDS_TEXT_DISTANCE_X] = 3;
-		Sizes[EGDS_TEXT_DISTANCE_Y] = 2;
-
-		Sizes[EGDS_TITLEBARTEXT_DISTANCE_X] = 3;
-		Sizes[EGDS_TITLEBARTEXT_DISTANCE_Y] = 2;
-	}
-
+	Sizes[EGDS_TITLEBARTEXT_DISTANCE_X] = 2;
+	Sizes[EGDS_TITLEBARTEXT_DISTANCE_Y] = 0;
 	Sizes[EGDS_MESSAGE_BOX_GAP_SPACE] = 15;
 	Sizes[EGDS_MESSAGE_BOX_MIN_TEXT_WIDTH] = 0;
 	Sizes[EGDS_MESSAGE_BOX_MAX_TEXT_WIDTH] = 500;
@@ -157,8 +108,6 @@ CGUISkin::CGUISkin(EGUI_SKIN_TYPE type, video::IVideoDriver* driver)
 
 	for (u32 i=0; i<EGDF_COUNT; ++i)
 		Fonts[i] = 0;
-
-	UseGradient = (Type == EGST_WINDOWS_METALLIC) || (Type == EGST_BURNING_SKIN) ;
 }
 
 
@@ -320,18 +269,6 @@ void CGUISkin::drawColored3DButtonPaneStandard(IGUIElement* element,
 
 	core::rect<s32> rect = r;
 
-	if ( Type == EGST_BURNING_SKIN )
-	{
-		rect.UpperLeftCorner.X -= 1;
-		rect.UpperLeftCorner.Y -= 1;
-		rect.LowerRightCorner.X += 1;
-		rect.LowerRightCorner.Y += 1;
-		draw3DSunkenPane(element,
-					colors[ EGDC_WINDOW ].getInterpolated( 0xFFFFFFFF, 0.9f )
-					,false, true, rect, clip);
-		return;
-	}
-
 	Driver->draw2DRectangle(colors[EGDC_3D_DARK_SHADOW], rect, clip);
 
 	rect.LowerRightCorner.X -= 1;
@@ -345,16 +282,7 @@ void CGUISkin::drawColored3DButtonPaneStandard(IGUIElement* element,
 	rect.LowerRightCorner.X -= 1;
 	rect.LowerRightCorner.Y -= 1;
 
-	if (!UseGradient)
-	{
-		Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
-	}
-	else
-	{
-		const video::SColor c1 = colors[EGDC_3D_FACE];
-		const video::SColor c2 = c1.getInterpolated(colors[EGDC_3D_DARK_SHADOW], 0.4f);
-		Driver->draw2DRectangle(rect, c1, c1, c2, c2, clip);
-	}
+	Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
 }
 // END PATCH
 
@@ -394,16 +322,8 @@ void CGUISkin::drawColored3DButtonPanePressed(IGUIElement* element,
 	rect.UpperLeftCorner.X += 1;
 	rect.UpperLeftCorner.Y += 1;
 
-	if (!UseGradient)
-	{
-		Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
-	}
-	else
-	{
-		const video::SColor c1 = colors[EGDC_3D_FACE];
-		const video::SColor c2 = c1.getInterpolated(colors[EGDC_3D_DARK_SHADOW], 0.4f);
-		Driver->draw2DRectangle(rect, c1, c1, c2, c2, clip);
-	}
+	Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
+
 }
 // END PATCH
 
@@ -597,23 +517,7 @@ core::rect<s32> CGUISkin::drawColored3DWindowBackground(IGUIElement* element,
 
 	if ( !checkClientArea )
 	{
-		if (!UseGradient)
-		{
-			Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
-		}
-		else if ( Type == EGST_BURNING_SKIN )
-		{
-			const video::SColor c1 = colors[EGDC_WINDOW].getInterpolated ( 0xFFFFFFFF, 0.9f );
-			const video::SColor c2 = colors[EGDC_WINDOW].getInterpolated ( 0xFFFFFFFF, 0.8f );
-
-			Driver->draw2DRectangle(rect, c1, c1, c2, c2, clip);
-		}
-		else
-		{
-			const video::SColor c2 = colors[EGDC_3D_SHADOW];
-			const video::SColor c1 = colors[EGDC_3D_FACE];
-			Driver->draw2DRectangle(rect, c1, c1, c1, c2, clip);
-		}
+		Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
 	}
 
 	// title bar
@@ -632,19 +536,7 @@ core::rect<s32> CGUISkin::drawColored3DWindowBackground(IGUIElement* element,
 		else
 		{
 			// draw title bar
-			//if (!UseGradient)
-			//	Driver->draw2DRectangle(titleBarColor, rect, clip);
-			//else
-			if ( Type == EGST_BURNING_SKIN )
-			{
-				const video::SColor c = titleBarColor.getInterpolated( video::SColor(titleBarColor.getAlpha(),255,255,255), 0.8f);
-				Driver->draw2DRectangle(rect, titleBarColor, titleBarColor, c, c, clip);
-			}
-			else
-			{
-				const video::SColor c = titleBarColor.getInterpolated(video::SColor(titleBarColor.getAlpha(),0,0,0), 0.2f);
-				Driver->draw2DRectangle(rect, titleBarColor, c, titleBarColor, c, clip);
-			}
+			Driver->draw2DRectangle(titleBarColor, rect, clip);
 		}
 	}
 
@@ -674,13 +566,6 @@ void CGUISkin::drawColored3DMenuPane(IGUIElement* element,
 		colors = Colors;
 
 	core::rect<s32> rect = r;
-
-	if ( Type == EGST_BURNING_SKIN )
-	{
-		rect.UpperLeftCorner.Y -= 3;
-		draw3DButtonPaneStandard(element, rect, clip);
-		return;
-	}
 
 	// in this skin, this is exactly what non pressed buttons look like,
 	// so we could simply call
@@ -727,14 +612,7 @@ void CGUISkin::drawColored3DMenuPane(IGUIElement* element,
 	rect.LowerRightCorner.X -= 2;
 	rect.LowerRightCorner.Y -= 2;
 
-	if (!UseGradient)
-		Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
-	else
-	{
-		const video::SColor c1 = colors[EGDC_3D_FACE];
-		const video::SColor c2 = colors[EGDC_3D_SHADOW];
-		Driver->draw2DRectangle(rect, c1, c1, c2, c2, clip);
-	}
+	Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
 }
 // END PATCH
 
@@ -769,25 +647,7 @@ void CGUISkin::drawColored3DToolBar(IGUIElement* element,
 	rect = r;
 	rect.LowerRightCorner.Y -= 1;
 
-	if (!UseGradient)
-	{
-		Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
-	}
-	else
-	if ( Type == EGST_BURNING_SKIN )
-	{
-		const video::SColor c1 = 0xF0000000 | colors[EGDC_3D_FACE].color;
-		const video::SColor c2 = 0xF0000000 | colors[EGDC_3D_SHADOW].color;
-
-		rect.LowerRightCorner.Y += 1;
-		Driver->draw2DRectangle(rect, c1, c2, c1, c2, clip);
-	}
-	else
-	{
-		const video::SColor c1 = colors[EGDC_3D_FACE];
-		const video::SColor c2 = colors[EGDC_3D_SHADOW];
-		Driver->draw2DRectangle(rect, c1, c1, c2, c2, clip);
-	}
+	Driver->draw2DRectangle(colors[EGDC_3D_FACE], rect, clip);
 }
 // END PATCH
 
@@ -961,14 +821,7 @@ void CGUISkin::drawColored3DTabBody(IGUIElement* element, bool border, bool back
 			//tr.UpperLeftCorner.X += 1;
 		}
 
-		if (!UseGradient)
-			Driver->draw2DRectangle(colors[EGDC_3D_FACE], tr, clip);
-		else
-		{
-			video::SColor c1 = colors[EGDC_3D_FACE];
-			video::SColor c2 = colors[EGDC_3D_SHADOW];
-			Driver->draw2DRectangle(tr, c1, c1, c2, c2, clip);
-		}
+		Driver->draw2DRectangle(colors[EGDC_3D_FACE], tr, clip);
 	}
 }
 // END PATCH
@@ -1002,12 +855,6 @@ void CGUISkin::drawColoredIcon(IGUIElement* element, EGUI_DEFAULT_ICON icon,
 			colors[gray? EGDC_GRAY_WINDOW_SYMBOL : EGDC_WINDOW_SYMBOL], starttime, currenttime, loop, true);
 }
 // END PATCH
-
-
-EGUI_SKIN_TYPE CGUISkin::getType() const
-{
-	return Type;
-}
 
 
 //! draws a 2d rectangle.

--- a/irr/src/CGUISkin.h
+++ b/irr/src/CGUISkin.h
@@ -21,7 +21,7 @@ namespace gui
 	{
 	public:
 
-		CGUISkin(EGUI_SKIN_TYPE type, video::IVideoDriver* driver);
+		CGUISkin(video::IVideoDriver* driver);
 
 		//! destructor
 		virtual ~CGUISkin();
@@ -288,10 +288,6 @@ namespace gui
 		virtual void draw2DRectangle(IGUIElement* element, const video::SColor &color,
 				const core::rect<s32>& pos, const core::rect<s32>* clip = 0);
 
-
-		//! get the type of this skin
-		virtual EGUI_SKIN_TYPE getType() const;
-
 		//! gets the colors
 		virtual void getColors(video::SColor* colors); // ::PATCH:
 
@@ -305,9 +301,6 @@ namespace gui
 		IGUISpriteBank* SpriteBank;
 		core::stringw Texts[EGDT_COUNT];
 		video::IVideoDriver* Driver;
-		bool UseGradient;
-
-		EGUI_SKIN_TYPE Type;
 	};
 
 } // end namespace gui


### PR DESCRIPTION
This PR is related to #15826, see this discussion https://github.com/luanti-org/luanti/issues/6733#issuecomment-2677019295.
###### Disclaimer: I have close to zero experience with irrlicht, this is a first hands-on experience for me.

## To do/discuss

This PR is a Work in Progress. As far as I can tell the main concerns are:

- [x] missing contrast, could be mitigated with different brightness
- [ ] harder to recognize separate buttons in groups of buttons
- [x] main menu tab color
- [ ] harder to distinguish from text fields, needs to still look clickable
- [x] addition of colors
- [x] 9-slice



## Screenshots
![image](https://github.com/user-attachments/assets/37870a4b-bc35-49e6-a1fe-77c5039704a6)
RE: removing the faux 3d stuff - let's keep that in.
![image](https://github.com/user-attachments/assets/3ac73f75-499f-4d01-8c9e-05267a8464c9)
https://github.com/luanti-org/luanti/pull/15826#issuecomment-2690583172
![image](https://github.com/user-attachments/assets/61cfdd77-0dfd-477d-a382-aa19f4b84718)

