### PR TITLE
Fix table[] focus regression from f4285a5

### DIFF
--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -32,7 +32,7 @@ GUITable::GUITable(gui::IGUIEnvironment *env,
 		core::rect<s32> rectangle,
 		ISimpleTextureSource *tsrc
 ):
-	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
+	gui::IGUIElement(gui::EGUIET_TABLE, env, parent, id, rectangle),
 	m_tsrc(tsrc)
 {
 	assert(tsrc != NULL);


### PR DESCRIPTION
Fixes #16132. When using the table's proper GUI element type in the checks, I somehow forgot to edit the constructor to also use the proper type. This PR fixes that, so the checks now work.

For extra caution, you can grep through the codebase for usages of these element types. (Which looks fine to me.)