### PR TITLE
SDL: Send events for X1 and X2 mouse buttons

### DIFF
--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -766,8 +766,7 @@ bool CIrrDeviceSDL::run()
 			SDL_Keymod keymod = SDL_GetModState();
 
 			irrevent.EventType = irr::EET_MOUSE_INPUT_EVENT;
-
-			irrevent.MouseInput.Event = irr::EMIE_MOUSE_MOVED;
+			irrevent.MouseInput.Event = irr::EMIE_MOUSE_MOVED; // value to be ignored
 
 #ifdef _IRR_EMSCRIPTEN_PLATFORM_
 			// Handle mouselocking in emscripten in Windowed mode.


### PR DESCRIPTION
Someone reminded me about this on Discord.

Side note: once we fully switch to SDL(2/3) we should consider cleaning this up by using `SDL_MouseButtonEvent` directly for Irrlicht's mouse event.

- Goal of the PR
  Send events for the "X1" and "X2" mouse buttons.
- How does the PR work?
  It generates `KEY_XBUTTON1` and `KEY_XBUTTON2` events for the X1 and X2 keys. As noted in a comment, this is not clean, but since we are free to switch to SDL2 (hopefully) quite soon it would be better to not add too much boilerplate code at the moment.
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  No.

## To do

This PR is Ready for Review.

## How to test
```
keymap_forward = KEY_XBUTTON2
keymap_backward = KEY_XBUTTON1
```