### PR TITLE
Safe `require` for module loading

### DIFF
--- a/builtin/common/safe_require.lua
+++ b/builtin/common/safe_require.lua
@@ -1,0 +1,101 @@
+-- Safe require with a custom loader
+
+local is_main_mod_env = INIT == "game"
+
+-- If mod security is disabled, there may be an existing package table.
+package = package or {}
+package.loaders = package.loaders or {}
+package.loaded = {} -- [module_name] = module
+
+local function mod_loader(module_name)
+	local parts = module_name:split(".")
+	local modname = parts[1]
+	local modpath = core.get_modpath(modname)
+	if not modpath then
+		return "no mod called " .. modname
+	end
+	if is_main_mod_env and (modname ~= core.get_current_modname() and package.loaded[modname] == nil) then
+		-- loadMod() in C++ always sets package.loaded[modname].
+		-- If it has not been set, it has not been loaded yet.
+		-- This does not apply to async / emerge envs, where package.loaded starts out empty,
+		-- and we might still want to require some pure library mods.
+		return "missing dependency on mod " .. modname .. " in mod.conf"
+	end
+	local base_path = table.concat({modpath, unpack(parts, 2)}, "/")
+	local suffixes = {"/init.lua"}
+	if #parts >= 2 then -- also try modpath/.../module.lua
+		table.insert(suffixes, ".lua")
+	end
+	local errors = {}
+	for _, suffix in ipairs(suffixes) do
+		local file_path = base_path .. suffix
+		local file, err = io.open(file_path, "r")
+		if file then
+			local contents, read_err = file:read("*a")
+			file:close()
+			if not contents then
+				return read_err
+			end
+			if contents:sub(1, 1) == "#" then
+				-- skip shebang, keep line ending
+				--- c.f. ScriptApiSecurity::safeLoadFileContent()
+				contents = contents:match("^[^\r\n]+(.*)")
+			end
+			local chunk, load_err = loadstring(contents, "@" .. file_path)
+			-- If loading the file succeeded, return the chunk as module loader;
+			-- if loading the *existing* file failed, return the error,
+			-- don't silence syntax errors by trying other files
+			-- (this is why we prefer not to use loadfile() here: it conflates the two kinds of errors)
+			return chunk or load_err
+		else
+			table.insert(errors, err)
+		end
+	end
+	return table.concat(errors, "\n")
+end
+
+table.insert(package.loaders, 1, mod_loader)
+
+local function is_valid_module_name(module_name)
+	return module_name:find("^[A-Za-z0-9_%.]+$") and
+			module_name:find("%.%.") == nil and
+			module_name:sub(1, 1) ~= "." and
+			module_name:sub(-1) ~= "."
+end
+
+local loading = {} -- unique object to mark module as loading
+
+function require(module_name)
+	assert(is_valid_module_name(module_name),
+			"module names must consist of alphanumeric names separated by dots")
+	-- c.f. ll_require() in loadlib.c (PUC Lua)
+	do
+		local module = package.loaded[module_name]
+		if module == loading then
+			error("failed to load module '" .. module_name .. "': cyclic require()")
+		end
+		if module ~= nil then
+			return module
+		end
+	end
+
+	local errors = {}
+	for _, loader in ipairs(package.loaders) do
+		local res = loader(module_name)
+		if type(res) == "function" then
+			package.loaded[module_name] = loading
+			local module = res()
+			if module == nil then
+				module = true
+			end
+			package.loaded[module_name] = module
+			return module
+		end
+		-- Loaders MUST return a function, string or nil per the reference manual.
+		-- It is useful to produce a proper error message on invalid types:
+		-- A loader may mistakenly be directly returning a module table.
+		assert(type(res) == "string" or res == nil, "loaders must return function, string or nil")
+		table.insert(errors, res)
+	end
+	error("failed to load module '" .. module_name .. "':\n" .. table.concat(errors, '\n'))
+end

--- a/builtin/init.lua
+++ b/builtin/init.lua
@@ -50,6 +50,7 @@ dofile(commonpath .. "serialize.lua")
 dofile(commonpath .. "misc_helpers.lua")
 
 if INIT == "game" then
+	dofile(commonpath .. "safe_require.lua")
 	dofile(scriptdir .. "game" .. DIR_DELIM .. "init.lua")
 	assert(not core.get_http_api)
 elseif INIT == "mainmenu" then
