### PR TITLE
Fix uninitialized variable warning in generate_srp_verifier_and_salt

### DIFF
--- a/src/util/auth.cpp
+++ b/src/util/auth.cpp
@@ -67,9 +67,9 @@ void generate_srp_verifier_and_salt(const std::string &name,
 	std::string *salt)
 {
 	char *bytes_v = nullptr;
-	size_t verifier_len;
+	size_t verifier_len = 0;
 	char *salt_ptr = nullptr;
-	size_t salt_len;
+	size_t salt_len = 0;
 	gen_srp_v(name, password, &salt_ptr, &salt_len, &bytes_v, &verifier_len);
 	*verifier = std::string(bytes_v, verifier_len);
 	*salt = std::string(salt_ptr, salt_len);


### PR DESCRIPTION
I'm always compiling dev version to use at home (Debian 12) and the compile process is showing:

```
In function ‘_S_copy’,
    inlined from ‘_S_copy_chars’ at /usr/include/c++/12/bits/basic_string.h:477:16,
    inlined from ‘_M_construct’ at /usr/include/c++/12/bits/basic_string.tcc:243:21,
    inlined from ‘__ct ’ at /usr/include/c++/12/bits/basic_string.h:620:14,
    inlined from ‘generate_srp_verifier_and_salt.constprop’ at /home/daniel/src/luanti/src/util/auth.cpp:74:19:
/usr/include/c++/12/bits/basic_string.h:420:9: warning: ‘verifier_len’ may be used uninitialized [-Wmaybe-uninitialized]
  420 |         if (__n == 1)
      |         ^
/home/daniel/src/luanti/src/util/auth.cpp: In function ‘generate_srp_verifier_and_salt.constprop’:
/home/daniel/src/luanti/src/util/auth.cpp:70:16: note: ‘verifier_len’ was declared here
   70 |         size_t verifier_len;
      |                ^
```

This PR might have no effect, just initialize the values to avoid the warning and have a clean build.