### PR TITLE
Use map_compression_level_disk from minetest.conf in recompress_map_data

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1280,6 +1280,7 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 	u64 last_update_time = 0;
 	bool &kill = *porting::signal_handler_killstatus();
 	const u8 serialize_as_ver = SER_FMT_VER_HIGHEST_WRITE;
+	const s16 map_compression_level = rangelim(g_settings->getS16("map_compression_level_disk"), -1, 9);
 
 	// This is ok because the server doesn't actually run
 	std::vector<v3s16> blocks;
@@ -1307,7 +1308,7 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 			oss.str("");
 			oss.clear();
 			writeU8(oss, serialize_as_ver);
-			mb.serialize(oss, serialize_as_ver, true, -1);
+			mb.serialize(oss, serialize_as_ver, true, map_compression_level);
 		}
 
 		db->saveBlock(*it, oss.str());
@@ -1325,5 +1326,6 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 	db->endSave();
 
 	actionstream << "Done, " << count << " blocks were recompressed." << std::endl;
+
 	return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1326,6 +1326,5 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 	db->endSave();
 
 	actionstream << "Done, " << count << " blocks were recompressed." << std::endl;
-
 	return true;
 }


### PR DESCRIPTION
- Goal of the PR : Use the compression level set in minetest.conf during recompression.

- How does the PR work? Reads map_compression_level_disk using g_settings, applies rangelim(-1, 9) to match existing behavior.
and replaces the previously hardcoded/default -1.

- This PR fixes #14115.

## To do

This PR is Ready for Review.
While it correctly applies the map_compression_level_disk setting during recompression, this change alone does not reduce the physical size of the map.sqlite file.

I suggest that additional steps such as running a VACUUM operation on the SQLite database be considered immediately after recompression, or as part of an optional cleanup step.
In my testing, this reduced the file size by up to 1 MB.

## Script for testing

Here's the script I used to compare chunk size statistics and overall map.sqlite file size before and after recompression.

<pre> <code>
#!/bin/bash

# === CONFIG ===
WORLD="hi"
DB="../worlds/$WORLD/map.sqlite"

# === CHECK ===
if [ ! -f "$DB" ]; then
  echo "[!] Database file not found: $DB"
  exit 1
fi

echo "Initial database file size:"
du -sh "$DB"

# === MENU ===
echo "Choose what to compare:"
echo "1) Blob size stats"
echo "2) First 5 blob hashes"
echo "3) Both"
read -p "Enter option [1/2/3]: " OPTION

# === RUN ===
echo "[BEFORE --recompress]"

if [[ "$OPTION" == "1" || "$OPTION" == "3" ]]; then
  echo -e "[Blob Size Stats - BEFORE]"
  sqlite3 "$DB" "SELECT COUNT(*), AVG(LENGTH(data)), MAX(LENGTH(data)), MIN(LENGTH(data)) FROM blocks;"
fi

if [[ "$OPTION" == "2" || "$OPTION" == "3" ]]; then
  echo -e "\n[First 5 Block Hashes - BEFORE]"
  sqlite3 "$DB" <<< $'.mode list\n.headers off\nSELECT quote(data) FROM blocks LIMIT 5;'
fi

# === RUN RECOMPRESSION ===
echo -e "Running recompression with Luanti..."
./luanti --server --recompress --worldname "$WORLD"

echo "Database file size after recompression:"
du -sh "$DB"

# === AFTER ===
echo "[AFTER --recompress]"

if [[ "$OPTION" == "1" || "$OPTION" == "3" ]]; then
  echo -e "[Blob Size Stats - AFTER]"
  sqlite3 "$DB" "SELECT COUNT(*), AVG(LENGTH(data)), MAX(LENGTH(data)), MIN(LENGTH(data)) FROM blocks;"
fi

if [[ "$OPTION" == "2" || "$OPTION" == "3" ]]; then
  echo -e "[First 5 Block Hashes - AFTER]"
  sqlite3 "$DB" <<< $'.mode list\n.headers off\nSELECT quote(data) FROM blocks LIMIT 5;'
fi

</code>
</pre>


## Test procedure:

Create a new world with map_compression_level_disk = 0 set in minetest.conf.
Generate some mapblocks by walking or flying around.
Change the config to map_compression_level_disk = 9.
Run the script i shared

My observations were that he average blob size dropped, confirming that recompression with level 9 was applied correctly.
However, the file size of map.sqlite didn’t change much until a VACUUM was performed, which then released unused space.
 You can also check the logs to see which compression_level was used.


