### PR TITLE
Replace "SMeshBuffer.h" with "CMeshBuffer.h"

### DIFF
--- a/irr/include/SMeshBuffer.h
+++ b/irr/include/SMeshBuffer.h
@@ -1,6 +1,0 @@
-// Copyright (C) 2002-2012 Nikolaus Gebhardt
-// This file is part of the "Irrlicht Engine".
-// For conditions of distribution and use, see copyright notice in irrlicht.h
-
-// replaced by template
-#include "CMeshBuffer.h" // IWYU pragma: export

--- a/irr/include/SkinnedMesh.h
+++ b/irr/include/SkinnedMesh.h
@@ -6,7 +6,7 @@
 
 #include "IAnimatedMesh.h"
 #include "ISceneManager.h"
-#include "SMeshBuffer.h"
+#include "CMeshBuffer.h"
 #include "SSkinMeshBuffer.h"
 #include "quaternion.h"
 #include "vector3d.h"

--- a/irr/src/CBillboardSceneNode.h
+++ b/irr/src/CBillboardSceneNode.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "IBillboardSceneNode.h"
-#include "SMeshBuffer.h"
+#include "CMeshBuffer.h"
 
 namespace irr
 {

--- a/irr/src/COBJMeshFileLoader.cpp
+++ b/irr/src/COBJMeshFileLoader.cpp
@@ -6,7 +6,7 @@
 #include "IMeshManipulator.h"
 #include "IVideoDriver.h"
 #include "SMesh.h"
-#include "SMeshBuffer.h"
+#include "CMeshBuffer.h"
 #include "SAnimatedMesh.h"
 #include "IReadFile.h"
 #include "fast_atof.h"

--- a/irr/src/COBJMeshFileLoader.h
+++ b/irr/src/COBJMeshFileLoader.h
@@ -8,7 +8,7 @@
 #include "IMeshLoader.h"
 #include "ISceneManager.h"
 #include "irrString.h"
-#include "SMeshBuffer.h"
+#include "CMeshBuffer.h"
 
 namespace irr
 {

--- a/src/client/clouds.h
+++ b/src/client/clouds.h
@@ -6,12 +6,16 @@
 
 #include "irrlichttypes_bloated.h"
 #include "constants.h"
-#include "irr_ptr.h"
 #include "skyparams.h"
 #include <iostream>
+//irr includes
+#include <irr_ptr.h>
 #include <ISceneNode.h>
 #include <SMaterial.h>
-#include <SMeshBuffer.h>
+#include <CMeshBuffer.h>
+
+namespace scene = irr::scene;
+namespace video = irr::video;
 
 class IShaderSource;
 

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -3,10 +3,6 @@
 // Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 #include "content_cao.h"
-#include <IBillboardSceneNode.h>
-#include <ICameraSceneNode.h>
-#include <IMeshManipulator.h>
-#include <IAnimatedMeshSceneNode.h>
 #include "client/client.h"
 #include "client/renderingengine.h"
 #include "client/sound.h"
@@ -34,10 +30,17 @@
 #include <cmath>
 #include "client/shader.h"
 #include "client/minimap.h"
+//irr includes
+#include <IBillboardSceneNode.h>
+#include <ICameraSceneNode.h>
+#include <IMeshManipulator.h>
+#include <IAnimatedMeshSceneNode.h>
 #include <quaternion.h>
 #include <SMesh.h>
 #include <IMeshBuffer.h>
-#include <SMeshBuffer.h>
+#include <CMeshBuffer.h>
+
+using namespace irr;
 
 class Settings;
 struct ToolCapabilities;

--- a/src/client/hud.h
+++ b/src/client/hud.h
@@ -6,12 +6,17 @@
 #pragma once
 
 #include <vector>
-#include <IGUIFont.h>
-#include <SMaterial.h>
-#include <SMeshBuffer.h>
-#include "irr_ptr.h"
 #include "irr_aabb3d.h"
 #include "../hud.h"
+//irr includes
+#include <IGUIFont.h>
+#include <IMesh.h>
+#include <SMaterial.h>
+#include <CMeshBuffer.h>
+#include <irr_ptr.h>
+
+namespace scene = irr::scene;
+namespace video = irr::video;
 
 class Client;
 class ITextureSource;

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -3,7 +3,6 @@
 // Copyright (C) 2010-2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 #include "mapblock_mesh.h"
-#include "CMeshBuffer.h"
 #include "client.h"
 #include "mapblock.h"
 #include "map.h"
@@ -21,9 +20,12 @@
 #include <algorithm>
 #include <cmath>
 #include "client/texturesource.h"
+// irr includes
 #include <SMesh.h>
 #include <IMeshBuffer.h>
-#include <SMeshBuffer.h>
+#include <CMeshBuffer.h>
+
+using namespace irr;
 
 /*
 	MeshMakeData

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -5,9 +5,6 @@
 #pragma once
 
 #include "irrlichttypes.h"
-#include "irr_ptr.h"
-#include "IMesh.h"
-#include "SMeshBuffer.h"
 
 #include "util/numeric.h"
 #include "client/tile.h"
@@ -15,6 +12,13 @@
 #include <array>
 #include <map>
 #include <unordered_map>
+// irr includes
+#include <irr_ptr.h>
+#include <IMesh.h>
+#include <CMeshBuffer.h>
+
+namespace scene = irr::scene;
+namespace video = irr::video;
 
 namespace irr::video {
 	class IVideoDriver;

--- a/src/client/mesh.cpp
+++ b/src/client/mesh.cpp
@@ -7,12 +7,12 @@
 #include "log.h"
 #include <cmath>
 #include <iostream>
-#include <IAnimatedMesh.h>
-#include <SAnimatedMesh.h>
+// irr includes
 #include <IAnimatedMeshSceneNode.h>
-#include "S3DVertex.h"
-#include "SMesh.h"
-#include "SMeshBuffer.h"
+#include <S3DVertex.h>
+#include <CMeshBuffer.h>
+
+using namespace irr;
 
 inline static void applyShadeFactor(video::SColor& color, float factor)
 {

--- a/src/client/mesh.h
+++ b/src/client/mesh.h
@@ -7,6 +7,14 @@
 #include "SColor.h"
 #include "SMaterialLayer.h"
 #include "nodedef.h"
+// irr includes
+#include <SColor.h>
+#include <SMaterialLayer.h>
+#include <SMesh.h>
+#include <SAnimatedMesh.h>
+
+namespace scene = irr::scene;
+namespace video = irr::video;
 
 namespace irr {
 	namespace scene {

--- a/src/client/minimap.h
+++ b/src/client/minimap.h
@@ -5,9 +5,6 @@
 #pragma once
 
 #include "irrlichttypes.h"
-#include "irr_ptr.h"
-#include "rect.h"
-#include "SMeshBuffer.h"
 
 #include "../hud.h"
 #include "mapnode.h"
@@ -15,6 +12,13 @@
 #include <map>
 #include <string>
 #include <vector>
+// irr includes
+#include <irr_ptr.h>
+#include <rect.h>
+#include <CMeshBuffer.h>
+
+namespace scene = irr::scene;
+namespace video = irr::video;
 
 namespace irr {
 	namespace video {

--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -22,7 +22,7 @@
 #include "settings.h"
 #include "profiler.h"
 
-#include "SMeshBuffer.h"
+using namespace irr;
 
 using BlendMode = ParticleParamTypes::BlendMode;
 

--- a/src/client/particles.h
+++ b/src/client/particles.h
@@ -5,16 +5,20 @@
 #pragma once
 
 #include "irrlichttypes_bloated.h"
-#include "irr_ptr.h"
-#include "ISceneNode.h"
-#include "S3DVertex.h"
-#include "SMeshBuffer.h"
 
+#include "../particles.h"
 #include <mutex>
 #include <memory>
 #include <vector>
 #include <unordered_map>
-#include "../particles.h"
+// irr includes
+#include <irr_ptr.h>
+#include <ISceneNode.h>
+#include <S3DVertex.h>
+#include <CMeshBuffer.h>
+
+namespace scene = irr::scene;
+namespace video = irr::video;
 
 namespace irr::video {
 	class ITexture;

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -5,14 +5,18 @@
 #pragma once
 
 #include "irrlichttypes_bloated.h"
-#include <ISceneNode.h>
-#include <SMeshBuffer.h>
 #include <array>
 #include "camera.h" // CameraMode
-#include "irr_ptr.h"
 #include "skyparams.h"
+// irr includes
+#include <ISceneNode.h>
+#include <CMeshBuffer.h>
+#include <irr_ptr.h>
 
 #define SKY_MATERIAL_COUNT 12
+
+namespace scene = irr::scene;
+namespace video = irr::video;
 
 namespace irr::video
 {

--- a/src/client/wieldmesh.cpp
+++ b/src/client/wieldmesh.cpp
@@ -18,12 +18,13 @@
 #include "log.h"
 #include "util/numeric.h"
 #include <map>
-#include <IMeshManipulator.h>
 #include "client/renderingengine.h"
-#include <SMesh.h>
-#include <IMeshBuffer.h>
-#include <SMeshBuffer.h>
 #include "item_visuals_manager.h"
+// irr includes
+#include <IMeshManipulator.h>
+#include <CMeshBuffer.h>
+
+using namespace irr;
 
 #define WIELD_SCALE_FACTOR 30.0f
 #define WIELD_SCALE_FACTOR_EXTRUDED 40.0f


### PR DESCRIPTION
- Replaces references to `SMeshBuffer.h` with `CMeshBuffer.h` in header files
- Adds `using namespace irr;` to the corresponding `.cpp` files in `/src` 
  - This will make it easier to remove `using namespace irr` from header files in the future
- Make namespaces more explicit (`video::SColor` to `irr::video::SColor`) 
  - This will also make it easier to remove `using namespace irr` from header files in the future
- Organize header includes to better indicate what includes come from `/irr` directly
  - `#include "irr_ptr.h"` -> `#include <irr_ptr.h>` as an example
  - Moved irr includes so they are visually separate from other includes
- Delete `SMeshBuffer.h`

## To do

This PR is Ready for Review.
