### PR TITLE
[no squash] Rewrite shader system a bunch

### DIFF
--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -126,7 +126,7 @@ bool ClientLauncher::run(GameStartData &start_data, const Settings &cmd_args)
 	// This is only global so it can be used by RenderingEngine::draw_load_screen().
 	assert(!g_menucloudsmgr && !g_menuclouds);
 	std::unique_ptr<IWritableShaderSource> ssrc(createShaderSource());
-	ssrc->addShaderConstantSetterFactory(new FogShaderConstantSetterFactory());
+	ssrc->addShaderUniformSetterFactory(new FogShaderUniformSetterFactory());
 	g_menucloudsmgr = m_rendering_engine->get_scene_manager()->createNewSceneManager();
 	g_menuclouds = new Clouds(g_menucloudsmgr, ssrc.get(), -1, rand());
 	g_menuclouds->setHeight(100.0f);

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -67,14 +67,14 @@ void FpsControl::limit(IrrlichtDevice *device, f32 *dtime)
 	last_time = time;
 }
 
-class FogShaderConstantSetter : public IShaderConstantSetter
+class FogShaderUniformSetter : public IShaderUniformSetter
 {
 	CachedPixelShaderSetting<float, 4> m_fog_color{"fogColor"};
 	CachedPixelShaderSetting<float> m_fog_distance{"fogDistance"};
 	CachedPixelShaderSetting<float> m_fog_shading_parameter{"fogShadingParameter"};
 
 public:
-	void onSetConstants(video::IMaterialRendererServices *services) override
+	void onSetUniforms(video::IMaterialRendererServices *services) override
 	{
 		auto *driver = services->getVideoDriver();
 		assert(driver);
@@ -101,9 +101,9 @@ public:
 	}
 };
 
-IShaderConstantSetter *FogShaderConstantSetterFactory::create()
+IShaderUniformSetter *FogShaderUniformSetterFactory::create()
 {
-	return new FogShaderConstantSetter();
+	return new FogShaderUniformSetter();
 }
 
 /* Other helpers */

--- a/src/client/renderingengine.h
+++ b/src/client/renderingengine.h
@@ -54,11 +54,11 @@ struct FpsControl {
 };
 
 // Populates fogColor, fogDistance, fogShadingParameter with values from Irrlicht
-class FogShaderConstantSetterFactory : public IShaderConstantSetterFactory
+class FogShaderUniformSetterFactory : public IShaderUniformSetterFactory
 {
 public:
-	FogShaderConstantSetterFactory() {};
-	virtual IShaderConstantSetter *create();
+	FogShaderUniformSetterFactory() {};
+	virtual IShaderUniformSetter *create();
 };
 
 /* Rendering engine class */

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -28,17 +28,6 @@
 std::string getShaderPath(const std::string &name_of_shader,
 		const std::string &filename);
 
-struct ShaderInfo {
-	std::string name = "";
-	video::E_MATERIAL_TYPE base_material = video::EMT_SOLID;
-	video::E_MATERIAL_TYPE material = video::EMT_SOLID;
-	NodeDrawType drawtype = NDT_NORMAL;
-	MaterialType material_type = TILE_MATERIAL_BASIC;
-
-	ShaderInfo() = default;
-	virtual ~ShaderInfo() = default;
-};
-
 /*
 	Abstraction for pushing constants (or what we pretend is) into
 	shaders. These end up as `#define` prepended to the shader source.
@@ -218,7 +207,18 @@ using CachedStructPixelShaderSetting = CachedStructShaderSetting<T, count, cache
 
 	A "shader" could more precisely be called a "shader material" and comprises
 	a vertex, fragment and optional geometry shader.
+	It is uniquely identified by a name, base material and the input constants.
 */
