### PR TITLE
[no squash] Some work on `TextureSource`

### DIFF
--- a/src/client/imagefilters.cpp
+++ b/src/client/imagefilters.cpp
@@ -344,38 +344,3 @@ void imageScaleNNAA(video::IImage *src, const core::rect<s32> &srcrect, video::I
 		dest->setPixel(dx, dy, pxl);
 	}
 }
-
-/* Check and align image to npot2 if required by hardware
- * @param image image to check for npot2 alignment
- * @param driver driver to use for image operations
- * @return image or copy of image aligned to npot2
- */
-video::IImage *Align2Npot2(video::IImage *image, video::IVideoDriver *driver)
-{
-	if (image == nullptr)
-		return image;
-
-	if (driver->queryFeature(video::EVDF_TEXTURE_NPOT))
-		return image;
-
-	core::dimension2d<u32> dim = image->getDimension();
-	unsigned int height = npot2(dim.Height);
-	unsigned int width  = npot2(dim.Width);
-
-	if (dim.Height == height && dim.Width == width)
-		return image;
-
-	if (dim.Height > height)
-		height *= 2;
-	if (dim.Width > width)
-		width *= 2;
-
-	video::IImage *targetimage =
-			driver->createImage(video::ECF_A8R8G8B8,
-					core::dimension2d<u32>(width, height));
-
-	if (targetimage != nullptr)
-		image->copyToScaling(targetimage);
-	image->drop();
-	return targetimage;
-}

--- a/src/client/imagefilters.h
+++ b/src/client/imagefilters.h
@@ -39,11 +39,3 @@ video::SColor imageAverageColor(const video::IImage *img);
  * and downscaling.
  */
 void imageScaleNNAA(video::IImage *src, const core::rect<s32> &srcrect, video::IImage *dest);
-
-/* Check and align image to npot2 if required by hardware
- * @param image image to check for npot2 alignment
- * @param driver driver to use for image operations
- * @return image or copy of image aligned to npot2
- */
-video::IImage *Align2Npot2(video::IImage *image, video::IVideoDriver *driver);
-

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -24,6 +24,13 @@ struct TextureInfo
 	std::set<std::string> sourceImages{};
 };
 
+// Stores internal information about a texture image.
+struct ImageInfo
+{
+	video::IImage *image = nullptr;
+	std::set<std::string> sourceImages;
+};
+
 // TextureSource
 class TextureSource final : public IWritableTextureSource
 {
@@ -123,7 +130,13 @@ public:
 
 	video::SColor getTextureAverageColor(const std::string &name);
 
+	void setImageCaching(bool enabled);
+
 private:
+	// Gets or generates an image for a texture string
+	// Caller needs to drop the returned image
+	video::IImage *getOrGenerateImage(const std::string &name,
+		std::set<std::string> &source_image_names);
 
 	// The id of the thread that is allowed to use irrlicht directly
 	std::thread::id m_main_thread;
@@ -131,6 +144,12 @@ private:
 	// Generates and caches source images
 	// This should be only accessed from the main thread
 	ImageSource m_imagesource;
+
+	// Is the image cache enabled?
+	bool m_image_cache_enabled = false;
+	// Caches finished texture images before they are uploaded to the GPU
+	// (main thread use only)
+	std::unordered_map<std::string, ImageInfo> m_image_cache;
 
 	// Rebuild images and textures from the current set of source images
 	// Shall be called from the main thread.
@@ -193,20 +212,43 @@ TextureSource::~TextureSource()
 	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
 	u32 textures_before = driver->getTextureCount();
 
+	for (const auto &it : m_image_cache) {
+		assert(it.second.image);
+		it.second.image->drop();
+	}
+
 	for (const auto &iter : m_textureinfo_cache) {
-		// cleanup texture
 		if (iter.texture)
 			driver->removeTexture(iter.texture);
 	}
 	m_textureinfo_cache.clear();
 
 	for (auto t : m_texture_trash) {
-		// cleanup trashed texture
 		driver->removeTexture(t);
 	}
 
 	infostream << "~TextureSource() before cleanup: " << textures_before
 			<< " after: " << driver->getTextureCount() << std::endl;
+}
+
+video::IImage *TextureSource::getOrGenerateImage(const std::string &name,
+		std::set<std::string> &source_image_names)
+{
+	auto it = m_image_cache.find(name);
+	if (it != m_image_cache.end()) {
+		source_image_names = it->second.sourceImages;
+		it->second.image->grab();
+		return it->second.image;
+	}
+
+	std::set<std::string> tmp;
+	auto *img = m_imagesource.generateImage(name, tmp);
+	if (img && m_image_cache_enabled) {
+		img->grab();
+		m_image_cache[name] = {img, tmp};
+	}
+	source_image_names = std::move(tmp);
+	return img;
 }
 
 u32 TextureSource::getTextureId(const std::string &name)
@@ -280,7 +322,7 @@ u32 TextureSource::generateTexture(const std::string &name)
 
 	// passed into texture info for dynamic media tracking
 	std::set<std::string> source_image_names;
