### PR TITLE
Add settings and parameters to tweak damage camera effects

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -130,6 +130,11 @@ local function load()
 			{ heading = fgettext_ne("Movement") },
 			"arm_inertia",
 			"view_bobbing_amount",
+			{ heading = fgettext_ne("Damage") },
+			"damage_flash_enable",
+			"damage_tilt_enable",
+			"damage_tilt_strength",
+			"damage_tilt_duration",
 		},
 	})
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -556,6 +556,26 @@ arm_inertia (Arm inertia) bool true
 #    For example: 0 for no view bobbing; 1.0 for normal; 2.0 for double.
 view_bobbing_amount (View bobbing factor) float 1.0 0.0 7.9
 
+[**Damage]
+
+#   Damage flash, causes the screen to flash reduce
+#   when the player takes damage.
+damage_flash_enable (Damage flash) bool true
+
+#   Damage tilt, causes the screen to shake
+#   when the player takes damage
+damage_tilt_enable (Damage shake) bool true
+
+#   Damage tilt strength. Controls the force of 
+#   camera shakes from taking damage
+damage_tilt_strength (Damage shake strength) float 1.0 0.0 2.0
+
+#   Damage tilt duration modifier. Controls the duration of
+#   camera shakes from taking damage. 
+#   0.0 for no time, 1.0 for normal time, 2.0 for twice as long.
+damage_tilt_duration (Damage shake duration) float 1.0 0.0 2.0
+
+
 [**Camera]
 
 #    Field of view in degrees.

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2687,12 +2687,19 @@ void Game::handleClientEvent_PlayerDamage(ClientEvent *event, CameraOrientation 
 			player->getCAO()->getProperties().hp_max : PLAYER_MAX_HP_DEFAULT;
 		f32 damage_ratio = event->player_damage.amount / hp_max;
 
-		runData.damage_flash += 95.0f + 64.f * damage_ratio;
-		runData.damage_flash = MYMIN(runData.damage_flash, 127.0f);
+		if(g_settings->getBool("damage_flash_enable")) {
+			runData.damage_flash += 95.0f + 64.f * damage_ratio;
+			runData.damage_flash = MYMIN(runData.damage_flash, 127.0f);
+		}
 
-		player->hurt_tilt_timer = 1.5f;
-		player->hurt_tilt_strength =
-			rangelim(damage_ratio * 5.0f, 1.0f, 4.0f);
+		f32 tilt_duration = g_settings->getFloat("damage_tilt_duration");
+		if (tilt_duration > 0 && g_settings->getBool("damage_tilt_enable")) {
+			player->hurt_tilt_timer = 1.5f * tilt_duration;
+
+			f32 tilt_strength = g_settings->getFloat("damage_tilt_strength");
+			player->hurt_tilt_strength =
+				rangelim(damage_ratio * 5.0f, 1.0f, 4.0f) * tilt_strength;
+		}
 	}
 
 	// Play damage sound

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -306,6 +306,10 @@ void set_default_settings()
 	settings->setDefault("show_entity_selectionbox", "false");
 	settings->setDefault("ambient_occlusion_gamma", "1.8");
 	settings->setDefault("arm_inertia", "true");
+	settings->setDefault("damage_flash_enable", "true");
+	settings->setDefault("damage_tilt_enable", "true");
+	settings->setDefault("damage_tilt_strength", "1.0");
+	settings->setDefault("damage_tilt_duration", "1.0");
 	settings->setDefault("show_nametag_backgrounds", "true");
 	settings->setDefault("show_block_bounds_radius_near", "4");
 	settings->setDefault("transparency_sorting_group_by_buffers", "true");


### PR DESCRIPTION
Goal: Add accessibility settings to disable/tweak the camera effects from taking damage (tilt/shake, red flash)
This builds on the partial solution to #15805 built by @FreshAlacrity, thank you very much for the foundation and for demonstrating all the changes needed to add settings to the menu. I have added on some damage tilt settings in addition to the damage flash enable setting.

## To do
Implement a color setting for camera flash, possibly.

This PR is Ready for Review.

## How to test
Build and launch project
Open a world with damage enabled
Take damage, and watch your screen flash and tilt
Change the settings under the heading "Damage" to your liking
Take damage again and observe the effect the settings have.
