### PR TITLE
[squash merge] Main menu: Fix ContentDB aliases for games having the '_game' suffix

### DIFF
--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -169,6 +169,7 @@ function contentdb.get_package_by_id(id)
 	return contentdb.package_by_id[id]
 end
 
+
 local function strip_game_suffix(type, name)
 	if (type == nil or type == "game") and #name > 5 and name:sub(#name - 4) == "_game" then
 		return name:sub(1, #name - 5)

--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -176,7 +176,6 @@ local function strip_game_suffix(type, name)
 		return name
 	end
 end
-	
 
 function contentdb.calculate_package_id(type, author, name)
 	return author:lower() .. "/" .. strip_game_suffix(type, name)

--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -433,7 +433,6 @@ function contentdb.set_packages_from_api(packages)
 			end
 		end
 	end
-	print(dump(contentdb.aliases))
 
 	contentdb.load_ok = true
 	contentdb.load_error = false

--- a/builtin/mainmenu/content/contentdb.lua
+++ b/builtin/mainmenu/content/contentdb.lua
@@ -169,15 +169,17 @@ function contentdb.get_package_by_id(id)
 	return contentdb.package_by_id[id]
 end
 
+local function strip_game_suffix(type, name)
+	if (type == nil or type == "game") and #name > 5 and name:sub(#name - 4) == "_game" then
+		return name:sub(1, #name - 5)
+	else
+		return name
+	end
+end
+	
 
 function contentdb.calculate_package_id(type, author, name)
-	local id = author:lower() .. "/"
-	if (type == nil or type == "game") and #name > 5 and name:sub(#name - 4) == "_game" then
-		id = id .. name:sub(1, #name - 5)
-	else
-		id = id .. name
-	end
-	return id
+	return author:lower() .. "/" .. strip_game_suffix(type, name)
 end
 
 
@@ -427,11 +429,12 @@ function contentdb.set_packages_from_api(packages)
 				-- We currently don't support name changing
 				local suffix = "/" .. package.name
 				if alias:sub(-#suffix) == suffix then
-					contentdb.aliases[alias:lower()] = package.id
+					contentdb.aliases[strip_game_suffix(packages.type, alias:lower())] = package.id
 				end
 			end
 		end
 	end
+	print(dump(contentdb.aliases))
 
 	contentdb.load_ok = true
 	contentdb.load_error = false


### PR DESCRIPTION
The objective is to fix #16063, but I did not fully test it, since I have no old installation of minetest_game with contentdb. However, I did check that the alias that now exists is `["minetest/minetest"] = "luanti/minetest"`.