### PR TITLE
Deprecate function support in `core.[de]serialize`

### DIFF
--- a/builtin/common/misc_helpers.lua
+++ b/builtin/common/misc_helpers.lua
@@ -14,11 +14,6 @@ local function basic_dump(o)
 		return tostring(o)
 	elseif tp == "nil" then
 		return "nil"
-	-- Uncomment for full function dumping support.
-	-- Not currently enabled because bytecode isn't very human-readable and
-	-- dump's output is intended for humans.
-	--elseif tp == "function" then
-	--	return string.format("loadstring(%q)", string.dump(o))
 	elseif tp == "userdata" then
 		return tostring(o)
 	else

--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -190,7 +190,33 @@ local function serialize(value, write)
 	dump(value)
 end
 
+-- Whether `value` recursively contains a function
+local function contains_function(value)
+	local seen = {}
+	local function check(val)
+		if type(val) == "function" then
+			return true
+		end
+		if type(val) == "table" then
+			if seen[val] then
+				return false
+			end
+			seen[val] = true
+			for k, v in pairs(val) do
+				if check(k) or check(v) then
+					return true
+				end
+			end
+		end
+		return false
+	end
+	return check(value)
+end
+
 function core.serialize(value)
+	if contains_function(value) then
+		core.log("deprecated", "Support for dumping functions in `core.serialize` is deprecated.")
+	end
 	local rope = {}
 	serialize(value, function(text)
 		 -- Faster than table.insert(rope, text) on PUC Lua 5.1

--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -23,3 +23,5 @@ This list is largely advisory and items may be reevaluated once the time comes.
 * stop reading initial properties from bare entity def
 * change particle default blend mode to `clip`
 * remove built-in knockback and related functions entirely
+* remove `safe` parameter from `core.serialize`, always enforce `safe = true`.
+  possibly error when `loadstring` calls are encountered in `core.deserialize`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7600,7 +7600,7 @@ Misc.
     * Will silently strip functions embedded via calls to `loadstring`
       (typically bytecode dumped by `core.serialize`) if `safe` is `true`.
       You should not rely on this if possible.
-      * Example: `core.deserialize("return loadstring''", true)` will be `nil`.
+      * Example: `core.deserialize("return loadstring('')", true)` will be `nil`.
     * This function should not be used on untrusted data, regardless of the
      value of `safe`. It is fine to serialize then deserialize user-provided
      data, but directly providing user input to deserialize is always unsafe.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7588,14 +7588,19 @@ Misc.
 * `core.serialize(table)`: returns a string
     * Convert a table containing tables, strings, numbers, booleans and `nil`s
       into string form readable by `core.deserialize`
+    * Support for dumping function bytecode is **deprecated**.
     * Example: `serialize({foo="bar"})`, returns `'return { ["foo"] = "bar" }'`
 * `core.deserialize(string[, safe])`: returns a table
     * Convert a string returned by `core.serialize` into a table
     * `string` is loaded in an empty sandbox environment.
-    * Will load functions if safe is false or omitted. Although these functions
-      cannot directly access the global environment, they could bypass this
-      restriction with maliciously crafted Lua bytecode if mod security is
-      disabled.
+    * Will load functions if `safe` is `false` or omitted.
+      Although these functions cannot directly access the global environment,
+      they could bypass this restriction with maliciously crafted Lua bytecode
+      if mod security is disabled.
+    * Will silently strip functions embedded via calls to `loadstring`
+      (typically bytecode dumped by `core.serialize`) if `safe` is `true`.
+      You should not rely on this if possible.
+      * Example: `core.deserialize("return loadstring''", true)` will be `nil`.
     * This function should not be used on untrusted data, regardless of the
      value of `safe`. It is fine to serialize then deserialize user-provided
      data, but directly providing user input to deserialize is always unsafe.


### PR DESCRIPTION
This deprecates support for dumping functions in `core.serialize`. Consequently, support for loading (or silently stripping) functions in `core.deserialize` is also deprecated. There are a plethora of reasons for this:

1. This just dumps bytecode, which is not portable.
2. If mod security is enabled, loading bytecode will cause an error.
3. Dumping functions is very restricted. Most functions won't work correctly after being dumped because upvalues are not preserved. Only pure functions that only use the environment have a chance to work.
4. Even more, for security reasons, we change the environment to a fresh, essentially empty one, so practically no function will really work, unless environments are somehow restored.
5. General security-ish reasons of a wanted data-code separation; especially with metatables allowing functions in object data is risky. (Though this should not be used on user-provided data to begin with.)

Note that it seems support for functions in `core.serialize` was never documented in `lua_api.md`.

I have strong doubts that this feature was ever used, or indeed can even be used, productively [^1]. Either way the nastiness significantly outweighs any slight benefits so this ought to be deprecated. Almost everyone who is (by accident?) using this feature is probably doing something wrong and deserves to get a warning.

[^1]: except for most trivial functions like simple mathematical formulae (e.g. `function(a, b) return a + b end`) - but even in this trivial example, issues (1) and (2) apply.

## How to test

Basic unit tests are included. You should also dump the following three lines in a mod:

```
core.serialize(function() end)
core.deserialize("return loadstring''", true)
core.deserialize("return loadstring''", false)
```

and check that something like this comes out:

```
2025-04-21 16:30:23: WARNING[ServerStart]: Support for dumping functions in `core.serialize` is deprecated. (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:357)
2025-04-21 16:30:23: WARNING[ServerStart]: Stripping function(s) in `core.deserialize` as `safe = true`. This will be an error in the future. (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:358)
2025-04-21 16:30:23: WARNING[ServerStart]: Support for loading functions in `core.deserialize` is deprecated. (at /home/lars/luanti/games/devtest/mods/unittests/misc.lua:359)
```

to verify that I got the stack levels right.

## See also

https://irc.luanti.org/luanti-dev/2025-04-20#i_6256627 this tripped up pgimeno [^2] as it resulted in nonprintable bytecode output (`%q` isn't enough), but most strings will be printable - bytecode isn't.

[^2]: arguably they were looking for `dump`ing rather than serialization