### PR TITLE
Fix scrollbar on ContentDB grid by adding an area label

### DIFF
--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -345,7 +345,9 @@ local function get_formspec(dlgdata)
 					core.colorize(mt_color_green, package.title) ..
 							core.colorize("#BFBFBF", " by " .. package.author)), "]",
 
-			"textarea[", img_w + 0.25, ",0.75;", cell_w - img_w - 0.25, ",", cell_h - 0.75, ";;;",
+			"label[", img_w + 0.25, ",0.75;", cell_w - img_w - 0.25, ",", cell_h - 0.75, ";",
+				core.formspec_escape(package.short_description), "]",
+			"tooltip[", img_w + 0.25, ",0.75;", cell_w - img_w - 0.25, ",", cell_h - 0.75, ";",
 				core.formspec_escape(package.short_description), "]",
 
 			"style[view_", i, ";border=false]",

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -347,8 +347,12 @@ local function get_formspec(dlgdata)
 
 			"label[", img_w + 0.25, ",0.75;", cell_w - img_w - 0.25, ",", cell_h - 0.75, ";",
 				core.formspec_escape(package.short_description), "]",
+
+			-- Add a tooltip in case the label overflows and the text is cut off.
 			"tooltip[", img_w + 0.25, ",0.75;", cell_w - img_w - 0.25, ",", cell_h - 0.75, ";",
