### PR TITLE
Expand usable range of decoration fill_ratio to etc 2.3e-10.

### DIFF
--- a/src/mapgen/mg_decoration.cpp
+++ b/src/mapgen/mg_decoration.cpp
@@ -163,7 +163,7 @@ void Decoration::placeDeco(Mapgen *mg, u32 blockseed, v3s16 nmin, v3s16 nmax)
 				deco_count = deco_count_f;
 			} else if (deco_count_f > 0.0f) {
 				// For very low density calculate a chance for 1 decoration
-				if (ps.range(1000) <= deco_count_f * 1000.0f)
+				if (ps.next() <= deco_count_f * PcgRandom::RANDOM_RANGE)
 					deco_count = 1;
 			}
 		}


### PR DESCRIPTION
All decorations with `fill_ration` lower than `0.001` are in actual Luanti processed as `fill_ration = 0.001` (generated only if PcgRandom returns 0).

This PR expands this, so only `fill_ration` lower than `2.3e-10` starts to be processed as `fill_ration = 2.3e-10` (generated only if PcgRandom returns 0).
It is limited by `PcgRandom`.

## To do

This PR is a Ready for Review.

## How to test

Create a test node, register it as decoration + add register_lbm to print something if the node is found, and experiment with fill_ratio values.
```

local place_on = {"default:permafrost_with_stones",
              "default:dirt_with_snow",
              "default:dirt_with_grass",
              "default:dry_dirt_with_dry_grass",
              "default:sand",
              "default:desert_sand",
              "default:dirt_with_coniferous_litter",
              "default:dirt_with_rainforest_litter"}
local biomes = {"tundra","taiga","snowy_grassland","grassland","grassland_dunes","coniferous_forest", "deciduous_forest", "savanna","rainforest"}
local node_fill_ratio = 1e-7

core.register_node("testmod:fill_ratio", {
  description = S("Fill ratio"),
  tiles = {"default_stone.png"},
})
core.register_lbm({
  name = "testmod:fill_ratio",
  nodenames = {"testmod:fill_ratio"},
  run_at_every_load = true,
  action = function(pos, node)
    print("fill_ration node at "..core.pos_to_string(pos))
  end,
})
core.register_decoration({
  name = "testmod:fill_ratio",
  deco_type = "simple",
  decoration = "testmod:fill_ratio",
  sidelen = 4,
  place_on = place_on,
  y_min = -2, 
  y_max = 80, 
  fill_ratio = node_fill_ratio,
  param2 = 0,
  param2_max = 3,
  biomes = biomes,
})
```
