### PR TITLE
Mainmenu: Fix error after ESC in dialog windows

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -166,13 +166,9 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 core.button_handler = function(fields)
-	if fields["try_quit"] then
-		for name, value in pairs(ui.childlist) do
-			if value.type == "toplevel" and name ~= ui.default then
-				core.event_handler("MenuQuit")
-				return
-			end
-		end
+	if fields["try_quit"] and not fields["key_enter"] then
+		core.event_handler("MenuQuit")
+		return
 	end
 	if fields["btn_reconnect_yes"] then
 		gamedata.reconnect_requested = false

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -166,6 +166,10 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 core.button_handler = function(fields)
+	if fields["try_quit"] and ui.overridden then
+		core.event_handler("MenuQuit")
+		return
+	end
 	if fields["btn_reconnect_yes"] then
 		gamedata.reconnect_requested = false
 		gamedata.errormessage = nil

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -166,9 +166,13 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 core.button_handler = function(fields)
-	if fields["try_quit"] and ui.overridden then
-		core.event_handler("MenuQuit")
-		return
+	if fields["try_quit"] then
+		for name, value in pairs(ui.childlist) do
+			if value.type == "toplevel" and name ~= ui.default then
+				core.event_handler("MenuQuit")
+				return
+			end
+		end
 	end
 	if fields["btn_reconnect_yes"] then
 		gamedata.reconnect_requested = false

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4053,7 +4053,6 @@ void GUIFormSpecMenu::tryClose()
 		quitMenu();
 	} else {
 		acceptInput(quit_mode_try);
-		m_text_dst->gotText(L"MenuQuit");
 	}
 }
 


### PR DESCRIPTION
The error was caused by fd857374, where 'MenuQuit' was processed after 'try_quit'. This commit fixes the error by moving the special 'MenuQuit' handling to Lua.

Fixes #16115 

## To do

This PR is Ready for Review.

## How to test

1. Enter a wrong password in the server list
2. Close the "access denied" dialogue by ESC
3. No error
4. Ensure there's no error for other dialogues.