-				core.formspec_escape(package.short_description), "]",
+				-- Text in tooltips doesn't wrap automatically, so we do it manually to
+				-- avoid everything being one long line.
+				core.formspec_escape(core.wrap_text(package.short_description, 80)), "]",
 
 			"style[view_", i, ";border=false]",
 			"style[view_", i, ":hovered;bgimg=", core.formspec_escape(defaulttexturedir .. "button_hover_semitrans.png"), "]",

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -326,6 +326,9 @@ local function get_formspec(dlgdata)
 	local start_idx = (cur_page - 1) * num_per_page + 1
 	for i=start_idx, math.min(#contentdb.packages, start_idx+num_per_page-1) do
 		local package = contentdb.packages[i]
+		local text = core.colorize(mt_color_green, package.title) ..
+			core.colorize("#BFBFBF", " by " .. package.author) .. "\n" ..
+			package.short_description
 
 		table.insert_all(formspec, {
 			"container[",
@@ -340,16 +343,11 @@ local function get_formspec(dlgdata)
 			"image[0,0;", img_w, ",", cell_h, ";",
 				core.formspec_escape(get_screenshot(package, package.thumbnail, 2)), "]",
 
-			"label[", img_w + 0.25 + 0.05, ",0.5;",
-				core.formspec_escape(
-					core.colorize(mt_color_green, package.title) ..
-							core.colorize("#BFBFBF", " by " .. package.author)), "]",
+			"label[", img_w + 0.25, ",0.25;", cell_w - img_w - 0.25, ",", cell_h - 0.25, ";",
+				core.formspec_escape(text), "]",
 
-			"label[", img_w + 0.25, ",0.75;", cell_w - img_w - 0.25, ",", cell_h - 0.75, ";",
-				core.formspec_escape(package.short_description), "]",
-
-			-- Add a tooltip in case the label overflows and the text is cut off.
-			"tooltip[", img_w + 0.25, ",0.75;", cell_w - img_w - 0.25, ",", cell_h - 0.75, ";",
+			-- Add a tooltip in case the label overflows and the short description is cut off.
+			"tooltip[", img_w + 0.25, ",0.25;", cell_w - img_w - 0.25, ",", cell_h - 0.25, ";",
 				-- Text in tooltips doesn't wrap automatically, so we do it manually to
 				-- avoid everything being one long line.
 				core.formspec_escape(core.wrap_text(package.short_description, 80)), "]",
@@ -368,7 +366,7 @@ local function get_formspec(dlgdata)
 		end
 
 		table.insert_all(formspec, {
-			"container[", cell_w - 0.625,",", 0.25, "]",
+			"container[", cell_w - 0.625,",", 0.125, "]",
 		})
 
 		if package.downloading then

--- a/builtin/mainmenu/content/dlg_contentdb.lua
+++ b/builtin/mainmenu/content/dlg_contentdb.lua
@@ -323,6 +323,11 @@ local function get_formspec(dlgdata)
 	})
 	local img_w = cell_h * 3 / 2
 
+	-- Use as much of the available space as possible (so no padding on the
+	-- right/bottom), but don't quite allow the text to touch the border.
+	local text_w = cell_w - img_w - 0.25 - 0.025
+	local text_h = cell_h - 0.25 - 0.025
+
 	local start_idx = (cur_page - 1) * num_per_page + 1
 	for i=start_idx, math.min(#contentdb.packages, start_idx+num_per_page-1) do
 		local package = contentdb.packages[i]
@@ -343,11 +348,11 @@ local function get_formspec(dlgdata)
 			"image[0,0;", img_w, ",", cell_h, ";",
 				core.formspec_escape(get_screenshot(package, package.thumbnail, 2)), "]",
 
-			"label[", img_w + 0.25, ",0.25;", cell_w - img_w - 0.25, ",", cell_h - 0.25, ";",
+			"label[", img_w + 0.25, ",0.25;", text_w, ",", text_h, ";",
 				core.formspec_escape(text), "]",
 
 			-- Add a tooltip in case the label overflows and the short description is cut off.
-			"tooltip[", img_w + 0.25, ",0.25;", cell_w - img_w - 0.25, ",", cell_h - 0.25, ";",
+			"tooltip[", img_w + 0.25, ",0.25;", text_w, ",", text_h, ";",
 				-- Text in tooltips doesn't wrap automatically, so we do it manually to
 				-- avoid everything being one long line.
 				core.formspec_escape(core.wrap_text(package.short_description, 80)), "]",

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2833,6 +2833,9 @@ Version History
   * Add field_enter_after_edit[] (experimental)
 * Formspec version 8 (5.10.0)
   * scroll_container[]: content padding parameter
+* Formspec version 9 (5.12.0)
+  * Add allow_close[]
+  * label[]: Add "area label" variant
 
 Elements
 --------
@@ -3145,9 +3148,11 @@ Elements
 ### `textarea[<X>,<Y>;<W>,<H>;<name>;<label>;<default>]`
 
 * Same as fields above, but with multi-line input
+* Text is wrapped to fit within the given bounds.
 * If the text overflows, a vertical scrollbar is added.
 * If the name is empty, the textarea is read-only and
   the background is not shown, which corresponds to a multi-line label.
+  See also `label[<X>,<Y>;<W>,<H>;<label>]` for an alternative.
 
 ### `label[<X>,<Y>;<label>]`
 
@@ -3164,9 +3169,12 @@ Elements
 
 ### `label[<X>,<Y>;<W>,<H>;<label>]`
 
-* The label formspec element displays the text set in `label`
+* The "area label" formspec element displays the text set in `label`
   at the specified position and size.
 * Text is wrapped to fit within the given bounds.
+* If the text is overflows, it is currently simply truncated, but this behavior
+  is subject to change. There is no scrollbar.
+* See also `textarea` for an alternative.
 * Only available with the new coordinate system.
 
 ### `hypertext[<X>,<Y>;<W>,<H>;<name>;<text>]`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3162,6 +3162,13 @@ Elements
   half a coordinate.  With the old system, newlines are spaced 2/5 of
   an inventory slot.
 
+### `label[<X>,<Y>;<W>,<H>;<label>]`
+
+* The label formspec element displays the text set in `label`
+  at the specified position and size.
+* Text is wrapped to fit within the given bounds.
+* Only available with the new coordinate system.
+
 ### `hypertext[<X>,<Y>;<W>,<H>;<name>;<text>]`
 * Displays a static formatted text with hyperlinks.
 * **Note**: This element is currently unstable and subject to change.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3172,8 +3172,8 @@ Elements
 * The "area label" formspec element displays the text set in `label`
   at the specified position and size.
 * Text is wrapped to fit within the given bounds.
-* If the text is overflows, it is currently simply truncated, but this behavior
-  is subject to change. There is no scrollbar.
+* If the text overflows, it is currently simply truncated, but this behavior is
+  subject to change. There is no scrollbar.
 * See also `textarea` for an alternative.
 * Only available with the new coordinate system.
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1759,12 +1759,19 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
-	if (!precheckElement("label", element, 2, 2, parts))
+	if (!precheckElement("label", element, 2, data->real_coordinates ? 3 : 2, parts))
 		return;
 
-	std::vector<std::string> v_pos = split(parts[0],',');
+	std::vector<std::string> v_pos = split(parts[0], ',');
+	MY_CHECKPOS("label", 0);
 
-	MY_CHECKPOS("label",0);
+	bool has_size = parts.size() >= 3;
+	v2s32 geom;
+	if (has_size) {
+		std::vector<std::string> v_geom = split(parts[1], ',');
+		MY_CHECKGEOM("label", 1);
+		geom = getRealCoordinateGeometry(v_geom);
+	}
 
 	if(!data->explicit_size)
 		warningstream<<"invalid use of label without a size[] element"<<std::endl;
@@ -1774,67 +1781,100 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 	if (!font)
 		font = m_font;
 
-	EnrichedString str(unescape_string(utf8_to_wide(parts[1])));
-	size_t str_pos = 0;
+	EnrichedString str(unescape_string(utf8_to_wide(parts[has_size ? 2 : 1])));
 
-	for (size_t i = 0; str_pos < str.size(); ++i) {
-		EnrichedString line = str.getNextLine(&str_pos);
+	if (geom == v2s32()) {
+		size_t str_pos = 0;
+		for (size_t i = 0; str_pos < str.size(); ++i) {
+			EnrichedString line = str.getNextLine(&str_pos);
 
+			core::rect<s32> rect;
+
+			if (data->real_coordinates) {
+				// Lines are spaced at the distance of 1/2 imgsize.
+				// This alows lines that line up with the new elements
+				// easily without sacrificing good line distance.  If
+				// it was one whole imgsize, it would have too much
+				// spacing.
+				v2s32 pos = getRealCoordinateBasePos(v_pos);
+
+				// Labels are positioned by their center, not their top.
+				pos.Y += (((float) imgsize.Y) / -2) + (((float) imgsize.Y) * i / 2);
+
+				rect = core::rect<s32>(
+					pos.X, pos.Y,
+					pos.X + font->getDimension(line.c_str()).Width,
+					pos.Y + imgsize.Y);
+
+			} else {
+				// Lines are spaced at the nominal distance of
+				// 2/5 inventory slot, even if the font doesn't
+				// quite match that.  This provides consistent
+				// form layout, at the expense of sometimes
+				// having sub-optimal spacing for the font.
+				// We multiply by 2 and then divide by 5, rather
+				// than multiply by 0.4, to get exact results
+				// in the integer cases: 0.4 is not exactly
+				// representable in binary floating point.
+
+				v2s32 pos = getElementBasePos(nullptr);
+				pos.X += stof(v_pos[0]) * spacing.X;
+				pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
+
+				pos.Y += ((float) i) * spacing.Y * 2.0 / 5.0;
+
+				rect = core::rect<s32>(
+					pos.X, pos.Y - m_btn_height,
+					pos.X + font->getDimension(line.c_str()).Width,
+					pos.Y + m_btn_height);
+			}
+
+			FieldSpec spec(
+				"",
+				L"",
+				L"",
+				258 + m_fields.size(),
+				4
+			);
+			gui::IGUIStaticText *e = gui::StaticText::add(Environment,
+					line, rect, false, false, data->current_parent,
+					spec.fid);
+			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER);
+
+			e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+			e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+			e->setOverrideFont(font);
+
+			m_fields.push_back(spec);
+
+			// labels should let events through
+			e->grab();
+			m_clickthrough_elements.push_back(e);
+		}
+	} else {
 		core::rect<s32> rect;
 
-		if (data->real_coordinates) {
-			// Lines are spaced at the distance of 1/2 imgsize.
-			// This alows lines that line up with the new elements
-			// easily without sacrificing good line distance.  If
-			// it was one whole imgsize, it would have too much
-			// spacing.
-			v2s32 pos = getRealCoordinateBasePos(v_pos);
-
-			// Labels are positioned by their center, not their top.
-			pos.Y += (((float) imgsize.Y) / -2) + (((float) imgsize.Y) * i / 2);
-
-			rect = core::rect<s32>(
+		v2s32 pos = getRealCoordinateBasePos(v_pos);
+		rect = core::rect<s32>(
 				pos.X, pos.Y,
-				pos.X + font->getDimension(line.c_str()).Width,
-				pos.Y + imgsize.Y);
-
-		} else {
-			// Lines are spaced at the nominal distance of
-			// 2/5 inventory slot, even if the font doesn't
-			// quite match that.  This provides consistent
-			// form layout, at the expense of sometimes
-			// having sub-optimal spacing for the font.
-			// We multiply by 2 and then divide by 5, rather
-			// than multiply by 0.4, to get exact results
-			// in the integer cases: 0.4 is not exactly
-			// representable in binary floating point.
-
-			v2s32 pos = getElementBasePos(nullptr);
-			pos.X += stof(v_pos[0]) * spacing.X;
-			pos.Y += (stof(v_pos[1]) + 7.0f / 30.0f) * spacing.Y;
-
-			pos.Y += ((float) i) * spacing.Y * 2.0 / 5.0;
-
-			rect = core::rect<s32>(
-				pos.X, pos.Y - m_btn_height,
-				pos.X + font->getDimension(line.c_str()).Width,
-				pos.Y + m_btn_height);
-		}
+				pos.X + geom.X,
+				pos.Y + geom.Y);
 
 		FieldSpec spec(
-			"",
-			L"",
-			L"",
-			258 + m_fields.size(),
-			4
+				"",
+				L"",
+				L"",
+				258 + m_fields.size(),
+				4
 		);
 		gui::IGUIStaticText *e = gui::StaticText::add(Environment,
-				line, rect, false, false, data->current_parent,
+				str, rect, false, false, data->current_parent,
 				spec.fid);
-		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER);
+		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
 
 		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setWordWrap(true);
 		e->setOverrideFont(font);
 
 		m_fields.push_back(spec);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1860,7 +1860,7 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 		}
 	} else {
 		v2s32 pos = getRealCoordinateBasePos(v_pos);
-		core::rect<s32> rect = core::rect<s32>(
+		core::rect<s32> rect(
 				pos.X, pos.Y,
 				pos.X + geom.X,
 				pos.Y + geom.Y);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1781,10 +1781,37 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 	if (!font)
 		font = m_font;
 
+	auto add_label = [&](core::rect<s32> rect, const EnrichedString &text,
+			EGUI_ALIGNMENT align_h, EGUI_ALIGNMENT align_v, bool word_wrap) {
+		FieldSpec spec(
+			"",
+			L"",
+			L"",
+			258 + m_fields.size(),
+			4
+		);
+		gui::IGUIStaticText *e = gui::StaticText::add(Environment,
+				text, rect, false, false, data->current_parent,
+				spec.fid);
+		e->setTextAlignment(align_h, align_v);
+		e->setWordWrap(word_wrap);
+
+		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
+		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
+		e->setOverrideFont(font);
+
+		m_fields.push_back(spec);
+
+		// labels should let events through
+		e->grab();
+		m_clickthrough_elements.push_back(e);
+	};
+
 	EnrichedString str(unescape_string(utf8_to_wide(parts[has_size ? 2 : 1])));
 
 	if (geom == v2s32()) {
 		size_t str_pos = 0;
+
 		for (size_t i = 0; str_pos < str.size(); ++i) {
 			EnrichedString line = str.getNextLine(&str_pos);
 
@@ -1829,59 +1856,16 @@ void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
 					pos.Y + m_btn_height);
 			}
 
-			FieldSpec spec(
-				"",
-				L"",
-				L"",
-				258 + m_fields.size(),
-				4
-			);
-			gui::IGUIStaticText *e = gui::StaticText::add(Environment,
-					line, rect, false, false, data->current_parent,
-					spec.fid);
-			e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER);
-
-			e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-			e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-			e->setOverrideFont(font);
-
-			m_fields.push_back(spec);
-
-			// labels should let events through
-			e->grab();
-			m_clickthrough_elements.push_back(e);
+			add_label(rect, line, gui::EGUIA_UPPERLEFT, gui::EGUIA_CENTER, false);
 		}
 	} else {
-		core::rect<s32> rect;
-
 		v2s32 pos = getRealCoordinateBasePos(v_pos);
-		rect = core::rect<s32>(
+		core::rect<s32> rect = core::rect<s32>(
 				pos.X, pos.Y,
 				pos.X + geom.X,
 				pos.Y + geom.Y);
 
-		FieldSpec spec(
-				"",
-				L"",
-				L"",
-				258 + m_fields.size(),
-				4
-		);
-		gui::IGUIStaticText *e = gui::StaticText::add(Environment,
-				str, rect, false, false, data->current_parent,
-				spec.fid);
-		e->setTextAlignment(gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT);
-
-		e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
-		e->setOverrideColor(style.getColor(StyleSpec::TEXTCOLOR, video::SColor(0xFFFFFFFF)));
-		e->setWordWrap(true);
-		e->setOverrideFont(font);
-
-		m_fields.push_back(spec);
-
-		// labels should let events through
-		e->grab();
-		m_clickthrough_elements.push_back(e);
+		add_label(rect, str, gui::EGUIA_UPPERLEFT, gui::EGUIA_UPPERLEFT, true);
 	}
 }
 

