### PR TITLE
Move dirs to luanti and linux and bsd to xdg

### DIFF
--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -449,8 +449,7 @@ bool setSystemPaths()
 		// Use "C:\Users\<user>\AppData\Roaming\<PROJECT_NAME_C>"
 		len = GetEnvironmentVariable("APPDATA", buf, sizeof(buf));
 		FATAL_ERROR_IF(len == 0 || len > sizeof(buf), "Failed to get APPDATA");
-		// TODO: Luanti with migration
-		path_user = std::string(buf) + DIR_DELIM + "Minetest";
+		path_user = std::string(buf) + DIR_DELIM PROJECT_NAME_C;
 	} else {
 		path_user = std::string(buf);
 	}
@@ -466,7 +465,7 @@ bool setSystemPaths()
 extern bool setSystemPaths(); // defined in porting_android.cpp
 
 
-//// Linux
+//// XDG systems
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 
 bool setSystemPaths()
@@ -515,9 +514,12 @@ bool setSystemPaths()
 	if (minetest_user_path && minetest_user_path[0] != '\0') {
 		path_user = std::string(minetest_user_path);
 	} else {
-		// TODO: luanti with migration
-		path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
-			+ "minetest";
+		const char *const xdg_data = getenv("XDG_DATA_HOME");
+		if (xdg_data) {
+			path_user = std::string(xdg_data);
+		} else {
+			path_user = std::string(getHomeOrFail()) + DIR_DELIM ".local" DIR_DELIM "share" DIR_DELIM PROJECT_NAME;
+		}
 	}
 
 	return true;
@@ -544,10 +546,9 @@ bool setSystemPaths()
 	if (minetest_user_path && minetest_user_path[0] != '\0') {
 		path_user = std::string(minetest_user_path);
 	} else {
-		// TODO: luanti with migration
 		path_user = std::string(getHomeOrFail())
 			+ "/Library/Application Support/"
-			+ "minetest";
+			PROJECT_NAME;
 	}
 	return true;
 }
@@ -562,9 +563,7 @@ bool setSystemPaths()
 	if (minetest_user_path && minetest_user_path[0] != '\0') {
 		path_user = std::string(minetest_user_path);
 	} else {
-		// TODO: luanti with migration
-		path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
-			+ "minetest";
+		path_user  = std::string(getHomeOrFail()) + DIR_DELIM "." PROJECT_NAME;
 	}
 	return true;
 }
@@ -670,13 +669,10 @@ void initializePaths()
 	const char *cache_dir = getenv("XDG_CACHE_HOME");
 	const char *home_dir = getenv("HOME");
 	if (cache_dir && cache_dir[0] != '\0') {
-		// TODO: luanti with migration
-		path_cache = std::string(cache_dir) + DIR_DELIM + "minetest";
+		path_cache = std::string(cache_dir) + DIR_DELIM PROJECT_NAME;
 	} else if (home_dir) {
 		// Then try $HOME/.cache/PROJECT_NAME
-		// TODO: luanti with migration
-		path_cache = std::string(home_dir) + DIR_DELIM + ".cache"
-			+ DIR_DELIM + "minetest";
+		path_cache = std::string(home_dir) + DIR_DELIM ".cache" DIR_DELIM PROJECT_NAME;
 	} else {
 		// If neither works, use $PATH_USER/cache
 		path_cache = path_user + DIR_DELIM + "cache";


### PR DESCRIPTION
- Goal of the PR
Rename legacy dirs to luanti
- How does the PR work?
Renames legacy dirs to luanti
- Does it resolve any reported issue?
https://github.com/luanti-org/luanti/issues/15322
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Idk
- If not a bug fix, why is this PR needed? What usecases does it solve?
It makes easer dump luanti data on xdg systems

## To do

This PR is a Work in Progress.

- [x] Move linux and bsd systems to xdg spec dirs
- [x] Move windows and mac to luanti dir
- [ ] Move android to luanti dir
- [ ] Migrate legacy dirs to new in code

## How to test

Build luanti without RUN_IN_PLACE and check .local/share/luanti on linux or bsd, or "C\Users\<user>\AppData\Roaming\Luanti" on windows or /Users/<user>/Library/Application Support/luanti on mac
