### PR TITLE
Switch to smallint for position keys (x,y,z) in postgres backend

### DIFF
--- a/src/database/database-postgresql.cpp
+++ b/src/database/database-postgresql.cpp
@@ -164,9 +164,9 @@ void MapDatabasePostgreSQL::createDatabase()
 {
 	createTableIfNotExists("blocks",
 		"CREATE TABLE blocks ("
-			"posX INT NOT NULL,"
-			"posY INT NOT NULL,"
-			"posZ INT NOT NULL,"
+			"posX smallint NOT NULL,"
+			"posY smallint NOT NULL,"
+			"posZ smallint NOT NULL,"
 			"data BYTEA,"
 			"PRIMARY KEY (posX,posY,posZ)"
 			");"


### PR DESCRIPTION
adopted #9108

#### tl;dr

this can save gigabytes on the db index and is probably also faster.
it's also backwards-compatible (but won't automatically apply).
note: I tested this in 2020 so I didn't do that again.

#### how to migrate

```sql
alter table blocks alter posX type smallint;
alter table blocks alter posY type smallint;
alter table blocks alter posZ type smallint;
```