### PR TITLE
Monoblocks: optimize blocks that contain a single type of node

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -57,7 +57,7 @@ void MeshMakeData::fillBlockData(const v3s16 &bp, MapNode *data)
 	VoxelArea data_area(v3s16(0,0,0), data_size - v3s16(1,1,1));
 
 	v3s16 blockpos_nodes = bp * MAP_BLOCKSIZE;
-	m_vmanip.copyFrom(data, MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE, data_area, v3s16(0,0,0), blockpos_nodes, data_size);
+	m_vmanip.copyFrom(data, false, data_area, v3s16(0,0,0), blockpos_nodes, data_size);
 }
 
 void MeshMakeData::fillSingleNode(MapNode data, MapNode padding)

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -57,7 +57,7 @@ void MeshMakeData::fillBlockData(const v3s16 &bp, MapNode *data)
 	VoxelArea data_area(v3s16(0,0,0), data_size - v3s16(1,1,1));
 
 	v3s16 blockpos_nodes = bp * MAP_BLOCKSIZE;
-	m_vmanip.copyFrom(data, data_area, v3s16(0,0,0), blockpos_nodes, data_size);
+	m_vmanip.copyFrom(data, MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE, data_area, v3s16(0,0,0), blockpos_nodes, data_size);
 }
 
 void MeshMakeData::fillSingleNode(MapNode data, MapNode padding)

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -117,7 +117,8 @@ MapBlock::~MapBlock()
 #endif
 
 	delete[] data;
