### PR TITLE
Formspec: Fix broken 9-slice image button with gui_scaling_filter

### DIFF
--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -718,18 +718,23 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	setUseAlphaChannel(style.getBool(StyleSpec::ALPHA, true));
 	setOverrideFont(style.getFont());
 
+	BgMiddle = style.getRect(StyleSpec::BGIMG_MIDDLE, BgMiddle);
+
 	if (style.isNotDefault(StyleSpec::BGIMG)) {
 		video::ITexture *texture = style.getTexture(StyleSpec::BGIMG,
 				getTextureSource());
-		setImage(guiScalingImageButton(
-				Environment->getVideoDriver(), texture,
-						AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
+		if (BgMiddle.getArea() == 0) {
+			setImage(guiScalingImageButton(
+					Environment->getVideoDriver(), texture,
+							AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
+		} else {
+			// Scaling happens in `draw2DImage9Slice`
+			setImage(texture);
+		}
 		setScaleImage(true);
 	} else {
 		setImage(nullptr);
 	}
-
-	BgMiddle = style.getRect(StyleSpec::BGIMG_MIDDLE, BgMiddle);
 
 	// Child padding and offset
 	Padding = style.getRect(StyleSpec::PADDING, core::rect<s32>());


### PR DESCRIPTION
Fixes #16145

With this change, custom button background images scale the same as backgrounds
created using 'background9[...]' (9-slice images). I believe the current inconsistency is not intentional, thus this PR. I don't know whether to label this as a bug or feature.

**Before:** (using the textures and code from the 2nd commit)
![Image](https://github.com/user-attachments/assets/0dca6441-9b02-43e4-8997-fc312bf553a0)
`/test_formspec` -> "Styles" tab:
![grafik](https://github.com/user-attachments/assets/9ac939c3-2b57-4ab0-a42a-82b79c3a5cce)


**After:** (using the textures and code from the 2nd commit)
![grafik](https://github.com/user-attachments/assets/98572784-f2ed-4dec-8cb1-0332f6a86bb9)
`/test_formspec` -> "Styles" tab:
![grafik](https://github.com/user-attachments/assets/00cc207d-39bf-4c77-9a04-6a2b6144ea34)

Unfortunately the scrollbar "buttons" are not styled this way, but that's to address in another PR.

## To do

This PR is Ready for Review.


## How to test

1. Apply commit https://github.com/luanti-org/luanti/pull/16146/commits/f14b4950d5b8a062331d388cf25609cadd31d131
2. Compare before/after
