### PR TITLE
Fix texture coords off by one error

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -308,12 +308,12 @@ void MapblockMeshGenerator::generateCuboidTextureCoords(const aabb3f &box, f32 *
 	f32 ty2 = (box.MaxEdge.Y / BS) + 0.5;
 	f32 tz2 = (box.MaxEdge.Z / BS) + 0.5;
 	f32 txc[24] = {
-		    tx1, 1 - tz2,     tx2, 1 - tz1, // up
+		    tx1,   - tz2,     tx2,   - tz1, // up
 		    tx1,     tz1,     tx2,     tz2, // down
-		    tz1, 1 - ty2,     tz2, 1 - ty1, // right
-		1 - tz2, 1 - ty2, 1 - tz1, 1 - ty1, // left
-		1 - tx2, 1 - ty2, 1 - tx1, 1 - ty1, // back
-		    tx1, 1 - ty2,     tx2, 1 - ty1, // front
+		    tz1,   - ty2,     tz2,   - ty1, // right
+		  - tz2,   - ty2,   - tz1,   - ty1, // left
+		  - tx2,   - ty2,   - tx1,   - ty1, // back
+		    tx1,   - ty2,     tx2,   - ty1, // front
 	};
 	for (int i = 0; i != 24; ++i)
 		coords[i] = txc[i];

--- a/src/client/content_mapblock.h
+++ b/src/client/content_mapblock.h
@@ -86,7 +86,7 @@ private:
 	template <typename Fn>
 	void drawCuboid(const aabb3f &box, const TileSpec *tiles, int tilecount,
 			const f32 *txc, u8 mask, Fn &&face_lighter);
-	void generateCuboidTextureCoords(aabb3f const &box, f32 *coords);
+	void generateCuboidTextureCoords(aabb3f const &box, f32 *coords, const TileSpec *tiles = nullptr);
 	void drawAutoLightedCuboid(aabb3f box, const TileSpec &tile, f32 const *txc	= nullptr, u8 mask = 0);
 	void drawAutoLightedCuboid(aabb3f box, const TileSpec *tiles, int tile_count, f32 const *txc = nullptr, u8 mask = 0);
 	u8 getNodeBoxMask(aabb3f box, u8 solid_neighbors, u8 sametype_neighbors) const;

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -418,17 +418,17 @@ scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 
 		f32 txc_default[24] = {
 			// up
-			tx1, 1 - tz2, tx2, 1 - tz1,
+			tx1, - tz2, tx2, - tz1,
 			// down
 			tx1, tz1, tx2, tz2,
 			// right
-			tz1, 1 - ty2, tz2, 1 - ty1,
+			tz1, - ty2, tz2, - ty1,
 			// left
-			1 - tz2, 1 - ty2, 1 - tz1, 1 - ty1,
+			- tz2, - ty2, - tz1, - ty1,
 			// back
-			1 - tx2, 1 - ty2, 1 - tx1, 1 - ty1,
+			- tx2, - ty2, - tx1, - ty1,
 			// front
-			tx1, 1 - ty2, tx2, 1 - ty1,
+			tx1, - ty2, tx2, - ty1,
 		};
 
 		// use default texture UV mapping if not provided

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -418,17 +418,17 @@ scene::IMesh* convertNodeboxesToMesh(const std::vector<aabb3f> &boxes,
 
 		f32 txc_default[24] = {
 			// up
-			tx1, - tz2, tx2, - tz1,
+			tx1, 1 - tz2, tx2, 1 - tz1,
 			// down
 			tx1, tz1, tx2, tz2,
 			// right
-			tz1, - ty2, tz2, - ty1,
+			tz1, 1 - ty2, tz2, 1 - ty1,
 			// left
-			- tz2, - ty2, - tz1, - ty1,
+			1 - tz2, 1 - ty2, 1 - tz1, 1 - ty1,
 			// back
-			- tx2, - ty2, - tx1, - ty1,
+			1 - tx2, 1 - ty2, 1 - tx1, 1 - ty1,
 			// front
-			tx1, - ty2, tx2, - ty1,
+			tx1, 1 - ty2, tx2, 1 - ty1,
 		};
 
 		// use default texture UV mapping if not provided


### PR DESCRIPTION
- Fixes #12266, `align_style` in general, and maybe other places where texture coordinates matter

While investigating #12266 I noticed that `align_style` does not align properly, even in the most basic case. How did nobody complain about this so far. To be fair it took quite some time to find the cause.
Anyway, if I'm not wrong, texture coordinates of all node tiles (except the bottom one) have an off by one error which this PR tries to fix.

(I hope I didn't misunderstand anything about the code, since this part worked fine for the past 8 years.)

## To do

Ready for Review.

## How to test

- Start devtest
- Press the key to toggle block bounds
- Place a lot of `tiled:tiled` nodes and see that the world alignment is correct.
- See that all other nodes look the same, including rotations
