### PR TITLE
Fix situation around using skinned meshes for nodes

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9393,7 +9393,8 @@ Player properties need to be saved manually.
     -- to scale the entity along both horizontal axes.
 
     mesh = "model.obj",
-    -- File name of mesh when using "mesh" visual
+    -- File name of mesh when using "mesh" visual.
+    -- For legacy reasons, this uses a 10x scale for meshes: 10 units = 1 node.
 
     textures = {},
     -- Number of required textures depends on visual:
@@ -10165,6 +10166,10 @@ Used by `core.register_node`.
 
     mesh = "",
     -- File name of mesh when using "mesh" drawtype
+    -- The center of the node is the model origin.
+    -- Due to historical reasons, .obj files use a scale of 1 node = 1 unit;
+    -- all other model file formats use a scale of 1 node = 10 units,
+    -- consistent with the scale used for entities.
 
     selection_box = {
         -- see [Node boxes] for possibilities

--- a/irr/include/SkinnedMesh.h
+++ b/irr/include/SkinnedMesh.h
@@ -162,12 +162,13 @@ public:
 		//! Weight Strength/Percentage (0-1)
 		f32 strength;
 
+		core::vector3df StaticPos;
+		core::vector3df StaticNormal;
+
 	private:
 		//! Internal members used by SkinnedMesh
 		friend class SkinnedMesh;
 		char *Moved;
-		core::vector3df StaticPos;
-		core::vector3df StaticNormal;
 	};
 
 	template <class T>

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -39,11 +39,6 @@ scene::IAnimatedMesh* createCubeMesh(v3f scale);
 */
 void scaleMesh(scene::IMesh *mesh, v3f scale);
 
-/*
-	Translate each vertex coordinate by the specified vector.
-*/
-void translateMesh(scene::IMesh *mesh, v3f vec);
-
 /*!
  * Sets a constant color for all vertices in the mesh buffer.
  */

--- a/src/nodedef.cpp
+++ b/src/nodedef.cpp
@@ -950,8 +950,9 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 		// Read the mesh and apply scale
 		mesh_ptr = client->getMesh(mesh);
 		if (mesh_ptr) {
-			v3f scale = v3f(BS) * visual_scale;
-			scaleMesh(mesh_ptr, scale);
+			auto *skinned_mesh = dynamic_cast<scene::SkinnedMesh *>(mesh_ptr);
+			// Compatibility: Do not apply BS scaling to skinned meshes. See #15811.
+			scaleMesh(mesh_ptr, v3f(skinned_mesh ? 1.0f : BS) * visual_scale);
 			recalculateBoundingBox(mesh_ptr);
 			if (!checkMeshNormals(mesh_ptr)) {
 				infostream << "ContentFeatures: recalculating normals for mesh "
@@ -961,8 +962,8 @@ void ContentFeatures::updateTextures(ITextureSource *tsrc, IShaderSource *shdsrc
 				// Animation is not supported, but we need to reset it to
 				// default state if it is animated.
 				// Note: recalculateNormals() also does this hence the else-block
-				if (mesh_ptr->getMeshType() == scene::EAMT_SKINNED)
-					((scene::SkinnedMesh*) mesh_ptr)->resetAnimation();
+				if (skinned_mesh)
+					skinned_mesh->resetAnimation();
 			}
 		}
 	}


### PR DESCRIPTION
Ameliorates the situation around using skinned mesh formats (like `.gltf`) for nodes. Relates to #15811, but in the interest of maintaining compatibility, refuses to fix it.

Fixes the bug that made `visual_scale` not apply to nodes by fixing `scaleMesh`. (I could also reorder things, but that would seem brittle: Something could just call `resetAnimation` at a later point in time and break it again.)

## How to test

Apply

```diff
diff --git a/games/devtest/mods/gltf/init.lua b/games/devtest/mods/gltf/init.lua
index f6a8f9bdf..e2cb79ce4 100644
--- a/games/devtest/mods/gltf/init.lua
+++ b/games/devtest/mods/gltf/init.lua
@@ -89,6 +89,7 @@ core.register_node("gltf:frog", {
 	tiles = {{name = "gltf_frog.png", backface_culling = false}},
 	drawtype = "mesh",
 	mesh = "gltf_frog.gltf",
+	visual_scale = 10,
 })
 
 core.register_chatcommand("show_model", {
```

observe a healthily sized frog:

![Screenshot from 2025-04-26 18-55-50](https://github.com/user-attachments/assets/3ee9ec59-acab-47d5-85e4-c5832a972c31)
