### PR TITLE
Change default inventory key to E, default Aux1 key to F

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Some can be changed in the key config dialog in the settings tab.
 | Left mouse button             | Dig/punch/use                                                  |
 | Right mouse button            | Place/use                                                      |
 | Shift + right mouse button    | Build (without using)                                          |
-| I                             | Inventory menu                                                 |
+| E                             | Inventory menu                                                 |
 | Mouse wheel                   | Select item                                                    |
 | 0-9                           | Select item                                                    |
 | Z                             | Zoom (needs zoom privilege)                                    |
@@ -63,7 +63,7 @@ Some can be changed in the key config dialog in the settings tab.
 | K                             | Enable/disable fly mode (needs fly privilege)                  |
 | J                             | Enable/disable fast mode (needs fast privilege)                |
 | H                             | Enable/disable noclip mode (needs noclip privilege)            |
-| E                             | Aux1 (Move fast in fast mode. Games may add special features)  |
+| F                             | Aux1 (Move fast in fast mode. Games may add special features)  |
 | C                             | Cycle through camera modes                                     |
 | V                             | Cycle through minimap modes                                    |
 | Shift + V                     | Change minimap orientation                                     |

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -211,10 +211,10 @@ keymap_dig (Dig/punch/use) key KEY_LBUTTON
 keymap_place (Place/use) key KEY_RBUTTON
 
 #    Key for opening the inventory.
-keymap_inventory (Open inventory) key KEY_KEY_I
+keymap_inventory (Open inventory) key KEY_KEY_E
 
 #    Key for moving fast in fast mode.
-keymap_aux1 (Aux1) key KEY_KEY_E
+keymap_aux1 (Aux1) key KEY_KEY_F
 
 #    Key for opening the chat window.
 keymap_chat (Open chat) key KEY_KEY_T

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -3370,12 +3370,12 @@
 #    Key for opening the inventory.
 #    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
 #    type: key
-# keymap_inventory = KEY_KEY_I
+# keymap_inventory = KEY_KEY_E
 
 #    Key for moving fast in fast mode.
 #    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h
 #    type: key
-# keymap_aux1 = KEY_KEY_E
+# keymap_aux1 = KEY_KEY_F
 
 #    Key for opening the chat window.
 #    See https://github.com/minetest/irrlicht/blob/master/include/Keycodes.h

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -150,8 +150,8 @@ void set_default_settings()
 	settings->setDefault("keymap_place", "KEY_RBUTTON");
 	USEKEY2("keymap_drop", "SYSTEM_SCANCODE_20", "KEY_KEY_Q");
 	USEKEY2("keymap_zoom", "SYSTEM_SCANCODE_29", "KEY_KEY_Z");
-	USEKEY2("keymap_inventory", "SYSTEM_SCANCODE_12", "KEY_KEY_I");
-	USEKEY2("keymap_aux1", "SYSTEM_SCANCODE_8", "KEY_KEY_E");
+	USEKEY2("keymap_inventory", "SYSTEM_SCANCODE_8", "KEY_KEY_E");
+	USEKEY2("keymap_aux1", "SYSTEM_SCANCODE_9", "KEY_KEY_F");
 	USEKEY2("keymap_chat", "SYSTEM_SCANCODE_23", "KEY_KEY_T");
 	USEKEY2("keymap_cmd", "SYSTEM_SCANCODE_56", "/");
 	USEKEY2("keymap_cmd_local", "SYSTEM_SCANCODE_55", ".");


### PR DESCRIPTION
- Fixes #16052 
- Fixes unnatural default keybinding for inventory by making it key E (instead of the old I), the default also for Minecraft
- Sets default Aux1 key to F (to make room for E)

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

- [ ] Check there are no other places the default keybinding for inventory, Aux1 is specified
- [ ] After merging: update docs page `/for-players/controls/`

## How to test

<!-- Example code or instructions -->

Launch a new game that uses inventory and Aux1 (e.g. VoxeLibre). Press E for inventory. Hold F to run.