### PR TITLE
Speed up active block management when player looks around

### DIFF
--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -194,6 +194,7 @@ void RemoteClient::GetNextBlocks (
 		m_nearest_unsent_d = 0;
 		m_last_camera_dir = camera_dir;
 		m_map_send_completion_timer = 0.0f;
+		env->setFastActiveBlockDivider(4);
 	}
 
 	s16 d_start = m_nearest_unsent_d;

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -434,7 +434,7 @@ std::unique_ptr<PlayerSAO> ServerEnvironment::loadPlayer(RemotePlayer *player, s
 	}
 
 	// Update active blocks quickly for a bit so objects in those blocks appear on the client
-	m_fast_active_block_divider = 10;
+	setFastActiveBlockDivider(10);
 
 	return playersao;
 }

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -280,6 +280,9 @@ public:
 	AuthDatabase *getAuthDatabase() { return m_auth_database; }
 	static bool migrateAuthDatabase(const GameParams &game_params,
 			const Settings &cmd_args);
+	void setFastActiveBlockDivider(int val) {
+		m_fast_active_block_divider = rangelim(val, 1, 10);
+	}
 private:
 
 	/**


### PR DESCRIPTION
This one might be slightly controversial. I am not emotionally attached to it. The server will do (slightly) more work, each time any player looks around more than 10%FOV.

The `active_block_mgmt_interval` defaults to 2.0s. That includes handling of blocks with active object in the cone defined by `active_object_send_range_blocks`.
So as you look around it takes up to 2s for objects to pop into sight (if they are farther away than `active_block_range`).

So what this is doing: If a player's camera angle changes by more than 10% of the FOV, use the mechanism from #12925 to reduce the `active_block_mgmt_interval` for few cycles. This sets the divider to smaller number than #12925, because (a) it's not quite as important than missing an object you were attached to when you join a server, and (b) a layer looks around much more than joining a server :)

The divider is set to 4, which means the interval (default) will be 500ms, 667ms, 1000ms, and then back to 2000ms.

- Goal of the PR

See above.

- How does the PR work?

See above

- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

In a world with entities, set `viewing_range` to maybe 500+ and `active_object_send_range_blocks` to 16 (or so). Make sure some entities are there, then move away from the entities more than 64 nodes (default `active_block_range` is 4). Then look away from the entities for at least 2s, then look back. Notice the time it takes for the entities to pop into existence. Then try the same with this PR, and notice how it more seamless.
