### PR TITLE
CI: Use gcc-9 and clang-11 with Ubuntu 22.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,12 +49,16 @@ jobs:
         env:
           CC: gcc-9
           CXX: g++-9
-          # Test fallback SHA implementations
-          CMAKE_FLAGS: '-DENABLE_OPENSSL=0'
+          CMAKE_FLAGS: '-DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
 
-      - name: Test
+      - name: Unittest
         run: |
           ./bin/luanti --run-unittests
+
+      # Do this here because we have ASan and error paths are sensitive to dangling pointers
+      - name: Test error cases
+        run: |
+          ./util/test_error_cases.sh
 
   # Current gcc version
   gcc_14:
@@ -88,7 +92,7 @@ jobs:
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps clang-11 llvm-11
+          install_linux_deps clang-11
 
       - name: Build
         run: |
@@ -96,16 +100,12 @@ jobs:
         env:
           CC: clang-11
           CXX: clang++-11
-          CMAKE_FLAGS: '-DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
+          # Test fallback SHA implementations
+          CMAKE_FLAGS: '-DENABLE_OPENSSL=0'
 
-      - name: Unittest
+      - name: Test
         run: |
           ./bin/luanti --run-unittests
-
-      # Do this here because we have ASan and error paths are sensitive to dangling pointers
-      - name: Test error cases
-        run: |
-          ./util/test_error_cases.sh
 
   # Current clang version
   clang_18:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,21 +34,21 @@ env:
 
 jobs:
   # Older gcc version (should be close to our minimum supported version)
-  gcc_7:
-    runs-on: ubuntu-20.04
+  gcc_9:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps g++-7
+          install_linux_deps g++-9
 
       - name: Build
         run: |
           ./util/ci/build.sh
         env:
-          CC: gcc-7
-          CXX: g++-7
+          CC: gcc-9
+          CXX: g++-9
           # Test fallback SHA implementations
           CMAKE_FLAGS: '-DENABLE_OPENSSL=0'
 
@@ -81,21 +81,21 @@ jobs:
           ../bin/luanti --run-unittests
 
   # Older clang version (should be close to our minimum supported version)
-  clang_7:
-    runs-on: ubuntu-20.04
+  clang_11:
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install deps
         run: |
           source ./util/ci/common.sh
-          install_linux_deps clang-7 llvm-7
+          install_linux_deps clang-11 llvm-11
 
       - name: Build
         run: |
           ./util/ci/build.sh
         env:
-          CC: clang-7
-          CXX: clang++-7
+          CC: clang-11
+          CXX: clang++-11
           CMAKE_FLAGS: '-DCMAKE_C_FLAGS="-fsanitize=address" -DCMAKE_CXX_FLAGS="-fsanitize=address"'
 
       - name: Unittest


### PR DESCRIPTION
Fix #15840 

This PR replaces the old gcc-7 and clang-7 tests on Ubuntu 20.04 with gcc-9 and clang-11 on Ubuntu 22.04, the minimum versions on this operating system. It addresses the fact that GitHub Actions has removed support for Ubuntu 20.04 in its runners.