### PR TITLE
Extend ore clust_scarcity semantics

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4852,7 +4852,7 @@ Ore attributes
 See section [Flag Specifier Format].
 
 Currently supported flags:
-`puff_cliffs`, `puff_additive_composition`.
+`puff_cliffs`, `puff_additive_composition`, `extended_scarcity`.
 
 ### `puff_cliffs`
 
@@ -4868,6 +4868,22 @@ this attribute set, puff ore generation will instead generate the absolute
 difference in noise displacement values. This flag has no effect for ore types
 other than `puff`.
 
+### `extended_scarcity`
+
+By default the number of scatter/blob ore clusters generated per volume is the
+quotient of the Euclidean division of the eligible volume (the chunk volume
+limited by `y_min` and `y_max` values of the ore def) by the `clust_scarcity`
+value of the ore def. This can cause ore generation to deviate significantly
+from the intuitive interpretation of the `clust_scarcity` value, especially
+when eligible volume gets small (because of a narrow y range potentially caused
+by a chunk border within the y range of the ore def), or `clust_scarcity` gets
+large for rare ores. If eligible volume gets smaller than `clust_scarcity` no
+ore nodes will be generated at all for that ore def. If this flag is set,
+scatter and blob ores may randomly generate an additional ore cluster in a
+volume. The chance for this additional cluster depends on the remainder of the
+division of eligible volume by `clust_scarcity` restoring the intuitive meaning
+of `clust_scarcity`. Setting this flag does not change the placement of the
+clusters that would be generated without this flag.
 
 
 
@@ -10772,7 +10788,11 @@ See [Ores] section above for essential information.
     clust_scarcity = 8 * 8 * 8,
     -- Ore has a 1 out of clust_scarcity chance of spawning in a node.
     -- If the desired average distance between ores is 'd', set this to
-    -- d * d * d.
+    -- d * d * d. Also see discussion of the flag `extended_scarcity` in
+    -- the 'Ore attributes' section above. Note that without that flag
+    -- the largest `clust_scarcity` to actually generate any ore nodes is
+    -- 80*80*<height of ore layer in chunk> when using the default
+    -- chunksize.
 
     clust_num_ores = 8,
     -- Number of ores in a cluster

--- a/src/mapgen/mg_ore.cpp
+++ b/src/mapgen/mg_ore.cpp
@@ -17,6 +17,7 @@ const FlagDesc flagdesc_ore[] = {
 	{"absheight",                 OREFLAG_ABSHEIGHT}, // Non-functional
 	{"puff_cliffs",               OREFLAG_PUFF_CLIFFS},
 	{"puff_additive_composition", OREFLAG_PUFF_ADDITIVE},
+	{"extended_scarcity",         OREFLAG_EXT_SCARCITY},
 	{NULL,                        0}
 };
 
@@ -144,7 +145,14 @@ void OreScatter::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	u32 cvolume    = csize * csize * csize;
 	u32 nclusters = volume / clust_scarcity;
 
-	for (u32 i = 0; i != nclusters; i++) {
+	for (u32 i = 0; i <= nclusters; i++) {
+		// With OREFLAG_EXT_SCARCITY add an additional cluster with chance
+		// proportional to the truncated fractional part of nclusters
+		if (i == nclusters &&
+			!((flags & OREFLAG_EXT_SCARCITY) &&
+				(((u32) pr.range(1, clust_scarcity)) <= (volume % clust_scarcity))))
+			break;
+
 		int x0 = pr.range(nmin.X, nmax.X - csize + 1);
 		int y0 = pr.range(nmin.Y, nmax.Y - csize + 1);
 		int z0 = pr.range(nmin.Z, nmax.Z - csize + 1);
@@ -366,7 +374,14 @@ void OreBlob::generate(MMVManip *vm, int mapseed, u32 blockseed,
 	if (!noise)
 		noise = new Noise(&np, mapseed, csize, csize, csize);
 
-	for (u32 i = 0; i != nblobs; i++) {
+	for (u32 i = 0; i <= nblobs; i++) {
+		// With OREFLAG_EXT_SCARCITY add an additional blob with chance
+		// proportional to the truncated fractional part of nblobs
+		if (i == nblobs &&
+			!((flags & OREFLAG_EXT_SCARCITY) &&
+				(((u32) pr.range(1, clust_scarcity)) <= (volume % clust_scarcity))))
+			break;
+
 		int x0 = pr.range(nmin.X, nmax.X - csize + 1);
 		int y0 = pr.range(nmin.Y, nmax.Y - csize + 1);
 		int z0 = pr.range(nmin.Z, nmax.Z - csize + 1);

--- a/src/mapgen/mg_ore.h
+++ b/src/mapgen/mg_ore.h
@@ -23,6 +23,7 @@ class MMVManip;
 #define OREFLAG_PUFF_ADDITIVE 0x04
 #define OREFLAG_USE_NOISE     0x08
 #define OREFLAG_USE_NOISE2    0x10
+#define OREFLAG_EXT_SCARCITY  0x20
 
 enum OreType {
 	ORE_SCATTER,


### PR DESCRIPTION
Closes #16065.

Scatter and blob ores only generate whole clusters, causing `clust_scarcity` to become quite inaccurate as a measure of clusters per volume for very rare ores (or even for not so rare ones when y range is small, possibly caused by a chunk border within the ore y range).

Introduce new ore flag `extended_scarcity` to randomly generate an additional cluster in a chunk depending on the remainder of the volume/clust_scarcity division.

This only checks the pr whether to place an additional cluster after all other clusters have been placed, keeping their position identical with and without the flag.

Add compact, short information about your PR for easier understanding:

## To do

This PR is Ready for Review.

- [ ] Review that I used the correct amount of casting and parenthesises 
- [ ] Check the wording of the documentation (it became rather verbose, but the problem is mostly that the current behavior is not obvious)

## How to test

Use the Skyblock:zero example from #16065 to verify (eyeballing seems to work just fine at that rarity) that
- `clust_scarcity = 80*80*80` generates the same distribution as before with and without the new `extended_scarcity` ore flag
- `clust_scarcity = 80*80*80+1` generates no emitters (as before) without the new flag and a different, but similar to `80*80*80` distribution with the flag
- `clust_scarcity = 80*80*40+1` generates the same distribution as before without the flag (which is the same as `80*80*80`); with the new flag it generates the exact same ore positions plus about the same amount of additional emitters giving a total number of emitters similar to `80*80*40`