### PR TITLE
Remove PrefersNonDefaultGPU from desktop file

### DIFF
--- a/misc/AppImageBuilder.yml
+++ b/misc/AppImageBuilder.yml
@@ -56,5 +56,3 @@ script: |
     # Is a backup icon location in case
     mkdir -p AppDir/usr/share/luanti/misc
     cp AppDir/usr/share/icons/hicolor/128x128/apps/luanti.png AppDir/usr/share/luanti/misc/luanti-xorg-icon-128.png
-    # Validation issues
-    sed -i '/PrefersNonDefaultGPU/d' AppDir/usr/share/applications/org.luanti.luanti.desktop

--- a/misc/org.luanti.luanti.desktop
+++ b/misc/org.luanti.luanti.desktop
@@ -7,7 +7,7 @@ Comment[fr]=Plate-forme de jeu multijoueurs à base de blocs
 Exec=luanti
 Icon=luanti
 Terminal=false
-PrefersNonDefaultGPU=true
+# Note: don't add PrefersNonDefaultGPU here, see #16095
 Type=Application
 Categories=Game;Simulation;
 StartupNotify=false


### PR DESCRIPTION
- removes PrefersNonDefaultGPU from desktop file and AppImage builder recipe
- the use of PrefersNonDefaultGPU is currently broken due to being misinterpreted by Desktop Environments and similar
- more details can be found here https://github.com/ValveSoftware/steam-for-linux/issues/9940
- a fix has been proposed to [switcheroo-control](https://gitlab.freedesktop.org/hadess/switcheroo-control/-/merge_requests/69) as well as [Gnome](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3193), [KDE](https://invent.kde.org/frameworks/kio/-/merge_requests/1556) and [Cinnamon](https://github.com/linuxmint/xapp/pull/178)

This PR is a Ready for Review.

## How to test

The change will only affect multi-GPU setups where the discrete GPU is the default and the integrated is not, this will only affect a small subset of people.
