### PR TITLE
Pr 16161 texture pack formspec theme

### DIFF
--- a/doc/texture_packs.md
+++ b/doc/texture_packs.md
@@ -38,6 +38,8 @@ A key-value config file with the following keys:
 * `textdomain`: Textdomain used to translate title and description.
   Defaults to the texture pack name.
   See [Translating content meta](lua_api.md#translating-content-meta).
+* `formspec_theme`: Optional default formspec styling.
+  This is a newline separated list of `style_type[...]` values.
 
 ### `description.txt`
 **Deprecated**, you should use texture_pack.conf instead.

--- a/src/gui/guiButton.cpp
+++ b/src/gui/guiButton.cpp
@@ -718,18 +718,23 @@ void GUIButton::setFromStyle(const StyleSpec& style)
 	setUseAlphaChannel(style.getBool(StyleSpec::ALPHA, true));
 	setOverrideFont(style.getFont());
 
+	BgMiddle = style.getRect(StyleSpec::BGIMG_MIDDLE, BgMiddle);
+
 	if (style.isNotDefault(StyleSpec::BGIMG)) {
 		video::ITexture *texture = style.getTexture(StyleSpec::BGIMG,
 				getTextureSource());
-		setImage(guiScalingImageButton(
-				Environment->getVideoDriver(), texture,
-						AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
+		if (BgMiddle.getArea() == 0) {
+			setImage(guiScalingImageButton(
+					Environment->getVideoDriver(), texture,
+							AbsoluteRect.getWidth(), AbsoluteRect.getHeight()));
+		} else {
+			// Scaling happens in `draw2DImage9Slice`
+			setImage(texture);
+		}
 		setScaleImage(true);
 	} else {
 		setImage(nullptr);
 	}
-
-	BgMiddle = style.getRect(StyleSpec::BGIMG_MIDDLE, BgMiddle);
 
 	// Child padding and offset
 	Padding = style.getRect(StyleSpec::PADDING, core::rect<s32>());

--- a/src/gui/guiButtonImage.cpp
+++ b/src/gui/guiButtonImage.cpp
@@ -24,6 +24,18 @@ GUIButtonImage::GUIButtonImage(gui::IGUIEnvironment *environment,
 	sendToBack(m_image.get());
 }
 
+void GUIButtonImage::draw()
+{
+	if (isDrawingBorder()) {
+		// `GUIButton` also allows drawing different textures depending on
+		// `EGUI_BUTTON_STATE` --> Skip everything if the border is disabled (else case).
+		GUIButton::draw();
+	} else {
+		IGUIElement::draw();
+	}
+}
+
+
 void GUIButtonImage::setForegroundImage(irr_ptr<video::ITexture> image,
 		const core::rect<s32> &middle)
 {

--- a/src/gui/guiButtonImage.h
+++ b/src/gui/guiButtonImage.h
@@ -19,6 +19,9 @@ public:
 			s32 id, core::rect<s32> rectangle, ISimpleTextureSource *tsrc,
 			bool noclip = false);
 
+	//! draws the element and its children
+	virtual void draw() override;
+
 	void setForegroundImage(irr_ptr<video::ITexture> image = nullptr,
 			const core::rect<s32> &middle = core::rect<s32>());
 

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -8,6 +8,7 @@
 #include "client/guiscalingfilter.h"
 #include "client/renderingengine.h"
 #include "client/shader.h"
+#include "client/texturepaths.h"
 #include "client/tile.h"
 #include "clientdynamicinfo.h"
 #include "config.h"
@@ -74,7 +75,12 @@ video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 	if (retval)
 		return retval;
 
-	video::IImage *image = m_driver->createImageFromFile(name.c_str());
+	// Try to find the texture in the active texture pack
+	std::string path;
+	if (!fs::IsPathAbsolute(name))
+		path = getTexturePath(name, nullptr);
+
+	video::IImage *image = m_driver->createImageFromFile(!path.empty() ? path.c_str() : name.c_str());
 	if (!image)
 		return NULL;
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -111,6 +111,8 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 
 	m_tooltip_show_delay = (u32)g_settings->getS32("tooltip_show_delay");
 	m_tooltip_append_itemname = g_settings->getBool("tooltip_append_itemname");
+
+	setThemeFromSettings();
 }
 
 GUIFormSpecMenu::~GUIFormSpecMenu()
@@ -2615,15 +2617,8 @@ void GUIFormSpecMenu::parsePadding(parserData *data, const std::string &element)
 			<< "'" << std::endl;
 }
 
-void GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element)
+void GUIFormSpecMenu::parseStyleToMap(StyleSpecMap &out, const std::string &element)
 {
-	if (data->type != "style" && data->type != "style_type") {
-		errorstream << "Invalid style element type: '" << data->type << "'" << std::endl;
-		return;
-	}
-
-	bool style_type = (data->type == "style_type");
-
 	std::vector<std::string> parts = split(element, ';');
 
 	if (parts.size() < 2) {
@@ -2702,11 +2697,7 @@ void GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element)
 			continue;
 		}
 
-		if (style_type) {
-			theme_by_type[selector].push_back(selector_spec);
-		} else {
-			theme_by_name[selector].push_back(selector_spec);
-		}
+		out[selector].push_back(selector_spec);
 
 		// Backwards-compatibility for existing _hovered/_pressed properties
 		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_HOVERED)
@@ -2725,11 +2716,7 @@ void GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element)
 				hover_spec.set(StyleSpec::FGIMG, selector_spec.get(StyleSpec::FGIMG_HOVERED, ""));
 			}
 