@@ -73,6 +74,7 @@ elseif INIT == "mainmenu" then
 elseif INIT == "async"  then
 	dofile(asyncpath .. "mainmenu.lua")
 elseif INIT == "async_game" then
+	dofile(commonpath .. "safe_require.lua")
 	dofile(commonpath .. "metatable.lua")
 	dofile(asyncpath .. "game.lua")
 elseif INIT == "client" then
@@ -82,6 +84,7 @@ elseif INIT == "sscsm" and core.get_current_modname() == "*client_builtin*" then
 elseif INIT == "sscsm" and core.get_current_modname() == "*server_builtin*" then
 	dofile(scriptdir .. "sscsm_server" .. DIR_DELIM .. "init.lua")
 elseif INIT == "emerge" then
+	dofile(commonpath .. "safe_require.lua")
 	dofile(scriptdir .. "emerge" .. DIR_DELIM .. "init.lua")
 elseif INIT == "pause_menu" then
 	dofile(scriptdir .. "pause_menu" .. DIR_DELIM .. "init.lua")

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -365,6 +365,70 @@ The main Lua script. Running this script should register everything it
 wants to register. Subsequent execution depends on Luanti calling the
 registered callbacks.
 
+#### Loading additional files
+
+The old way to load additional Lua files was to use `dofile` with manually constructed paths,
+making sure to run files in order of dependencies, e.g.
+
+* `mymod/init.lua`:
+  ```lua
+  mymod = {}
+  local modpath = core.get_modpath("mymod") -- could also use core.get_current_modname()
+  dofile(modpath .. "/utils.lua")
+  dofile(modpath .. "/content.lua")
+  ```
+* `mymod/utils.lua`:
+  ```lua
+  local utils = {}
+  mymod.utils = utils
+  function utils.frobnicate(...) ... end
+  ```
+* `mymod/content.lua`:
+  ```lua
+  local utils = mymod.utils -- "module" dependency
+  utils.frobnicate(...)
+  ```
+
+This has several drawbacks; Lua offers `require` as a better alternative,
+which used to not be available in Luanti for security reasons.
+As of version 5.18.0, Luanti provides its own version of `require`:
+
+* `require("mymod")` gives you whatever `init.lua` of `mymod` returns.
+* `require("mod.foo.bar")` tries to load `<mod_dir>/foo/bar/init.lua`, then `<mod_dir>/foo/bar.lua`.
+* You must declare a dependency on all mods from which you require modules in `mod.conf`
+  (excepting of course the mod itself).
+* `require("math")` looks for a mod named `math`; it does *not* give you Lua's built-in `math` library.
+* `require` also works in async and emerge environments.
+  Each thread gets its own, initially empty `package` table; loaded modules do not transfer.
+* For insecure environments, `ie.require` is Lua's `require` as-is.
+* If mod security is disabled, `require` falls back to Lua's built-in loaders,
+  but Luanti's loader still takes precedence.
+
+The behavior of `require` is customizable via the `package` table:
+`package.loaders` is a list of loaders which are tried in order.
+A loader is a `function(module_name)` which returns `nil` to fail silently,
+a string explaining why it couldn't load the module,
+or a function that when called returns the module.
+The default loader behaves as described above.
+
+Using `require`, the above example could now be written as
+
+* `mymod/init.lua`:
+  ```lua
+  require("mymod.content")
+  ```
+* `mymod/utils.lua`:
+  ```lua
+  local utils = {}
+  function utils.frobnicate(...) ... end
+  return utils
+  ```
+* `mymod/content.lua`:
+  ```lua
+  local utils = require("mymod.utils") -- "module" dependency
+  utils.frobnicate(...)
+  ```
+
 ### `textures`, `sounds`, `media`, `models`, `locale`, `fonts`
 
 Media files (textures, sounds, whatever) that will be transferred to the

--- a/games/devtest/.luacheckrc
+++ b/games/devtest/.luacheckrc
@@ -32,8 +32,9 @@ read_globals = {
 	"PcgRandom",
 
 	string = {fields = {"split", "trim"}},
-	table  = {fields = {"copy", "getn", "indexof", "insert_all", "key_value_swap"}},
-	math   = {fields = {"hypot", "round"}},
+	table = {fields = {"copy", "getn", "indexof", "insert_all", "key_value_swap"}},
+	math = {fields = {"hypot", "round"}},
+	package = {fields = {"loaders"}},
 }
 
 globals = {

--- a/games/devtest/mods/unittests/init.lua
+++ b/games/devtest/mods/unittests/init.lua
@@ -247,3 +247,10 @@ else
 		end,
 	})
 end