-	porting::TrackFreedMemory(sizeof(MapNode) * nodecount);
+	if (!m_is_mono_block)
+		porting::TrackFreedMemory(sizeof(MapNode) * nodecount);
 }
 
 static inline size_t get_max_objects_per_block()

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -101,10 +101,10 @@ static const char *modified_reason_strings[] = {
 */
 
 MapBlock::MapBlock(v3s16 pos, IGameDef *gamedef):
-		m_is_mono_block(true),
 		m_pos(pos),
 		m_pos_relative(pos * MAP_BLOCKSIZE),
-		m_gamedef(gamedef)
+		m_gamedef(gamedef),
+		m_is_mono_block(true)
 {
 	reallocate(1, MapNode(CONTENT_IGNORE));
 }

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -429,7 +429,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 	const u8 params_width = 2;
 	if(disk)
 	{
-		const int size = m_is_mono_block ? 1 : nodecount;
+		const size_t size = m_is_mono_block ? 1 : nodecount;
 		MapNode *tmp_nodes = new MapNode[size];
 		memcpy(tmp_nodes, data, size * sizeof(MapNode));
 		getBlockNodeIdMapping(&nimap, tmp_nodes, m_gamedef->ndef(), size);

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -211,10 +211,13 @@ void MapBlock::copyTo(VoxelManipulator &dst)
 	v3s16 data_size(MAP_BLOCKSIZE, MAP_BLOCKSIZE, MAP_BLOCKSIZE);
 	VoxelArea data_area(v3s16(0,0,0), data_size - v3s16(1,1,1));
 
+	bool was_mono_block = m_is_mono_block;
 	deconvertMonoblock();
 	// Copy from data to VoxelManipulator
 	dst.copyFrom(data, data_area, v3s16(0,0,0),
 			getPosRelative(), data_size);
+	if (was_mono_block)
+		tryConvertToMonoblock();
 }
 
 void MapBlock::copyFrom(const VoxelManipulator &src)
@@ -226,8 +229,18 @@ void MapBlock::copyFrom(const VoxelManipulator &src)
 	// Copy from VoxelManipulator to data
 	src.copyTo(data, data_area, v3s16(0,0,0),
 			getPosRelative(), data_size);
-
 	tryConvertToMonoblock();
+}
+
+void MapBlock::reallocate(u32 c, MapNode n)
+{
+	delete[] data;
+	if (c == 1)
+		porting::TrackFreedMemory(sizeof(MapNode) * nodecount);
+
+	data = new MapNode[c];
+	for (u32 i = 0; i < c; i++)
+		data[i] = n;
 }
 
 void MapBlock::tryConvertToMonoblock()

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -297,12 +297,12 @@ void MapBlock::expireIsAirCache()
 // Note that there's no technical reason why we *have to* renumber the IDs,
 // but we do it anyway as it also helps compressability.
 static void getBlockNodeIdMapping(NameIdMapping *nimap, MapNode *nodes,
-	const NodeDefManager *nodedef, bool is_mono_block)
+	const NodeDefManager *nodedef, u32 nodecount)
 {
 	IdIdMapping &mapping = IdIdMapping::giveClearedThreadLocalInstance();
 
 	content_t id_counter = 0;
-	for (u32 i = 0; i < (is_mono_block ? 1 : MapBlock::nodecount); i++) {
+	for (u32 i = 0; i < nodecount; i++) {
 		content_t global_id = nodes[i].getContent();
 		content_t id = CONTENT_IGNORE;
 
@@ -424,7 +424,7 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 			tmp_nodes = new MapNode[nodecount];
 			memcpy(tmp_nodes, data, nodecount * sizeof(MapNode));
 		}
-		getBlockNodeIdMapping(&nimap, tmp_nodes, m_gamedef->ndef(), m_is_mono_block);
+		getBlockNodeIdMapping(&nimap, tmp_nodes, m_gamedef->ndef(), m_is_mono_block ? 1 : nodecount);
 
 		buf = MapNode::serializeBulk(version, tmp_nodes, nodecount,
 				content_width, params_width, m_is_mono_block);

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -212,13 +212,9 @@ void MapBlock::copyTo(VoxelManipulator &dst)
 	v3s16 data_size(MAP_BLOCKSIZE, MAP_BLOCKSIZE, MAP_BLOCKSIZE);
 	VoxelArea data_area(v3s16(0,0,0), data_size - v3s16(1,1,1));
 
-	bool was_mono_block = m_is_mono_block;
-	deconvertMonoblock();
 	// Copy from data to VoxelManipulator
-	dst.copyFrom(data, data_area, v3s16(0,0,0),
+	dst.copyFrom(data, m_is_mono_block ? 1 : nodecount, data_area, v3s16(0,0,0),
 			getPosRelative(), data_size);
-	if (was_mono_block)
-		tryConvertToMonoblock();
 }
 
 void MapBlock::copyFrom(const VoxelManipulator &src)

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -232,6 +232,13 @@ void MapBlock::copyFrom(const VoxelManipulator &src)
 	src.copyTo(data, data_area, v3s16(0,0,0),
 			getPosRelative(), data_size);
 
+	checkForMonoblock();
+}
+
+void MapBlock::checkForMonoblock() {
+	if (m_is_mono_block)
+		return;
+
 	MapNode n = data[0];
 	bool is_mono_block = true;
 	for (u32 i=1; i<nodecount; i++) {
@@ -628,8 +635,7 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 		}
 
 		if (nimap.size() == 1) {
-			m_is_mono_block = true;
-			reallocate(1, data[0]);
+			checkForMonoblock();
 			u16 dummy;
 			if (nimap.getId("air", dummy)) {
 				m_is_air = true;

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -104,9 +104,9 @@ MapBlock::MapBlock(v3s16 pos, IGameDef *gamedef):
 		m_pos(pos),
 		m_pos_relative(pos * MAP_BLOCKSIZE),
 		m_gamedef(gamedef),
-		m_is_mono_block(true)
+		m_is_mono_block(false)
 {
-	reallocate(1, MapNode(CONTENT_IGNORE));
+	reallocate(nodecount, MapNode(CONTENT_IGNORE));
 }
 
 MapBlock::~MapBlock()

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -429,17 +429,10 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 	const u8 params_width = 2;
 	if(disk)
 	{
-		MapNode *tmp_nodes;
-		if (m_is_mono_block) {
-			tmp_nodes = new MapNode[1];
-			tmp_nodes[0] = data[0];
-		}
-		else
-		{
-			tmp_nodes = new MapNode[nodecount];
-			memcpy(tmp_nodes, data, nodecount * sizeof(MapNode));
-		}
-		getBlockNodeIdMapping(&nimap, tmp_nodes, m_gamedef->ndef(), m_is_mono_block ? 1 : nodecount);
+		const int size = m_is_mono_block ? 1 : nodecount;
+		MapNode *tmp_nodes = new MapNode[size];
+		memcpy(tmp_nodes, data, size * sizeof(MapNode));
+		getBlockNodeIdMapping(&nimap, tmp_nodes, m_gamedef->ndef(), size);
 
 		buf = MapNode::serializeBulk(version, tmp_nodes, nodecount,
 				content_width, params_width, m_is_mono_block);

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -231,6 +231,24 @@ void MapBlock::copyFrom(const VoxelManipulator &src)
 	// Copy from VoxelManipulator to data
 	src.copyTo(data, data_area, v3s16(0,0,0),
 			getPosRelative(), data_size);
+
+	MapNode n = data[0];
+	bool is_mono_block = true;
+	for (u32 i=1; i<nodecount; i++) {
+		if (n != data[i]) {
+			is_mono_block = false;
+			break;
+		}
+	}
+
+	if (is_mono_block) {
+		m_is_mono_block = true;
+		reallocate(1, n);
+		if (n.getContent() == CONTENT_AIR) {
+			m_is_air = true;
+			m_is_air_expired = false;
+		}
+	}
 }
 
 void MapBlock::actuallyUpdateIsAir()

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -421,7 +421,8 @@ void MapBlock::serialize(std::ostream &os_compressed, u8 version, bool disk, int
 			tmp_nodes = new MapNode[1];
 			tmp_nodes[0] = data[0];
 		}
-		else {
+		else
+		{
 			tmp_nodes = new MapNode[nodecount];
 			memcpy(tmp_nodes, data, nodecount * sizeof(MapNode));
 		}

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -75,10 +75,7 @@ public:
 
 	MapNode* getData()
 	{
-		if (m_is_mono_block) {
-			reallocate(nodecount, data[0]);
-			m_is_mono_block = false;
-		}
+		deconvertMonoblock();
 		return data;
 	}
 
@@ -255,10 +252,7 @@ public:
 		if (!isValidPosition(x, y, z))
 			throw InvalidPositionException();
 
-		if (m_is_mono_block) {
-			reallocate(nodecount, data[0]);
-			m_is_mono_block = false;
-		}
+		deconvertMonoblock();
 		data[z * zstride + y * ystride + x] = n;
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_SET_NODE);
 	}
@@ -287,10 +281,7 @@ public:
 
 	inline void setNodeNoCheck(s16 x, s16 y, s16 z, MapNode n)
 	{
-		if (m_is_mono_block) {
-			reallocate(nodecount, data[0]);
-			m_is_mono_block = false;
-		}
+		deconvertMonoblock();
 		data[z * zstride + y * ystride + x] = n;
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_SET_NODE);
 	}
@@ -449,7 +440,8 @@ private:
 	*/
 
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
-	void checkForMonoblock();
+	void tryConvertToMonoblock();
+	void deconvertMonoblock();
 
 	void reallocate(u32 c, MapNode n)
 	{
@@ -497,11 +489,11 @@ private:
 	short m_refcount = 0;
 
 	/*
-	 * Note that this is not an inline array because that has implications for
-	 * heap fragmentation (the array is exactly 16K), CPU caches and/or
-	 * optimizability of algorithms working on this array.
+	 * Note that this is not an inline array because that has implications for heap
+	 * fragmentation (the array is exactly 16K, or exactly 4 bytes for a "monoblock"),
+	 * CPU caches and/or optimizability of algorithms working on this array.
 	 */
-	MapNode * data = nullptr; // of `nodecount` elements
+	MapNode * data = nullptr;
 
 	// provides the item and node definitions
 	IGameDef *m_gamedef;

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -21,6 +21,9 @@ class NodeMetadataList;
 class IGameDef;
 class MapBlockMesh;
 class VoxelManipulator;
+#if BUILD_UNITTESTS
+class TestMapBlock;
+#endif
 
 #define BLOCK_TIMESTAMP_UNDEFINED 0xffffffff
 
@@ -429,6 +432,11 @@ public:
 	static const u32 nodecount = MAP_BLOCKSIZE * MAP_BLOCKSIZE * MAP_BLOCKSIZE;
 
 private:
+#if BUILD_UNITTESTS
+	// access to data, tryConvertToMonoBlock, deconvertMonoblock
+	friend class TestMapBlock;
+#endif
+
 	/*
 		Private methods
 	*/
@@ -436,17 +444,7 @@ private:
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
 	void tryConvertToMonoblock();
 	void deconvertMonoblock();
-
-	void reallocate(u32 c, MapNode n)
-	{
-		delete[] data;
-		if (c == 1)
-			porting::TrackFreedMemory(sizeof(MapNode) * nodecount);
-
-		data = new MapNode[c];
-		for (u32 i = 0; i < c; i++)
-			data[i] = n;
-	}
+	void reallocate(u32 c, MapNode n);
 
 	/*
 	 * PLEASE NOTE: When adding something here be mindful of position and size

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -444,7 +444,7 @@ private:
 	void tryShrinkNodes();
 	// if only a single node is stored, expand storage back to the full array
 	void expandNodesIfNeeded();
-	void reallocate(u32 c, MapNode n);
+	void reallocate(u32 count, MapNode n);
 
 	/*
 	 * PLEASE NOTE: When adding something here be mindful of position and size

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -76,7 +76,7 @@ public:
 
 	MapNode* getData()
 	{
-		deconvertMonoblock();
+		expandNodesIfNeeded();
 		return data;
 	}
 
@@ -250,7 +250,7 @@ public:
 		if (!isValidPosition(x, y, z))
 			throw InvalidPositionException();
 
-		deconvertMonoblock();
+		expandNodesIfNeeded();
 		data[z * zstride + y * ystride + x] = n;
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_SET_NODE);
 	}
@@ -276,7 +276,7 @@ public:
 
 	inline void setNodeNoCheck(s16 x, s16 y, s16 z, MapNode n)
 	{
-		deconvertMonoblock();
+		expandNodesIfNeeded();
 		data[z * zstride + y * ystride + x] = n;
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_SET_NODE);
 	}
@@ -441,9 +441,9 @@ private:
 
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
 	// check if all nodes are identical, if so store them as a single node
-	void tryConvertToMonoblock();
+	void tryShrinkNodes();
 	// if only a single node is stored, expand storage back to the full array
-	void deconvertMonoblock();
+	void expandNodesIfNeeded();
 	void reallocate(u32 c, MapNode n);
 
 	/*
@@ -464,7 +464,7 @@ public:
 private:
 	// see isOrphan()
 	bool m_orphan = false;
-	bool m_is_mono_block = false;
+	bool m_is_mono_block;
 
 	// Position in blocks on parent
 	v3s16 m_pos;

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -21,9 +21,7 @@ class NodeMetadataList;
 class IGameDef;
 class MapBlockMesh;
 class VoxelManipulator;
-#if BUILD_UNITTESTS
 class TestMapBlock;
-#endif
 
 #define BLOCK_TIMESTAMP_UNDEFINED 0xffffffff
 
@@ -442,7 +440,9 @@ private:
 	*/
 
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
+	// check if all nodes are identical, if so store them as a single node
 	void tryConvertToMonoblock();
+	// if only a single node is stored, expand storage back to the full array
 	void deconvertMonoblock();
 	void reallocate(u32 c, MapNode n);
 

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -464,7 +464,6 @@ public:
 private:
 	// see isOrphan()
 	bool m_orphan = false;
-	bool m_is_mono_block;
 
 	// Position in blocks on parent
 	v3s16 m_pos;
@@ -499,6 +498,7 @@ private:
 	*/
 	float m_usage_timer = 0;
 
+	bool m_is_mono_block;
 public:
 	//// ABM optimizations ////
 	// True if we never want to cache content types for this block

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -449,6 +449,7 @@ private:
 	*/
 
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
+	void checkForMonoblock();
 
 	void reallocate(u32 c, MapNode n)
 	{

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -440,6 +440,9 @@ private:
 	void reallocate(u32 c, MapNode n)
 	{
 		delete[] data;
+		if (c == 1)
+			porting::TrackFreedMemory(sizeof(MapNode) * nodecount);
+
 		data = new MapNode[c];
 		for (u32 i = 0; i < c; i++)
 			data[i] = n;

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -230,10 +230,7 @@ public:
 		if (!*valid_position)
 			return {CONTENT_IGNORE};
 
-		if (m_is_mono_block)
-			return data[0];
-		else
-			return data[z * zstride + y * ystride + x];
+		return data[m_is_mono_block ? 0 : z * zstride + y * ystride + x];
 	}
 
 	inline MapNode getNode(v3s16 p, bool *valid_position)
@@ -268,10 +265,7 @@ public:
 
 	inline MapNode getNodeNoCheck(s16 x, s16 y, s16 z)
 	{
-		if (m_is_mono_block)
-			return data[0];
-		else
-			return data[z * zstride + y * ystride + x];
+		return data[m_is_mono_block ? 0 : z * zstride + y * ystride + x];
 	}
 
 	inline MapNode getNodeNoCheck(v3s16 p)

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -30,7 +30,7 @@ class TestMapBlock;
 ////
 
 enum ModReason : u32 {
-	MOD_REASON_REALLOCATE                 = 1 << 0,
+//	UNUSED                                = 1 << 0,
 	MOD_REASON_SET_IS_UNDERGROUND         = 1 << 1,
 	MOD_REASON_SET_LIGHTING_COMPLETE      = 1 << 2,
 	MOD_REASON_SET_GENERATED              = 1 << 3,
@@ -440,9 +440,9 @@ private:
 	*/
 
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
-	// check if all nodes are identical, if so store them as a single node
+	// check if all nodes are identical, if so convert to monoblock
 	void tryShrinkNodes();
-	// if only a single node is stored, expand storage back to the full array
+	// if a monoblock, expand storage back to the full array
 	void expandNodesIfNeeded();
 	void reallocate(u32 count, MapNode n);
 
@@ -487,7 +487,7 @@ private:
 	 * fragmentation (the array is exactly 16K, or exactly 4 bytes for a "monoblock"),
 	 * CPU caches and/or optimizability of algorithms working on this array.
 	 */
-	MapNode * data = nullptr;
+	MapNode *data = nullptr;
 
 	// provides the item and node definitions
 	IGameDef *m_gamedef;
@@ -498,6 +498,10 @@ private:
 	*/
 	float m_usage_timer = 0;
 
+	/*
+	 * For "monoblocks", the whole block is filled with the same node, only this node is stored.
+	 * (For reduced memory usage)
+	 */
 	bool m_is_mono_block;
 public:
 	//// ABM optimizations ////

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -601,14 +601,21 @@ Buffer<u8> MapNode::serializeBulk(int version,
 
 	// Writing to the buffer linearly is faster
 	u8 *p = &databuf[0];
-	for (u32 i = 0; i < nodecount; i++, p += 2)
-		writeU16(p, nodes[is_mono_block ? 0 : i].param0);
-
-	for (u32 i = 0; i < nodecount; i++, p++)
-		writeU8(p, nodes[is_mono_block ? 0 : i].param1);
-
-	for (u32 i = 0; i < nodecount; i++, p++)
-		writeU8(p, nodes[is_mono_block ? 0 : i].param2);
+	if (is_mono_block) {
+		for (u32 i = 0; i < nodecount; i++, p += 2)
+			writeU16(p, nodes[0].param0);
+		for (u32 i = 0; i < nodecount; i++, p++)
+			writeU8(p, nodes[0].param1);
+		for (u32 i = 0; i < nodecount; i++, p++)
+			writeU8(p, nodes[0].param2);
+	} else {
+		for (u32 i = 0; i < nodecount; i++, p += 2)
+			writeU16(p, nodes[i].param0);
+		for (u32 i = 0; i < nodecount; i++, p++)
+			writeU8(p, nodes[i].param1);
+		for (u32 i = 0; i < nodecount; i++, p++)
+			writeU8(p, nodes[i].param2);
+	}
 
 	return databuf;
 }

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -589,7 +589,7 @@ void MapNode::deSerialize(const u8 *source, u8 version)
 
 Buffer<u8> MapNode::serializeBulk(int version,
 		const MapNode *nodes, u32 nodecount,
-		u8 content_width, u8 params_width)
+		u8 content_width, u8 params_width, bool is_mono_block)
 {
 	if (!ser_ver_supported_write(version))
 		throw VersionMismatchException("ERROR: MapNode format not supported");
@@ -602,13 +602,13 @@ Buffer<u8> MapNode::serializeBulk(int version,
 	// Writing to the buffer linearly is faster
 	u8 *p = &databuf[0];
 	for (u32 i = 0; i < nodecount; i++, p += 2)
-		writeU16(p, nodes[i].param0);
+		writeU16(p, nodes[is_mono_block ? 0 : i].param0);
 
 	for (u32 i = 0; i < nodecount; i++, p++)
-		writeU8(p, nodes[i].param1);
+		writeU8(p, nodes[is_mono_block ? 0 : i].param1);
 
 	for (u32 i = 0; i < nodecount; i++, p++)
-		writeU8(p, nodes[i].param2);
+		writeU8(p, nodes[is_mono_block ? 0 : i].param2);
 
 	return databuf;
 }

--- a/src/mapnode.cpp
+++ b/src/mapnode.cpp
@@ -602,12 +602,13 @@ Buffer<u8> MapNode::serializeBulk(int version,
 	// Writing to the buffer linearly is faster
 	u8 *p = &databuf[0];
 	if (is_mono_block) {
+		MapNode n = nodes[0];
 		for (u32 i = 0; i < nodecount; i++, p += 2)
-			writeU16(p, nodes[0].param0);
+			writeU16(p, n.param0);
 		for (u32 i = 0; i < nodecount; i++, p++)
-			writeU8(p, nodes[0].param1);
+			writeU8(p, n.param1);
 		for (u32 i = 0; i < nodecount; i++, p++)
-			writeU8(p, nodes[0].param2);
+			writeU8(p, n.param2);
 	} else {
 		for (u32 i = 0; i < nodecount; i++, p += 2)
 			writeU16(p, nodes[i].param0);

--- a/src/mapnode.h
+++ b/src/mapnode.h
@@ -307,7 +307,7 @@ struct alignas(u32) MapNode
 	//   compressed = true to zlib-compress output
 	static Buffer<u8> serializeBulk(int version,
 			const MapNode *nodes, u32 nodecount,
-			u8 content_width, u8 params_width);
+			u8 content_width, u8 params_width, bool is_mono_block = false);
 	static void deSerializeBulk(std::istream &is, int version,
 			MapNode *nodes, u32 nodecount,
 			u8 content_width, u8 params_width);

--- a/src/unittest/test_mapblock.cpp
+++ b/src/unittest/test_mapblock.cpp
@@ -57,21 +57,25 @@ void TestMapBlock::runTests(IGameDef *gamedef)
 void TestMapBlock::testMonoblock(IGameDef *gamedef)
 {
 	MapBlock block({}, gamedef);
-	UASSERT(block.m_is_mono_block);
-	block.data[0] = MapNode(CONTENT_AIR);
+	UASSERT(!block.m_is_mono_block);
 
 	// make the array is expanded
 	block.expandNodesIfNeeded();
-	UASSERT(std::all_of(block.data, block.data + MapBlock::nodecount, [](MapNode &n) { return n == MapNode(CONTENT_AIR); }));
+	UASSERT(std::all_of(block.data, block.data + MapBlock::nodecount, [](MapNode &n) { return n == MapNode(CONTENT_IGNORE); }));
 
 	// covert to monoblock
 	block.tryShrinkNodes();
+	UASSERT(block.m_is_mono_block);
+	UASSERT(block.data[0].param0 == CONTENT_IGNORE);
+
+	block.data[0] = MapNode(CONTENT_AIR);
 	UASSERT(block.m_is_mono_block);
 	UASSERT(block.data[0].param0 == CONTENT_AIR);
 
 	// get the data(), should deconvert the block
 	block.getData();
 	UASSERT(!block.m_is_mono_block);
+	UASSERT(std::all_of(block.data, block.data + MapBlock::nodecount, [](MapNode &n) { return n == MapNode(CONTENT_AIR); }));
 
 	// covert back to mono block
 	block.tryShrinkNodes();

--- a/src/unittest/test_mapblock.cpp
+++ b/src/unittest/test_mapblock.cpp
@@ -63,7 +63,7 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 		block.data[i] = MapNode(CONTENT_AIR);
 	}
 	// covert to monoblock
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
 	UASSERT(block.data[0].param0 == CONTENT_AIR);
 	UASSERT(block.data != t);
@@ -76,17 +76,17 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 	UASSERT(block.data == d1);
 
 	// covert back to mono block
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
 	t = block.data;
 
 	// deconvert explicitly
-	block.deconvertMonoblock();
+	block.expandNodesIfNeeded();
 	UASSERT(!block.m_is_mono_block);
 	UASSERT(block.data != t);
 
 	// covert back to mono block
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
 	t = block.data;
 
@@ -97,7 +97,7 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 	t = block.data;
 
 	// cannot covert to mono block
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(!block.m_is_mono_block);
 	UASSERT(block.data == t);
 
@@ -107,7 +107,7 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 	}
 
 	// can covert to mono block
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
 	UASSERT(block.data[0].param0 == 42);
 	UASSERT(block.data != t);
@@ -143,19 +143,19 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 	UASSERT(block.m_is_mono_block);
 
 	block.setNode(5,5,5,MapNode(23));
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(!block.m_is_mono_block);
 
 	block.setNode(5,5,5,MapNode(42, 1, 0));
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(!block.m_is_mono_block);
 
 	block.setNode(5,5,5,MapNode(42, 0, 1));
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(!block.m_is_mono_block);
 
 	block.setNode(5,5,5,MapNode(42));
-	block.tryConvertToMonoblock();
+	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
 }
 

--- a/src/unittest/test_mapblock.cpp
+++ b/src/unittest/test_mapblock.cpp
@@ -58,52 +58,40 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 {
 	MapBlock block({}, gamedef);
 	UASSERT(block.m_is_mono_block);
-	MapNode *t = block.data;
 	block.data[0] = MapNode(CONTENT_AIR);
 
+	// make the array is expanded
 	block.expandNodesIfNeeded();
-	UASSERT(block.data != t);
 	UASSERT(std::all_of(block.data, block.data + MapBlock::nodecount, [](MapNode &n) { return n == MapNode(CONTENT_AIR); }));
-	t = block.data;
 
 	// covert to monoblock
 	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
 	UASSERT(block.data[0].param0 == CONTENT_AIR);
-	UASSERT(block.data != t);
-	t = block.data;
 
 	// get the data(), should deconvert the block
-	MapNode *d1 = block.getData();
+	block.getData();
 	UASSERT(!block.m_is_mono_block);
-	UASSERT(block.data != t);
-	UASSERT(block.data == d1);
 
 	// covert back to mono block
 	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
-	t = block.data;
 
 	// deconvert explicitly
 	block.expandNodesIfNeeded();
 	UASSERT(!block.m_is_mono_block);
-	UASSERT(block.data != t);
 
 	// covert back to mono block
 	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
-	t = block.data;
 
 	// set a node, should deconvert the block
 	block.setNode(5,5,5, MapNode(42));
 	UASSERT(!block.m_is_mono_block);
-	UASSERT(block.data != t);
-	t = block.data;
 
 	// cannot covert to mono block
 	block.tryShrinkNodes();
 	UASSERT(!block.m_is_mono_block);
-	UASSERT(block.data == t);
 
 	// set all nodes to 42
 	for (size_t i = 0; i < MapBlock::nodecount; ++i) {
@@ -114,8 +102,6 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);
 	UASSERT(block.data[0].param0 == 42);
-	UASSERT(block.data != t);
-	t = block.data;
 
 	VoxelManipulator vmm;
 	v3s16 data_size(MAP_BLOCKSIZE, MAP_BLOCKSIZE, MAP_BLOCKSIZE);

--- a/src/unittest/test_mapblock.cpp
+++ b/src/unittest/test_mapblock.cpp
@@ -121,7 +121,6 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 	UASSERT(vmm.getNode({5,5,5}).param0 == 42);
 
 	block.setNode(5,5,5,MapNode(23));
-	t = block.data;
 
 	block.copyFrom(vmm);
 	UASSERT(block.m_is_mono_block);
@@ -130,6 +129,34 @@ void TestMapBlock::testMonoblock(IGameDef *gamedef)
 	vmm.setNode({5,5,5}, MapNode(23));
 	block.copyFrom(vmm);
 	UASSERT(!block.m_is_mono_block);
+
+	vmm.setNode({5,5,5}, MapNode(42,1,0));
+	block.copyFrom(vmm);
+	UASSERT(!block.m_is_mono_block);
+
+	vmm.setNode({5,5,5}, MapNode(42,0,1));
+	block.copyFrom(vmm);
+	UASSERT(!block.m_is_mono_block);
+
+	vmm.setNode({5,5,5}, MapNode(42));
+	block.copyFrom(vmm);
+	UASSERT(block.m_is_mono_block);
+
+	block.setNode(5,5,5,MapNode(23));
+	block.tryConvertToMonoblock();
+	UASSERT(!block.m_is_mono_block);
+
+	block.setNode(5,5,5,MapNode(42, 1, 0));
+	block.tryConvertToMonoblock();
+	UASSERT(!block.m_is_mono_block);
+
+	block.setNode(5,5,5,MapNode(42, 0, 1));
+	block.tryConvertToMonoblock();
+	UASSERT(!block.m_is_mono_block);
+
+	block.setNode(5,5,5,MapNode(42));
+	block.tryConvertToMonoblock();
+	UASSERT(block.m_is_mono_block);
 }
 
 void TestMapBlock::testSaveLoad(IGameDef *gamedef, const u8 version)

--- a/src/unittest/test_mapblock.cpp
+++ b/src/unittest/test_mapblock.cpp
@@ -57,11 +57,15 @@ void TestMapBlock::runTests(IGameDef *gamedef)
 void TestMapBlock::testMonoblock(IGameDef *gamedef)
 {
 	MapBlock block({}, gamedef);
-	UASSERT(!block.m_is_mono_block);
+	UASSERT(block.m_is_mono_block);
 	MapNode *t = block.data;
-	for (size_t i = 0; i < MapBlock::nodecount; ++i) {
-		block.data[i] = MapNode(CONTENT_AIR);
-	}
+	block.data[0] = MapNode(CONTENT_AIR);
+
+	block.expandNodesIfNeeded();
+	UASSERT(block.data != t);
+	UASSERT(std::all_of(block.data, block.data + MapBlock::nodecount, [](MapNode &n) { return n == MapNode(CONTENT_AIR); }));
+	t = block.data;
+
 	// covert to monoblock
 	block.tryShrinkNodes();
 	UASSERT(block.m_is_mono_block);

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -217,11 +217,11 @@ void VoxelManipulator::copyFrom(MapNode *src, size_t n_nodes, const VoxelArea& s
 	for (s16 z = 0; z < size.Z; z++) {
 		for (s16 y = 0; y < size.Y; y++) {
 			if (n_nodes == 1) {
-				std::fill(m_data + i_local, m_data + i_local + size.X, src[0]);
+				std::fill_n(m_data + i_local, size.X, src[0]);
 			} else {
-				std::copy(src + i_src, src + i_src + size.X, m_data + i_local);
+				std::copy_n(src + i_src, size.X, m_data + i_local);
 			}
-			std::fill(m_flags + i_local, m_flags + i_local + size.X, 0);
+			std::fill_n(m_flags + i_local, size.X, 0);
 			i_src += src_step;
 			i_local += dest_step;
 		}

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -177,7 +177,7 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 	delete[] old_flags;
 }
 
-void VoxelManipulator::copyFrom(MapNode *src, size_t n_nodes, const VoxelArea& src_area,
+void VoxelManipulator::copyFrom(MapNode *src, bool is_mono_block, const VoxelArea& src_area,
 		v3s16 from_pos, v3s16 to_pos, const v3s16 &size)
 {
 	/* The reason for this optimised code is that we're a member function
@@ -216,7 +216,7 @@ void VoxelManipulator::copyFrom(MapNode *src, size_t n_nodes, const VoxelArea& s
 
 	for (s16 z = 0; z < size.Z; z++) {
 		for (s16 y = 0; y < size.Y; y++) {
-			if (n_nodes == 1) {
+			if (is_mono_block) {
 				std::fill_n(m_data + i_local, size.X, src[0]);
 			} else {
 				std::copy_n(src + i_src, size.X, m_data + i_local);

--- a/src/voxel.cpp
+++ b/src/voxel.cpp
@@ -177,7 +177,7 @@ void VoxelManipulator::addArea(const VoxelArea &area)
 	delete[] old_flags;
 }
 
-void VoxelManipulator::copyFrom(MapNode *src, const VoxelArea& src_area,
+void VoxelManipulator::copyFrom(MapNode *src, size_t n_nodes, const VoxelArea& src_area,
 		v3s16 from_pos, v3s16 to_pos, const v3s16 &size)
 {
 	/* The reason for this optimised code is that we're a member function
@@ -216,8 +216,12 @@ void VoxelManipulator::copyFrom(MapNode *src, const VoxelArea& src_area,
 
 	for (s16 z = 0; z < size.Z; z++) {
 		for (s16 y = 0; y < size.Y; y++) {
-			memcpy(&m_data[i_local], &src[i_src], size.X * sizeof(*m_data));
-			memset(&m_flags[i_local], 0, size.X);
+			if (n_nodes == 1) {
+				std::fill(m_data + i_local, m_data + i_local + size.X, src[0]);
+			} else {
+				std::copy(src + i_src, src + i_src + size.X, m_data + i_local);
+			}
+			std::fill(m_flags + i_local, m_flags + i_local + size.X, 0);
 			i_src += src_step;
 			i_local += dest_step;
 		}

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -482,7 +482,7 @@ public:
 		Copy data and set flags to 0
 		dst_area.getExtent() <= src_area.getExtent()
 	*/
-	void copyFrom(MapNode *src, size_t n_nodes, const VoxelArea& src_area,
+	void copyFrom(MapNode *src, bool is_mono_block, const VoxelArea& src_area,
 			v3s16 from_pos, v3s16 to_pos, const v3s16 &size);
 
 	// Copy data

--- a/src/voxel.h
+++ b/src/voxel.h
@@ -482,7 +482,7 @@ public:
 		Copy data and set flags to 0
 		dst_area.getExtent() <= src_area.getExtent()
 	*/
-	void copyFrom(MapNode *src, const VoxelArea& src_area,
+	void copyFrom(MapNode *src, size_t n_nodes, const VoxelArea& src_area,
 			v3s16 from_pos, v3s16 to_pos, const v3s16 &size);
 
 	// Copy data


### PR DESCRIPTION
See discussion in #16097

For blocks that only contain a single type of node, that node is only stored once.
When copied to a VMANIP the full array is materialized. Could be optimized.

@appgurueu pointed out, rightly, that the normal compression we do in disk and on the wire naturally already takes care of mono-block, so this is just to save in process memory.

Only works on the server, currently. Making it work on the client would need a protocol version change.

- Goal of the PR, How does the PR work?
See description

- Does it resolve any reported issue?
#16097

## To do

This PR is a ready for review.

It needs mostly testing and a review of the approach.

## How to test

Try any world, new or existing, everything should just work.
There should be no measurable overall slowdown, and server memory usage should be drastically (50-90% depending on scene) reduced, especially with larger viewing ranging.