-			if (style_type) {
-				theme_by_type[selector].push_back(hover_spec);
-			} else {
-				theme_by_name[selector].push_back(hover_spec);
-			}
+			out[selector].push_back(hover_spec);
 		}
 		if (selector_spec.hasProperty(StyleSpec::BGCOLOR_PRESSED)
 				|| selector_spec.hasProperty(StyleSpec::BGIMG_PRESSED)
@@ -2747,15 +2734,21 @@ void GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element)
 				press_spec.set(StyleSpec::FGIMG, selector_spec.get(StyleSpec::FGIMG_PRESSED, ""));
 			}
 
-			if (style_type) {
-				theme_by_type[selector].push_back(press_spec);
-			} else {
-				theme_by_name[selector].push_back(press_spec);
-			}
+			out[selector].push_back(press_spec);
 		}
 	}
+}
 
-	return;
+void GUIFormSpecMenu::parseStyle(parserData *data, const std::string &element)
+{
+	if (data->type != "style" && data->type != "style_type") {
+		errorstream << "Invalid style element type: '" << data->type << "'" << std::endl;
+		return;
+	}
+
+	bool style_type = (data->type == "style_type");
+
+	parseStyleToMap(style_type ? theme_by_type : theme_by_name, element);
 }
 
 void GUIFormSpecMenu::parseSetFocus(parserData*, const std::string &element)
@@ -2976,6 +2969,21 @@ void GUIFormSpecMenu::parseElement(parserData* data, const std::string &element)
 			<< std::endl;
 }
 
+void GUIFormSpecMenu::setThemeFromSettings()
+{
+	const std::string settingspath = g_settings->get("texture_path") + DIR_DELIM + "texture_pack.conf";
+	Settings settings;
+	if (!settings.readConfigFile(settingspath.c_str()))
+		return;
+	if (!settings.exists("formspec_theme"))
+		return;
+
+	auto splits = split(settings.get("formspec_theme"), '\n');
+	for (const std::string &s : splits) {
+		parseStyleToMap(theme_by_type_default, s);
+	}
+}
+
 void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 {
 	// Useless to regenerate without a screensize
@@ -3038,7 +3046,7 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 	m_dropdowns.clear();
 	m_scroll_containers.clear();
 	theme_by_name.clear();
-	theme_by_type.clear();
+	theme_by_type = theme_by_type_default;
 	m_clickthrough_elements.clear();
 	field_enter_after_edit.clear();
 	field_close_on_enter.clear();

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -256,6 +256,8 @@ public:
 		m_hovered_item_tooltips.emplace_back(name);
 	}
 
+	void setThemeFromSettings();
+
 	/*
 		Remove and re-add (or reposition) stuff
 	*/
@@ -304,8 +306,9 @@ protected:
 	bool precheckElement(const std::string &name, const std::string &element,
 		size_t args_min, size_t args_max, std::vector<std::string> &parts);
 
-	std::unordered_map<std::string, std::vector<StyleSpec>> theme_by_type;
-	std::unordered_map<std::string, std::vector<StyleSpec>> theme_by_name;
+	using StyleSpecMap = std::unordered_map<std::string, std::vector<StyleSpec>>;
+	StyleSpecMap theme_by_type, theme_by_name,
+		theme_by_type_default;
 	std::unordered_set<std::string> property_warned;
 
 	StyleSpec getDefaultStyleForElement(const std::string &type,
@@ -485,6 +488,7 @@ private:
 	void parseAnchor(parserData *data, const std::string &element);
 	bool parsePaddingDirect(parserData *data, const std::string &element);
 	void parsePadding(parserData *data, const std::string &element);
+	void parseStyleToMap(StyleSpecMap &out, const std::string &element);
 	void parseStyle(parserData *data, const std::string &element);
 	void parseSetFocus(parserData *, const std::string &element);
 	void parseModel(parserData *data, const std::string &element);


### PR DESCRIPTION
This PR is based on #16146 to ensure the best experience. This is optional.

**Commit 1:** (using commit https://github.com/luanti-org/luanti/commit/f14b4950d5b8a062331d388cf25609cadd31d131 for demonstration)
No styling (master):
![grafik](https://github.com/user-attachments/assets/9d67f6d7-e0dc-465a-850e-828e680167fa)
With styling, before (master):
![grafik](https://github.com/user-attachments/assets/90ab9303-045e-4ada-8a24-e0e324d35ba2)
With styling, after (PR):
![grafik](https://github.com/user-attachments/assets/8ecc158f-7394-4720-b143-f8c9235b2bd8)

**Commit 2:""
This a feature to specify the formspec appearance by texture packs. See testing instructions below.


## To do

This PR is Ready for Review.

## How to test

1. Put the from commit https://github.com/luanti-org/luanti/commit/f14b4950d5b8a062331d388cf25609cadd31d131 into the active texture pack
2. Edit or create `texture_pack.conf`
3. Add 
```
formspec_theme = """
button,image_button;bgimg_middle=2,2,-2,-2;bgimg=button_normal.png
button:hovered,image_button:hovered;bgimg_middle=2,2,-2,-2;bgimg=button_hovered.png
button:pressed,image_button:pressed;bgimg_middle=2,2,-2,-2;bgimg=button_pressed.png
"""
```
4. The main menu should have a new appearance and the in-game inventory should look like this. unified_inventory for example:
![grafik](https://github.com/user-attachments/assets/464d4ef9-891f-41c2-846c-091e5fc2f238)