--- a/src/network/networkprotocol.cpp
+++ b/src/network/networkprotocol.cpp
@@ -71,4 +71,4 @@
 const u16 LATEST_PROTOCOL_VERSION = 48;
 
 // See also formspec [Version History] in doc/lua_api.md
-const u16 FORMSPEC_API_VERSION = 8;
+const u16 FORMSPEC_API_VERSION = 9;


### PR DESCRIPTION
Adoption of #15478, with my review comments fixed, and with title/author overflowing fixed as well

Fixes #15339, fixes #7408

One thing to note is that the new area label in this PR becomes part of the public formspec API, so any complaints about API design etc. would have to be made now.

Screenshot, before (title/author has visible overflow, description has hidden overflow with an unusable scrollbar)
<img alt="before" src="https://github.com/user-attachments/assets/5bde8a4f-770b-43d7-82a3-acf6f0b72647" width="512" />
<img src="https://github.com/user-attachments/assets/f542d8d9-703b-4604-9f52-ec4422378de0" width="512" alt="before on mobile" />

Screenshot, after (title/author and description are both wrapped as one run of text, overflow is hidden with no scrollbar shown)
<img alt="after" src="https://github.com/user-attachments/assets/33de1a97-35ee-4583-a0c1-c36aec7affc0" width="512" />
<img src="https://github.com/user-attachments/assets/3ef250b9-1bbc-404e-a311-57e859f052ff" width="512" alt="after on mobile" />

There is also a tooltip so that you can still read the full short description in case it overflows.

## To do

This PR is a Ready for Review.

From the old PR:

> Ideally, the text would either reduce in font size or ellipsize (...) rather than clip but this is the best Irrlicht word wrapping offers

(obviously out of scope)

> Fix the title? #7408
> If the right of the card was made into a single label, the title line would wrap if there's not enough space. However, the width of a label needs to be the same for all lines so the refresh/installed icon might need to be moved

Title is fixed. The icon possibly intersecting the title/author is not a new problem, so doesn't necessarily have to be fixed here. I don't necessarily think we should move the icon either. We'd really just need a more advanced text placement API supporting "floating" images (could try hypertext, would have to add an API feature to hide the scrollbar).

Because of title/author and description having to be in one label, the "paragraph space" between them is gone (would be possible to have with hypertext).

## How to test

From the old PR:

> Use CDB dialog and /test_formspec in devtest