+
+local t = {}
+unittests.register("test_mod_require", function()
+	-- Requiring a mod should work and return the API table returned by init.lua
+	assert(require("unittests") == t)
+end)
+return t

--- a/games/devtest/mods/unittests/inside_async_env.lua
+++ b/games/devtest/mods/unittests/inside_async_env.lua
@@ -12,6 +12,7 @@ local function do_tests()
 	assert(not core.set_node)
 	assert(not core.object_refs)
 	-- stuff that should be here
+	assert(require("unittests.require.foo") == "foo")
 	assert(ItemStack)
 	local meta = ItemStack():get_meta()
 	assert(type(meta) == "userdata")

--- a/games/devtest/mods/unittests/inside_mapgen_env.lua
+++ b/games/devtest/mods/unittests/inside_mapgen_env.lua
@@ -6,6 +6,7 @@ local function do_tests()
 	assert(not core.get_player_by_name)
 	assert(not core.object_refs)
 	-- stuff that should be here
+	assert(require("unittests.require.foo") == "foo")
 	assert(core.register_on_generated)
 	assert(core.get_node)
 	assert(core.spawn_tree)

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -385,8 +385,6 @@ local function test_sandbox()
 		core.log("warning", "Lua sandbox disabled, skipping test")
 		return
 	end
-	-- this would point to _G but we have it unset
-	assert(package.loaded == nil)
 	-- string metatable must match global string table
 	assert(rawequal(getmetatable("").__index, string))
 	-- (some) entirely dangerous functions
@@ -408,3 +406,33 @@ local function test_str_pack_unpack()
 	assert(a == 42.3 and b == -384)
 end
 unittests.register("test_str_pack_unpack", test_str_pack_unpack)
+
+unittests.register("test_require", function()
+	-- Requiring modules within a mod should work as expected
+	assert(require("unittests.require.foo") == "foo")
+	assert(require("unittests.require.bar") == "bar")
+	assert(pcall(require, "unittests.require.baz") == false)
+	-- Shebangs should be skipped
+	assert(require("unittests.require.shebang") == "yay")
+	-- Modules should not be pre-populated with (unsanitized) builtins
+	assert(pcall(require, "os") == false)
+	-- Cyclic require should produce a useful error message
+	local _, err = pcall(require, "unittests.require.cyclic.a")
+	print(err)
+	assert(err:find"cyclic require%(%)")
+	-- Custom loader
+	table.insert(package.loaders, function(module_name)
+		if module_name ~= "the_answer_to_life_the_universe_and_all_the_rest" then
+			return
+		end
+		return function() -- module loader
+			return 42
+		end
+	end)
+	local _, answer = pcall(require, "the_answer_to_life_the_universe_and_all_the_rest")
+	local success = pcall(require, "nosuchthing")
+	table.remove(package.loaders)
+	assert(answer == 42)
+	assert(success == false)
+end)
+

--- a/games/devtest/mods/unittests/require/bar/init.lua
+++ b/games/devtest/mods/unittests/require/bar/init.lua
@@ -1,0 +1,1 @@
+return "bar"

--- a/games/devtest/mods/unittests/require/cyclic/a.lua
+++ b/games/devtest/mods/unittests/require/cyclic/a.lua
@@ -1,0 +1,1 @@
+require("unittests.require.cyclic.b")

--- a/games/devtest/mods/unittests/require/cyclic/b.lua
+++ b/games/devtest/mods/unittests/require/cyclic/b.lua
@@ -1,0 +1,1 @@
+require("unittests.require.cyclic.a")

--- a/games/devtest/mods/unittests/require/foo.lua
+++ b/games/devtest/mods/unittests/require/foo.lua
@@ -1,0 +1,1 @@
+return "foo"

--- a/games/devtest/mods/unittests/require/shebang.lua
+++ b/games/devtest/mods/unittests/require/shebang.lua
@@ -1,0 +1,2 @@
+#! skip me!
+return "yay"

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
+#include "common/c_internal.h"
+#include "common/c_types.h"
 #include "cpp_api/s_base.h"
 #include "cpp_api/s_internal.h"
 #include "cpp_api/s_security.h"
 #include "debug.h"
+#include "log.h"
 #include "lua_api/l_object.h"
 #include "common/c_converter.h"
 #include "server/player_sao.h"
