### PR TITLE
Fix black font and menu header when game exits in background

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -367,9 +367,6 @@ Client::~Client()
 	for (auto &csp : m_sounds_client_to_server)
 		m_sound->freeId(csp.first);
 	m_sounds_client_to_server.clear();
-
-	// Go back to our mainmenu fonts
-	g_fontengine->clearMediaFonts();
 }
 
 void Client::connect(const Address &address, const std::string &address_name)

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -531,6 +531,16 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 {
 	bool *kill = porting::signal_handler_killstatus();
 	video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
+	auto *device = m_rendering_engine->get_raw_device();
+
+	// Wait until app is in foreground because of #15883
+	infostream << "Waiting for app to be in foreground" << std::endl;
+	while (m_rendering_engine->run() && !*kill) {
+		if (device->isWindowVisible())
+			break;
+		sleep_ms(25);
+	}
+	infostream << "Waited for app to be in foreground" << std::endl;
 
 	infostream << "Waiting for other menus" << std::endl;
 	auto framemarker = FrameMarker("ClientLauncher::main_menu()-wait-frame").started();
@@ -548,7 +558,7 @@ void ClientLauncher::main_menu(MainMenuData *menudata)
 	framemarker.end();
 	infostream << "Waited for other menus" << std::endl;
 
-	auto *cur_control = m_rendering_engine->get_raw_device()->getCursorControl();
+	auto *cur_control = device->getCursorControl();
 	if (cur_control) {
 		// Cursor can be non-visible when coming from the game
 		cur_control->setVisible(true);

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -117,6 +117,10 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 	m_data(data),
 	m_kill(kill)
 {
+	// Go back to our mainmenu fonts
+	// Delayed until mainmenu initialization because of #15883
+	g_fontengine->clearMediaFonts();
+
 	// initialize texture pointers
 	for (image_definition &texture : m_textures) {
 		texture.texture = NULL;


### PR DESCRIPTION
fixes #15883

## To do

This PR is a Ready for Review.

## How to test

1. see https://github.com/luanti-org/luanti/issues/15883#issuecomment-2824265569. also check the logs to verify that the "Waiting/waited for app to be in foreground" messages appear at the expected times.

2. verify that mod-provided custom fonts are still reset properly when going back to the mainmenu