### PR TITLE
Handle texture filtering sanely to avoid blurriness

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1883,7 +1883,7 @@ world_aligned_mode (World-aligned textures mode) enum enable disable,enable,forc
 #    World-aligned textures may be scaled to span several nodes. However,
 #    the server may not send the scale you want, especially if you use
 #    a specially-designed texture pack; with this option, the client tries
-#    to determine the scale automatically basing on the texture size.
+#    to determine the scale automatically based on the texture size.
 #    See also texture_min_size.
 #    Warning: This option is EXPERIMENTAL!
 autoscale_mode (Autoscaling mode) enum disable disable,enable,force
@@ -1895,7 +1895,7 @@ autoscale_mode (Autoscaling mode) enum disable disable,enable,force
 #    This setting is ONLY applied if any of the mentioned filters are enabled.
 #    This is also used as the base node texture size for world-aligned
 #    texture autoscaling.
-texture_min_size (Base texture size) int 64 1 32768
+texture_min_size (Base texture size) int 192 192 16384
 
 #    Side length of a cube of map blocks that the client will consider together
 #    when generating meshes.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -518,6 +518,15 @@ stripping out the file extension:
 
 Supported texture formats are PNG (`.png`), JPEG (`.jpg`) and Targa (`.tga`).
 
+Luanti generally uses nearest-neighbor upscaling for textures to preserve the crisp
+look of pixel art (low-res textures).
+Users can optionally enable bilinear and/or trilinear filtering. However, to avoid
+everything becoming blurry, textures smaller than 192px will either not be filtered,
+or will be upscaled to that minimum resolution first without filtering.
+
+This is subject to change to move more control to the Lua API, but you can rely on
+low-res textures not suddenly becoming filtered.
+
 Texture modifiers
 -----------------
 

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -281,12 +281,11 @@ void WieldMeshSceneNode::setExtruded(const std::string &imagename,
 		material.MaterialType = m_material_type;
 		material.MaterialTypeParam = 0.5f;
 		material.BackfaceCulling = true;
-		// Enable bi/trilinear filtering only for high resolution textures
-		bool bilinear_filter = dim.Width > 32 && m_bilinear_filter;
-		bool trilinear_filter = dim.Width > 32 && m_trilinear_filter;
+		// don't filter low-res textures, makes them look blurry
+		bool f_ok = std::min(dim.Width, dim.Height) >= TEXTURE_FILTER_MIN_SIZE;
 		material.forEachTexture([=] (auto &tex) {
-			setMaterialFilters(tex, bilinear_filter, trilinear_filter,
-					m_anisotropic_filter);
+			setMaterialFilters(tex, m_bilinear_filter && f_ok,
+				m_trilinear_filter && f_ok, m_anisotropic_filter);
 		});
 		// mipmaps cause "thin black line" artifacts
 		material.UseMipMaps = false;

--- a/src/constants.h
+++ b/src/constants.h
@@ -99,3 +99,9 @@
 #define SCREENSHOT_MAX_SERIAL_TRIES 1000
 
 #define TTF_DEFAULT_FONT_SIZE (16)
+
+// Minimum texture size enforced/checked for enabling linear filtering
+// This serves as the minimum for `texture_min_size`.
+// The intent is to ensure that the rendering doesn't turn terribly blurry
+// when filtering is enabled.
+#define TEXTURE_FILTER_MIN_SIZE 192U

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -246,7 +246,7 @@ void set_default_settings()
 	settings->setDefault("undersampling", "1");
 	settings->setDefault("world_aligned_mode", "enable");
 	settings->setDefault("autoscale_mode", "disable");
-	settings->setDefault("texture_min_size", "64");
+	settings->setDefault("texture_min_size", std::to_string(TEXTURE_FILTER_MIN_SIZE));
 	settings->setDefault("enable_fog", "true");
 	settings->setDefault("fog_start", "0.4");
 	settings->setDefault("3d_mode", "none");

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -272,7 +272,8 @@ void TextureSettings::readSettings()
 	connected_glass                = g_settings->getBool("connected_glass");
 	translucent_liquids            = g_settings->getBool("translucent_liquids");
 	enable_minimap                 = g_settings->getBool("enable_minimap");
-	node_texture_size              = std::max<u16>(g_settings->getU16("texture_min_size"), 1);
+	node_texture_size              = rangelim(g_settings->getU16("texture_min_size"),
+		TEXTURE_FILTER_MIN_SIZE, 16384);
 	std::string leaves_style_str   = g_settings->get("leaves_style");
 	std::string world_aligned_mode_str = g_settings->get("world_aligned_mode");
 	std::string autoscale_mode_str = g_settings->get("autoscale_mode");


### PR DESCRIPTION
tl;dr enabling "bilinear filter" or "trilinear filter" is no longer an automatic blurry knob

fixes #15604 as proposed
relates to #13108

## To do

This PR is Ready for Review.

## How to test

1. test various settings, texture sizes/packs, mods, ...
2. confirm everything looks nice
