### PR TITLE
Show SDL version in the About tab

### DIFF
--- a/irr/include/IrrlichtDevice.h
+++ b/irr/include/IrrlichtDevice.h
@@ -16,6 +16,7 @@
 #include "IrrCompileConfig.h"
 #include "position2d.h"
 #include "SColor.h" // video::ECOLOR_FORMAT
+#include <string>
 #include <variant>
 
 namespace irr
@@ -331,6 +332,12 @@ public:
 	/** This allows the user to check which windowing system is currently being
 	used. */
 	virtual E_DEVICE_TYPE getType() const = 0;
+
+	//! Get the version string of the underlying system (e.g. SDL)
+	virtual std::string getVersionString() const
+	{
+		return "";
+	}
 
 	//! Get the display density in dots per inch.
 	//! Returns 0.0f on failure.

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -109,6 +109,14 @@ public:
 		return EIDT_SDL;
 	}
 
+	//! Get the SDL version
+	std::string getVersionString() const override
+	{
+		SDL_version ver;
+		SDL_GetVersion(&ver); // TODO: SDL3 returns this directly instead of using a pointer
+		return std::to_string(ver.major) + "." + std::to_string(ver.minor) + "." + std::to_string(ver.patch);
+	}
+
 	//! Get the display density in dots per inch.
 	float getDisplayDensity() const override;
 

--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -113,7 +113,7 @@ public:
 	std::string getVersionString() const override
 	{
 		SDL_version ver;
-		SDL_GetVersion(&ver); // TODO: SDL3 returns this directly instead of using a pointer
+		SDL_GetVersion(&ver);
 		return std::to_string(ver.major) + "." + std::to_string(ver.minor) + "." + std::to_string(ver.patch);
 	}
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -945,8 +945,9 @@ int ModApiMainMenu::l_get_active_renderer(lua_State *L)
 /******************************************************************************/
 int ModApiMainMenu::l_get_active_irrlicht_device(lua_State *L)
 {
-	const char *device_name = [] {
-		switch (RenderingEngine::get_raw_device()->getType()) {
+	auto device = RenderingEngine::get_raw_device();
+	std::string device_name = [device] {
+		switch (device->getType()) {
 		case EIDT_WIN32: return "WIN32";
 		case EIDT_X11: return "X11";
 		case EIDT_OSX: return "OSX";
@@ -955,7 +956,9 @@ int ModApiMainMenu::l_get_active_irrlicht_device(lua_State *L)
 		default: return "Unknown";
 		}
 	}();
-	lua_pushstring(L, device_name);
+	if (auto version = device->getVersionString(); !version.empty())
+		device_name.append(" " + version);
+	lua_pushstring(L, device_name.c_str());
 	return 1;
 }
 


### PR DESCRIPTION
- Goal of the PR
  Show SDL version in the "Active renderer" field in the about tab.
- How does the PR work?
  The SDL device uses [`SDL_GetVersion`](https://wiki.libsdl.org/SDL2/SDL_GetVersion) to construct a version string that is then appended to the device name.
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  IMO this can help with reproducing SDL-related issues.

## To do

This PR is Ready for Review.

## How to test

Look at the "About" tab. The "Active renderer" should show e.g. `4.6 / opengl / SDL 2.32.54`.