-	video::IImage *img = m_imagesource.generateImage(name, source_image_names);
+	video::IImage *img = getOrGenerateImage(name, source_image_names);
 
 	video::ITexture *tex = nullptr;
 
@@ -356,7 +398,7 @@ Palette* TextureSource::getPalette(const std::string &name)
 	if (it == m_palettes.end()) {
 		// Create palette
 		std::set<std::string> source_image_names; // unused, sadly.
-		video::IImage *img = m_imagesource.generateImage(name, source_image_names);
+		video::IImage *img = getOrGenerateImage(name, source_image_names);
 		if (!img) {
 			warningstream << "TextureSource::getPalette(): palette \"" << name
 				<< "\" could not be loaded." << std::endl;
@@ -458,6 +500,8 @@ void TextureSource::rebuildImagesAndTextures()
 	infostream << "TextureSource: recreating " << m_textureinfo_cache.size()
 			<< " textures" << std::endl;
 
+	assert(!m_image_cache_enabled || m_image_cache.empty());
+
 	// Recreate textures
 	for (TextureInfo &ti : m_textureinfo_cache) {
 		if (ti.name.empty())
@@ -474,7 +518,7 @@ void TextureSource::rebuildTexture(video::IVideoDriver *driver, TextureInfo &ti)
 	sanity_check(std::this_thread::get_id() == m_main_thread);
 
 	std::set<std::string> source_image_names;
-	video::IImage *img = m_imagesource.generateImage(ti.name, source_image_names);
+	video::IImage *img = getOrGenerateImage(ti.name, source_image_names);
 
 	// Create texture from resulting image
 	video::ITexture *t = nullptr, *t_old = ti.texture;
@@ -510,14 +554,10 @@ void TextureSource::rebuildTexture(video::IVideoDriver *driver, TextureInfo &ti)
 
 video::SColor TextureSource::getTextureAverageColor(const std::string &name)
 {
-	video::IVideoDriver *driver = RenderingEngine::get_video_driver();
-	video::ITexture *texture = getTexture(name);
-	if (!texture)
-		return {0, 0, 0, 0};
-	// Note: this downloads the texture back from the GPU, which is pointless
-	video::IImage *image = driver->createImage(texture,
-		core::position2d<s32>(0, 0),
-		texture->getOriginalSize());
+	assert(std::this_thread::get_id() == m_main_thread);
+
+	std::set<std::string> unused;
+	auto *image = getOrGenerateImage(name, unused);
 	if (!image)
 		return {0, 0, 0, 0};
 
@@ -525,4 +565,16 @@ video::SColor TextureSource::getTextureAverageColor(const std::string &name)
 	image->drop();
 
 	return c;
+}
+
+void TextureSource::setImageCaching(bool enabled)
+{
+	m_image_cache_enabled = enabled;
+	if (!enabled) {
+		for (const auto &it : m_image_cache) {
+			assert(it.second.image);
+			it.second.image->drop();
+		}
+		m_image_cache.clear();
+	}
 }

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -86,7 +86,11 @@ public:
 	 */
 	virtual void insertSourceImage(const std::string &name, video::IImage *img)=0;
 
-	/// @brief rebuilds all textures (in case-source images have changed)
+	/**
+	 * Rebuilds all textures (in case-source images have changed)
+	 * @note This won't invalidate old ITexture's, but you have to retrieve them
+	 * again to see changes.
+	 */
 	virtual void rebuildImagesAndTextures()=0;
 };
 

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -69,6 +69,17 @@ public:
 
 	/// @brief Return average color of a texture string
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
+
+	// Note: this method is here because caching is the decision of the
+	// API user, even if his access is read-only.
+
+	/**
+	 * Enables or disables the caching of finished texture images.
+	 * This can be useful if you want to call getTextureAverageColor without
+	 * duplicating work.
+	 * @note Disabling caching will flush the cache.
+	 */
+	virtual void setImageCaching(bool enabled) {};
 };
 
 class IWritableTextureSource : public ITextureSource
@@ -88,8 +99,8 @@ public:
 
 	/**
 	 * Rebuilds all textures (in case-source images have changed)
-	 * @note This won't invalidate old ITexture's, but you have to retrieve them
-	 * again to see changes.
+	 * @note This won't invalidate old ITexture's, but may or may not reuse them.
+	 * So you have to re-get all textures anyway.
 	 */
 	virtual void rebuildImagesAndTextures()=0;
 };

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -25,10 +25,10 @@ class ISimpleTextureSource
 {
 public:
 	ISimpleTextureSource() = default;
-
 	virtual ~ISimpleTextureSource() = default;
 
-	virtual video::ITexture* getTexture(
+	/// @brief Generates and gets a texture
+	virtual video::ITexture *getTexture(
 			const std::string &name, u32 *id = nullptr) = 0;
 };
 
@@ -36,24 +36,38 @@ class ITextureSource : public ISimpleTextureSource
 {
 public:
 	ITextureSource() = default;
-
 	virtual ~ITextureSource() = default;
 
+	using ISimpleTextureSource::getTexture;
+
+	/// @brief Generates and gets ID of a texture
 	virtual u32 getTextureId(const std::string &name)=0;
+
+	/// @brief Returns name of existing texture by ID
 	virtual std::string getTextureName(u32 id)=0;
-	virtual video::ITexture* getTexture(u32 id)=0;
-	virtual video::ITexture* getTexture(
-			const std::string &name, u32 *id = nullptr)=0;
-	virtual video::ITexture* getTextureForMesh(
+
+	/// @brief Returns existing texture by ID
+	virtual video::ITexture *getTexture(u32 id)=0;
+
+	/**
+	 * @brief Generates and gets a texture
+	 * Filters will be applied to make the texture suitable for mipmapping and
+	 * linear filtering during rendering.
+	 */
+	virtual video::ITexture *getTextureForMesh(
 			const std::string &name, u32 *id = nullptr) = 0;
-	/*!
+	/**
 	 * Returns a palette from the given texture name.
 	 * The pointer is valid until the texture source is
 	 * destructed.
-	 * Should be called from the main thread.
+	 * Must be called from the main thread.
 	 */
-	virtual Palette* getPalette(const std::string &name) = 0;
+	virtual Palette *getPalette(const std::string &name) = 0;
+
+	/// @brief Check if given image name exists
 	virtual bool isKnownSourceImage(const std::string &name)=0;
+
+	/// @brief Return average color of a texture string
 	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
 };
 
@@ -61,20 +75,19 @@ class IWritableTextureSource : public ITextureSource
 {
 public:
 	IWritableTextureSource() = default;
-
 	virtual ~IWritableTextureSource() = default;
 
-	virtual u32 getTextureId(const std::string &name)=0;
-	virtual std::string getTextureName(u32 id)=0;
-	virtual video::ITexture* getTexture(u32 id)=0;
-	virtual video::ITexture* getTexture(
-			const std::string &name, u32 *id = nullptr)=0;
-	virtual bool isKnownSourceImage(const std::string &name)=0;
-
+	/// @brief Fulfil texture requests from other threads
 	virtual void processQueue()=0;
+
+	/**
+	 * @brief Inserts a source image. Must be called from the main thread.
+	 * Takes ownership of @p img
+	 */
 	virtual void insertSourceImage(const std::string &name, video::IImage *img)=0;
+
+	/// @brief rebuilds all textures (in case-source images have changed)
 	virtual void rebuildImagesAndTextures()=0;
-	virtual video::SColor getTextureAverageColor(const std::string &name)=0;
 };
 
 IWritableTextureSource *createTextureSource();

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -64,7 +64,7 @@ MenuTextureSource::~MenuTextureSource()
 video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 {
 	if (id)
-		*id = 0;
+		*id = 1;
 
 	if (name.empty())
 		return NULL;
@@ -78,7 +78,6 @@ video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 	if (!image)
 		return NULL;
 
-	image = Align2Npot2(image, m_driver);
 	retval = m_driver->addTexture(name.c_str(), image);
 	image->drop();
 

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -761,10 +761,6 @@ static bool isWorldAligned(AlignStyle style, WorldAlignMode mode, NodeDrawType d
 void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc,
 	scene::IMeshManipulator *meshmanip, Client *client, const TextureSettings &tsettings)
 {
-	// minimap pixel color - the average color of a texture
-	if (tsettings.enable_minimap && !tiledef[0].name.empty())
-		minimap_color = tsrc->getTextureAverageColor(tiledef[0].name);
-
 	// Figure out the actual tiles to use
 	TileDef tdef[6];
 	for (u32 j = 0; j < 6; j++) {
@@ -908,6 +904,10 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 		overlay_material = TILE_MATERIAL_LIQUID_TRANSPARENT;
 
 	u32 overlay_shader = shdsrc->getShader("nodes_shader", overlay_material, drawtype);
+
+	// minimap pixel color = average color of top tile
+	if (tsettings.enable_minimap && !tdef[0].name.empty() && drawtype != NDT_AIRLIKE)
+		minimap_color = tsrc->getTextureAverageColor(tdef[0].name);
 
 	// Tiles (fill in f->tiles[])
 	for (u16 j = 0; j < 6; j++) {
@@ -1445,13 +1445,16 @@ void NodeDefManager::updateTextures(IGameDef *gamedef, void *progress_callback_a
 	TextureSettings tsettings;
 	tsettings.readSettings();
 
-	u32 size = m_content_features.size();
+	tsrc->setImageCaching(true);
 
+	u32 size = m_content_features.size();
 	for (u32 i = 0; i < size; i++) {
 		ContentFeatures *f = &(m_content_features[i]);
 		f->updateTextures(tsrc, shdsrc, meshmanip, client, tsettings);
 		client->showUpdateProgressTexture(progress_callback_args, i, size);
 	}
+
+	tsrc->setImageCaching(false);
 #endif
 }
 


### PR DESCRIPTION
context on last commit:
Currently a texture like `default_stone.png^[applyfiltersformesh` is generated once, uploaded to the GPU and the image data thrown away.
When we want to introduce array textures we may need the same texture image multiple times and/or generated in advance. This change makes that possible.

## To do

This PR is Ready for Review.

## How to test

1. play game
2. nothing should have changed