### PR TITLE
Add option to ignore Lua destructor test with warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -486,6 +486,12 @@ if(ANDROID)
 	list(APPEND common_SRCS porting_android.cpp)
 endif()
 
+option(IGNORE_LUA_DESTRUCTOR_TEST_FAILURE "Ignore failures in Lua destructor test" FALSE)
+
+if(IGNORE_LUA_DESTRUCTOR_TEST_FAILURE)
+	add_compile_definitions(IGNORE_LUA_DESTRUCTOR_TEST_FAILURE)
+endif()
+
 if(BUILD_UNITTESTS)
 	add_subdirectory(unittest)
 	list(APPEND common_SRCS ${UNITTEST_SRCS})

--- a/src/unittest/test_lua.cpp
+++ b/src/unittest/test_lua.cpp
@@ -5,6 +5,7 @@
 
 #include "test.h"
 #include "config.h"
+#include "log.h"
 
 #include <stdexcept>
 
@@ -82,7 +83,13 @@ void TestLua::testLuaDestructors()
 	}, &did_destruct);
 	lua_close(L);
 
+#ifdef IGNORE_LUA_DESTRUCTOR_TEST_FAILURE
+	if (!did_destruct) {
+		warningstream << "The Lua destructor test has failed and you have elected to ignore it. You should know what you're doing. Memory leaks, deadlocks, and other nasty things are possible." << std::endl;
+	}
+#else
 	UASSERT(did_destruct);
+#endif
 }
 
 namespace {


### PR DESCRIPTION
Some uncommon architectures (e.g. armel) fail the destructor test but users may still want to use them without disabling all unit tests.

This is a potential workaround for https://github.com/luanti-org/luanti/issues/16031 in situations where we want to ensure the other unit tests still pass.

## To do

This PR is Ready for Review.

## How to test

Add `-DIGNORE_LUA_DESTRUCTOR_TEST_FAILURE=TRUE` to `cmake` options and test on one of the known failing architectures: armel, armhf, loong64, or mips64el.