### PR TITLE
[no squash] httpfetch improvements

### DIFF
--- a/builtin/game/features.lua
+++ b/builtin/game/features.lua
@@ -46,6 +46,7 @@ core.features = {
 	biome_weights = true,
 	particle_blend_clip = true,
 	remove_item_match_meta = true,
+	httpfetch_additional_methods = true,
 }
 
 function core.has_feature(arg)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -11849,7 +11849,7 @@ Used by `HTTPApiTable.fetch` and `HTTPApiTable.fetch_async`.
     multipart = boolean
     -- Optional, if true performs a multipart HTTP request.
     -- Default is false.
-    -- Post only, data must be array
+    -- Not allowed for GET method and `data` must be a table.
 
     post_data = "Raw POST request data string" OR {field1 = "data1", field2 = "data2"},
     -- Deprecated, use `data` instead. Forces `method = "POST"`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5780,6 +5780,8 @@ Utilities
       particle_blend_clip = true,
       -- The `match_meta` optional parameter is available for `InvRef:remove_item()` (5.12.0)
       remove_item_match_meta = true,
+      -- The HTTP API supports the HEAD and PATCH methods (5.12.0)
+      httpfetch_additional_methods = true,
   }
   ```
 
@@ -11824,22 +11826,22 @@ Used by `HTTPApiTable.fetch` and `HTTPApiTable.fetch_async`.
 
 ```lua
 {
-    url = "http://example.org",
+    url = "https://example.org",
 
     timeout = 10,
     -- Timeout for request to be completed in seconds. Default depends on engine settings.
 
-    method = "GET", "POST", "PUT" or "DELETE"
+    method = "GET", "HEAD", "POST", "PUT", "PATCH" or "DELETE"
     -- The http method to use. Defaults to "GET".
 
-    data = "Raw request data string" OR {field1 = "data1", field2 = "data2"},
-    -- Data for the POST, PUT or DELETE request.
+    data = "Raw request data string" or {field1 = "data1", field2 = "data2"},
+    -- Data for the POST, PUT, PATCH or DELETE request.
     -- Accepts both a string and a table. If a table is specified, encodes
     -- table as x-www-form-urlencoded key-value pairs.
 
     user_agent = "ExampleUserAgent",
     -- Optional, if specified replaces the default Luanti user agent with
-    -- given string
+    -- given string.
 
     extra_headers = { "Accept-Language: en-us", "Accept-Charset: utf-8" },
     -- Optional, if specified adds additional headers to the HTTP request.
@@ -11849,7 +11851,7 @@ Used by `HTTPApiTable.fetch` and `HTTPApiTable.fetch_async`.
     multipart = boolean
     -- Optional, if true performs a multipart HTTP request.
     -- Default is false.
-    -- Not allowed for GET method and `data` must be a table.
+    -- Not allowed for GET or HEAD method and `data` must be a table.
 
     post_data = "Raw POST request data string" OR {field1 = "data1", field2 = "data2"},
     -- Deprecated, use `data` instead. Forces `method = "POST"`.
@@ -11877,7 +11879,8 @@ Passed to `HTTPApiTable.fetch` callback. Returned by
     code = 200,
     -- HTTP status code
 
-    data = "response"
+    data = "",
+    -- Response body
 }
 ```
 

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -300,12 +300,14 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 			break;
 		}
 		if (request.method != HTTP_GET) {
-			if (!request.raw_data.empty()) {
+			if (request.fields.empty()) {
+				// Note that we need to set this to an empty buffer (not NULL)
+				// even if no data is to be sent.
 				curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE,
 						request.raw_data.size());
 				curl_easy_setopt(curl, CURLOPT_POSTFIELDS,
 						request.raw_data.c_str());
-			} else if (!request.fields.empty()) {
+			} else {
 				std::string str;
 				for (auto &field : request.fields) {
 					if (!str.empty())
@@ -314,10 +316,8 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 					str += "=";
 					str += urlencode(field.second);
 				}
-				curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE,
-						str.size());
-				curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS,
-						str.c_str());
+				curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, str.size());
+				curl_easy_setopt(curl, CURLOPT_COPYPOSTFIELDS, str.c_str());
 			}
 		}
 	}

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -65,7 +65,7 @@ struct HTTPFetchRequest
 	// Fields of the request
 	StringMap fields;
 
-	// Raw data of the request overrides fields
+	// Raw data of the request (instead of fields)
 	std::string raw_data;
 
 	// If not empty, should contain entries such as "Accept: text/html"

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -31,8 +31,10 @@ namespace {
 enum HttpMethod : u8
 {
 	HTTP_GET,
+	HTTP_HEAD,
 	HTTP_POST,
 	HTTP_PUT,
+	HTTP_PATCH,
 	HTTP_DELETE,
 };
 

--- a/src/httpfetch.h
+++ b/src/httpfetch.h
@@ -55,23 +55,22 @@ struct HTTPFetchRequest
 	long connect_timeout;
 
 	// Indicates if this is multipart/form-data or
-	// application/x-www-form-urlencoded.  POST-only.
+	// application/x-www-form-urlencoded. Not allowed for GET.
 	bool multipart = false;
 
-	//  The Method to use default = GET
-	//  Avaible methods GET, POST, PUT, DELETE
+	// Method to use
 	HttpMethod method = HTTP_GET;
 
 	// Fields of the request
 	StringMap fields;
 
-	// Raw data of the request (instead of fields)
+	// Raw data of the request (instead of fields, ignored if multipart)
 	std::string raw_data;
 
 	// If not empty, should contain entries such as "Accept: text/html"
 	std::vector<std::string> extra_headers;
 
-	// useragent to use
+	// User agent to send
 	std::string useragent;
 
 	HTTPFetchRequest();


### PR DESCRIPTION
fixes #14846

## How to test

1)
```lua
local http_api = assert(minetest.request_http_api())
local function test()
	http_api.fetch({
		url = "https://httpbin.org/put",
		method = "PUT",
	}, function(result)
	    print(dump(result))
	end)
end
minetest.after(1.2, test)
minetest.after(6, test)
```
should work without freezing

2)
```lua
local http_api = assert(minetest.request_http_api())
local function test()
	http_api.fetch({
		url = "https://httpbin.org/put",
		method = "PUT",
		multipart = true,
		data = {hmm = "yes"},
	}, function(result)
	    print(dump(result))
	end)
end
minetest.after(1.10, test)
```
should complete successfully

3)
```lua
local http_api = assert(minetest.request_http_api())
local function test()
	http_api.fetch({
		url = "https://www.luanti.org/",
		method = "HEAD",
	}, function(result)
	    print(dump(result))
	end)
end
minetest.after(1.25, test)
```
should complete successfully