### PR TITLE
Fix cross-building by ensuring output path is set

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -591,9 +591,12 @@ if(USE_CURL)
 endif()
 
 
-# When cross-compiling assume the user doesn't want to run the executable anyway,
-# otherwise place it in <source dir>/bin/ since Luanti can only run from there.
-if(NOT CMAKE_CROSSCOMPILING)
+# When cross-compiling place the executable in <build dir>/bin so that multiple
+# targets can be built from the same source folder. Otherwise, place it in
+# <source dir>/bin/ since Luanti can only run from there.
+if(CMAKE_CROSSCOMPILING)
+	set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
+else()
 	set(EXECUTABLE_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin")
 endif()
 


### PR DESCRIPTION
No longer tries to write to `/minetest` while cross-building, which will likely fail with permission errors.

For more information, please see Debian Bug [#1102644](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1102644), partially quoted below:

> luanti fails to cross build from source, because it attempts to create /minetest and that happens to not work resulting in Permission denied as expected. The root cause for this is that EXECUTABLE_OUTPUT_PATH ends up being empty [...]

## To do

This PR is Ready for Review.

## How to test

Cross-build.
