### PR TITLE
Exit confirmation dialog on ESC in main menu

### DIFF
--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -49,7 +49,36 @@ local tabs = {
 --------------------------------------------------------------------------------
 local function main_event_handler(tabview, event)
 	if event == "MenuQuit" then
-		core.close()
+		if not ui.childlist["mainmenu_quit_confirm"] then
+			tabview:hide()
+			local dlg = dialog_create(
+				"mainmenu_quit_confirm",
+				function()
+					return confirmation_formspec(
+						fgettext("Are you sure you want to quit?"),
+						"btn_quit_confirm_yes", fgettext("Quit"),
+						"btn_quit_confirm_cancel", fgettext("Cancel")
+					)
+				end,
+				function(this, fields)
+					if fields.btn_quit_confirm_yes then
+						this:delete()
+						core.close()
+						return true
+					elseif fields.btn_quit_confirm_cancel or fields.key_escape or fields.quit then
+						this:delete()
+						if tabview and tabview.show then
+							tabview:show()
+						end
+						return true
+					end
+				end,
+				nil
+			)
+			dlg:set_parent(tabview)
+			dlg:show()
+		end
+		return true
 	end
 	return true
 end


### PR DESCRIPTION
This PR is related to #15986, see the discussion https://github.com/luanti-org/luanti/pull/15986#issuecomment-2783998207.

- Goal of the PR and usecase
https://github.com/luanti-org/luanti/pull/15986#issue-2975071716 already summarized it.
- How does the PR work?
It creates a dialog where `core.close()` would have been called.
- Does it resolve any reported issue?
Not any that I am aware of.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Maybe 2.3?

## To do

- [ ] test on Android
- [ ] adjust wording?

## How to test

Open Luanti → press <kbd>esc</kbd> → confirmation dialog opens.