@@ -246,38 +249,58 @@ std::string ScriptApiBase::getCurrentModNameInsecure(lua_State *L)
 	return ret;
 }
 
-void ScriptApiBase::loadMod(const std::string &script_path,
-		const std::string &mod_name)
-{
-	ModNameStorer mod_name_storer(getStack(), mod_name);
-
-	loadScript(script_path);
-}
-
-void ScriptApiBase::loadScript(const std::string &script_path)
+static void load_script(lua_State *L, const char *script_path, int nresults)
 {
 	verbosestream << "Loading and running script from " << script_path << std::endl;
-
-	lua_State *L = getStack();
 
 	int error_handler = PUSH_ERROR_HANDLER(L);
 
 	bool ok;
 	if (ScriptApiSecurity::isSecure(L)) {
-		ok = ScriptApiSecurity::safeLoadFile(L, script_path.c_str());
+		ok = ScriptApiSecurity::safeLoadFile(L, script_path);
 	} else {
-		ok = !luaL_loadfile(L, script_path.c_str());
+		ok = !luaL_loadfile(L, script_path);
 	}
-	ok = ok && !lua_pcall(L, 0, 0, error_handler);
+	ok = ok && !lua_pcall(L, 0, nresults, error_handler);
 	if (!ok) {
 		const char *error_msg = lua_tostring(L, -1);
 		if (!error_msg)
 			error_msg = "(error object is not a string)";
 		lua_pop(L, 2); // Pop error message and error handler
-		throw ModError("Failed to load and run script from " +
+		throw ModError(std::string("Failed to load and run script from ") +
 				script_path + ":\n" + error_msg);
 	}
-	lua_pop(L, 1); // Pop error handler
+	lua_remove(L, error_handler);
+	// leave the return values from loading the file on the stack
+}
+
+void ScriptApiBase::loadMod(const std::string &script_path,
+		const std::string &mod_name, bool set_package_loaded)
+{
+	lua_State *L = getStack();
+	StackUnroller unroller(L);
+	ModNameStorer mod_name_storer(L, mod_name);
+
+	load_script(L, script_path.c_str(), 1);
+	if (set_package_loaded) {
+		int retval = lua_gettop(L); // script return value = module
+		// nil -> true to mark as loaded
+		if (lua_isnil(L, -1)) {
+			lua_pop(L, 1);
+			lua_pushboolean(L, true);
+		}
+		lua_getglobal(L, "package");
+		int package = lua_gettop(L);
+		lua_getfield(L, package, "loaded");
+		int package_loaded = lua_gettop(L);
+		lua_pushvalue(L, retval);
+		lua_setfield(L, package_loaded, mod_name.c_str());
+	}
+}
+
+void ScriptApiBase::loadScript(const std::string &script_path)
+{
+	load_script(getStack(), script_path.c_str(), 0);
 }
 
 #if CHECK_CLIENT_BUILD()

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -75,7 +75,9 @@ public:
 	DISABLE_CLASS_COPY(ScriptApiBase);
 
 	// These throw a ModError on failure
-	void loadMod(const std::string &script_path, const std::string &mod_name);
+	/// @param set_package_loaded whether to store returned value in package.loaded
+	void loadMod(const std::string &script_path, const std::string &mod_name,
+			bool set_package_loaded = false);
 	void loadScript(const std::string &script_path);
 
 #if CHECK_CLIENT_BUILD()

--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -44,7 +44,7 @@ void ServerModManager::loadMods(ServerScripting &script)
 
 		auto t1 = porting::getTimeMs();
 		std::string script_path = mod.path + DIR_DELIM + "init.lua";
-		script.loadMod(script_path, mod.name);
+		script.loadMod(script_path, mod.name, true);
 		infostream << "Mod \"" << mod.name << "\" loaded after "
 			<< (porting::getTimeMs() - t1) << " ms" << std::endl;
 	}


### PR DESCRIPTION
This implements `require`, the proper way to load files in Lua, as opposed to the slightly nasty `dofile` way modders have been forced to use.

`require` lets modders lazily load files, expose only the APIs they want to expose via `return`, and caches these "modules"; you get topological sorting for free.

AI was used for review.

## To do

This PR is a Work in Progress.

- [x] Harmonize `require` definition in different environments (currently this is SSM-only)
- [x] Insecure environment `require` should ideally be somewhat compatible with this `require` (slight problem: backwards compat requires to some extent that it isn't) 
- [x] Better docs

## How to test

Basic unit tests are included.
