### PR TITLE
[no-sq] Do not modify peer timeout on MTP connection shutdown

### DIFF
--- a/src/network/mtp/impl.cpp
+++ b/src/network/mtp/impl.cpp
@@ -1314,11 +1314,6 @@ Connection::~Connection()
 	m_sendThread->stop();
 	m_receiveThread->stop();
 
-	//TODO for some unkonwn reason send/receive threads do not exit as they're
-	// supposed to be but wait on peer timeout. To speed up shutdown we reduce
-	// timeout to half a second.
-	m_sendThread->setPeerTimeout(0.5);
-
 	// wait for threads to finish
 	m_sendThread->wait();
 	m_receiveThread->wait();

--- a/src/network/mtp/impl.h
+++ b/src/network/mtp/impl.h
@@ -12,6 +12,7 @@
 #include "util/numeric.h"
 #include "porting.h"
 #include "network/networkprotocol.h"
+#include <atomic>
 #include <iostream>
 #include <vector>
 #include <memory>
@@ -301,7 +302,7 @@ private:
 	// Backwards compatibility
 	PeerHandler *m_bc_peerhandler;
 
-	bool m_shutting_down = false;
+	std::atomic<bool> m_shutting_down = false;
 };
 
 } // namespace


### PR DESCRIPTION
Shortening the peer timeout was necessary at some point to work around an unknown bug. I changed the timeout set in the workaround from 0.5s to 20s to exacerbate any issue and was not able to reproduce the bug running a headless Luanti server on WSL Tumbleweed and connecting with a client on the Windows host. That is not enough to say the issue no longer exists. This PR may cause a regression.

The access to change the peer timeout was unsynchronized and done by a different thread than the sending thread, so it was detected by TSan to be a data race. Since this patch deletes the code performing the write, the data race is no longer a concern, and no synchronization must be added.

## To do

Ready for Review.

## How to test

TSan should no longer report a race, and Luanti should always shutdown quickly when it receives SIGTERM or SIGKILL. I have not tested the shutdown speed in ways other than mentioned in the above description. @nerzhul wrote the workaround, so he is in the best position to review this.