+
+struct ShaderInfo {
+	std::string name;
+	video::E_MATERIAL_TYPE base_material = video::EMT_SOLID;
+	// Material ID the shader has received from Irrlicht
+	video::E_MATERIAL_TYPE material = video::EMT_SOLID;
+	// Input constants
+	ShaderConstants input_constants;
+};
+
 class IShaderSource {
 public:
 	IShaderSource() = default;
@@ -229,19 +229,38 @@ public:
 	 *
 	 * Use this to get the material ID to plug into `video::SMaterial`.
 	 */
-	virtual ShaderInfo getShaderInfo(u32 id) = 0;
-
-	/// @brief Generates or gets a shader suitable for nodes and entities
-	virtual u32 getShader(const std::string &name,
-		MaterialType material_type, NodeDrawType drawtype = NDT_NORMAL) = 0;
+	virtual const ShaderInfo &getShaderInfo(u32 id) = 0;
 
 	/**
-	 * Generates or gets a shader for general use.
+	 * Generates or gets a shader.
+	 *
+	 * Note that the input constants are not for passing the entire world into
+	 * the shader. Use `IShaderConstantSetter` to handle user settings.
 	 * @param name name of the shader (directory on disk)
+	 * @param input_const primary key constants for this shader
+	 * @param base_mat base material to use
+	 * @return shader ID
+	 * @note `base_material` only controls alpha behavior
+	 */
+	virtual u32 getShader(const std::string &name,
+		const ShaderConstants &input_const, video::E_MATERIAL_TYPE base_mat) = 0;
+
+	/// @brief Helper: Generates or gets a shader suitable for nodes and entities
+	u32 getShader(const std::string &name,
+		MaterialType material_type, NodeDrawType drawtype = NDT_NORMAL);
+
+	/**
+	 * Helper: Generates or gets a shader for common, general use.
+	 * @param name name of the shader
 	 * @param blendAlpha enable alpha blending for this material?
 	 * @return shader ID
 	 */
-	virtual u32 getShaderRaw(const std::string &name, bool blendAlpha = false) = 0;
+	inline u32 getShaderRaw(const std::string &name, bool blendAlpha = false)
+	{
+		auto base_mat = blendAlpha ? video::EMT_TRANSPARENT_ALPHA_CHANNEL :
+			video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF;
+		return getShader(name, ShaderConstants(), base_mat);
+	}
 };
 
 class IWritableShaderSource : public IShaderSource {

--- a/src/client/shader.h
+++ b/src/client/shader.h
@@ -40,7 +40,7 @@ struct ShaderInfo {
 };
 
 /*
-	Setter of constants for shaders
+	Abstraction for updating uniforms used by shaders
 */
 
 namespace irr::video {
@@ -48,19 +48,19 @@ namespace irr::video {
 }
 
 
-class IShaderConstantSetter {
+class IShaderUniformSetter {
 public:
-	virtual ~IShaderConstantSetter() = default;
-	virtual void onSetConstants(video::IMaterialRendererServices *services) = 0;
+	virtual ~IShaderUniformSetter() = default;
+	virtual void onSetUniforms(video::IMaterialRendererServices *services) = 0;
 	virtual void onSetMaterial(const video::SMaterial& material)
 	{ }
 };
 
 
-class IShaderConstantSetterFactory {
+class IShaderUniformSetterFactory {
 public:
-	virtual ~IShaderConstantSetterFactory() = default;
-	virtual IShaderConstantSetter* create() = 0;
+	virtual ~IShaderUniformSetterFactory() = default;
+	virtual IShaderUniformSetter* create() = 0;
 };
 
 
@@ -236,7 +236,7 @@ public:
 	virtual void rebuildShaders()=0;
 
 	/// @note Takes ownership of @p setter.
-	virtual void addShaderConstantSetterFactory(IShaderConstantSetterFactory *setter) = 0;
+	virtual void addShaderUniformSetterFactory(IShaderUniformSetterFactory *setter) = 0;
 };
 
 IWritableShaderSource *createShaderSource();

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -514,6 +514,9 @@ void ShadowRenderer::mixShadowsQuad()
  * Shaders system with custom IShaderConstantSetCallBack without messing up the
  * code too much. If anyone knows how to integrate this with the standard MT
  * shaders, please feel free to change it.
+ *
+ * TODO: as of now (2025) it should be possible to hook these up to the normal
+ * shader system.
  */
 
 void ShadowRenderer::createShaders()

--- a/src/client/shadows/dynamicshadowsrender.cpp
+++ b/src/client/shadows/dynamicshadowsrender.cpp
@@ -107,7 +107,7 @@ void ShadowRenderer::disable()
 void ShadowRenderer::preInit(IWritableShaderSource *shsrc)
 {
 	if (g_settings->getBool("enable_dynamic_shadows")) {
-		shsrc->addShaderConstantSetterFactory(new ShadowConstantSetterFactory());
+		shsrc->addShaderUniformSetterFactory(new ShadowUniformSetterFactory());
 	}
 }
 

--- a/src/client/shadows/shadowsshadercallbacks.cpp
+++ b/src/client/shadows/shadowsshadercallbacks.cpp
@@ -5,7 +5,7 @@
 #include "client/shadows/shadowsshadercallbacks.h"
 #include "client/renderingengine.h"
 
-void ShadowConstantSetter::onSetConstants(video::IMaterialRendererServices *services)
+void ShadowUniformSetter::onSetUniforms(video::IMaterialRendererServices *services)
 {
 	auto *shadow = RenderingEngine::get_shadow_renderer();
 	if (!shadow)

--- a/src/client/shadows/shadowsshadercallbacks.h
+++ b/src/client/shadows/shadowsshadercallbacks.h
@@ -9,7 +9,7 @@
 
 // Used by main game rendering
 
-class ShadowConstantSetter : public IShaderConstantSetter
+class ShadowUniformSetter : public IShaderUniformSetter
 {
 	CachedPixelShaderSetting<f32, 16> m_shadow_view_proj{"m_ShadowViewProj"};
 	CachedPixelShaderSetting<f32, 3> m_light_direction{"v_LightDirection"};
@@ -33,17 +33,17 @@ class ShadowConstantSetter : public IShaderConstantSetter
 	CachedPixelShaderSetting<f32> m_perspective_zbias_pixel{"zPerspectiveBias"};
 
 public:
-	ShadowConstantSetter() = default;
-	~ShadowConstantSetter() = default;
+	ShadowUniformSetter() = default;
+	~ShadowUniformSetter() = default;
 
-	virtual void onSetConstants(video::IMaterialRendererServices *services) override;
+	virtual void onSetUniforms(video::IMaterialRendererServices *services) override;
 };
 
-class ShadowConstantSetterFactory : public IShaderConstantSetterFactory
+class ShadowUniformSetterFactory : public IShaderUniformSetterFactory
 {
 public:
-	virtual IShaderConstantSetter *create() {
-		return new ShadowConstantSetter();
+	virtual IShaderUniformSetter *create() {
+		return new ShadowUniformSetter();
 	}
 };
 


### PR DESCRIPTION
**context / what does this do?**
`IShaderSource` was designed with the idea that if you want a shader, you must want it for a node. So it depends heavily on being given a tile material and the node drawtype.
This doesn't make sense and led to bad code (see a6293b9861b7e9ab8bb6ce91663f363970ecc816 or [this](https://github.com/luanti-org/luanti/blob/0695541bf59b305cc6661deb5d57a30e92cb9c6c/src/client/shadows/dynamicshadowsrender.cpp#L511-L517)).
With this PR you have a cleaner interface, with which you can easily generate shaders with arbitrary constants.

**why do we want this?**
basically for #15968
If we introduce array textures it will be used selectively and we will need to handle this in the shader code (so it needs to be passed through to it).
Now we could introduce more workarounds to allow that, but with this PR there's a clean API instead.

## To do

This PR is Ready for Review.

## How to test

1. use client as usual
2. everything should work
