### PR TITLE
Detect mouse moving out of inventory slot

### DIFF
--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -203,9 +203,9 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 	if (!hovered || hovered->getID() == -1)
 		hovered = m_fs_menu;
 
-	bool ret = hovered->OnEvent(event);
-
 	IsVisible = was_visible;
+
+	bool ret = hovered->OnEvent(event);
 
 	return ret;
 }


### PR DESCRIPTION
Fixes #16100.

Currently moving the mouse out of an inventory slot, e.g. into the area between two slots, will make that inventory list invisible during event processing, causing the old mouse position check in the formspec event processing code to erroneously return an invalid slot if the old position is a slot in the same inventory list, which in turn causes the event to be ignored, even though the pointed at item changes.

Fortunately it seems that currently it's good enough to detect moving the pointer into a slot - which works - and no action on moving out is needed, but that might just be an accident. At least the formspec code doesn't look like it expects a displayed invlist to suddenly go into full stealth mode.

This patch restores inv list visibility before propagating the event. Shouldn't make an observable difference currently, but allows the formspec event code to act normally on leaving a slot in the future.

I haven't found anything user observable in the event processing of `GUiFormspeMenu` that currently depends on the visibility of the inventory list, so it shouldn't  cause any issues, but one never knows:-)