### PR TITLE
Change exit keybinding and fix bug in allow_close[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Some can be changed in the key config dialog in the settings tab.
 | T                             | Chat                                                           |
 | /                             | Command                                                        |
 | Esc                           | Pause menu/abort/exit (pauses only singleplayer game)          |
-| Ctrl + Esc                    | Exit directly to main menu from anywhere, bypassing pause menu |
+| Shift + Esc                   | Exit directly to main menu from anywhere, bypassing pause menu |
 | +                             | Increase view range                                            |
 | -                             | Decrease view range                                            |
 | K                             | Enable/disable fly mode (needs fly privilege)                  |

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -151,7 +151,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			fullscreen_is_down = event.KeyInput.PressedDown;
 			return true;
 		} else if (keyCode == EscapeKey &&
-				event.KeyInput.PressedDown && event.KeyInput.Control) {
+				event.KeyInput.PressedDown && event.KeyInput.Shift) {
 			g_gamecallback->disconnect();
 			return true;
 		}

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -206,7 +206,10 @@ public:
 
 	void defaultAllowClose(bool value)
 	{
+		// Also set m_allowclose here in order to have the correct value if
+		// escape is pressed before regenerateGui() is called.
 		m_default_allowclose = value;
+		m_allowclose = value;
 	}
 
 	void setDebugView(bool value)


### PR DESCRIPTION
Fixes #16067, and fixes https://github.com/luanti-org/luanti/pull/15971#issuecomment-2821566270 with hopefully no other unforeseen consequences by changing Ctrl + Esc to Shift + Esc.

## To do

This PR is Ready for Review.

## How to test

Make sure your window manager doesn't use Shift + Esc for anything, and test that main menu can't be closed while opening.