### PR TITLE
Formspec: change tabs with ctrl+tab

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4060,6 +4060,31 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 {
 	if (event.EventType==EET_KEY_INPUT_EVENT) {
 		KeyPress kp(event.KeyInput);
+		// Ctrl (+ Shift) + Tab: Select the (previous or) next tab of a TabControl instance.
+		bool shift = event.KeyInput.Shift;
+		bool ctrl = event.KeyInput.Control;
+		if (event.KeyInput.PressedDown && (event.KeyInput.Key == KEY_TAB && ctrl)) {
+			// Try to find a tab control among our elements
+			for (const FieldSpec &s : m_fields) {
+				if (s.ftype != f_TabHeader)
+					continue;
+
+				IGUIElement *element = getElementFromId(s.fid, true);
+				if (!element || element->getType() != gui::EGUIET_TAB_CONTROL)
+					continue;
+
+				gui::IGUITabControl *tabs = static_cast<gui::IGUITabControl *>(element);
+				s32 num_tabs = tabs->getTabCount();
+				if (num_tabs <= 1)
+					continue;
+
+				s32 active = tabs->getActiveTab();
+				// Shift: Previous tab, No shift: Next tab
+				active = (active + (shift ? -1 : 1) + num_tabs) % num_tabs;
+				tabs->setActiveTab(active);
+				return true; // handled
+			}
+		}
 		if (event.KeyInput.PressedDown && (
 				(kp == EscapeKey) ||
 				((m_client != NULL) && (kp == getKeySetting("keymap_inventory"))))) {

--- a/src/gui/guiTable.cpp
+++ b/src/gui/guiTable.cpp
@@ -831,8 +831,10 @@ bool GUITable::OnEvent(const SEvent &event)
 			return true;
 		}
 		else if (event.KeyInput.Key == KEY_ESCAPE ||
-				event.KeyInput.Key == KEY_SPACE) {
+				event.KeyInput.Key == KEY_SPACE ||
+				(event.KeyInput.Key == KEY_TAB && event.KeyInput.Control)) {
 			// pass to parent
+			return IGUIElement::OnEvent(event);
 		}
 		else if (event.KeyInput.PressedDown && event.KeyInput.Char) {
 			// change selection based on text as it is typed


### PR DESCRIPTION
This PR adds the ability to switch to the next/previous tab using <kbd>ctrl</kbd>(+<kbd>shift</kbd>) +<kbd>tab</kbd>.
##### Note: I have used AI during development.

- Goal of the PR
Make it easier/quicker to go to the next/previous tab using keyboard controls.

- How does the PR work?
It modifies the `GUIFormSpecMenu`'s `OnEvent` method to cycle through tabs using the above mentioned keyboard shortcut.

    There are also a few event handling refinements:

    * Updated `GUIFormSpecMenu`'s `preprocessEvent` method to prevent `Ctrl+Tab` and `Return` keys from being incorrectly consumed by child elements like checkboxes, tables, and list boxes.
    * Modified `GUITable` to pass key events with the `Control` modifier to its parent, ensuring consistent event propagation.
    * Adjusted `GUITable`'s `OnEvent` method to no longer consume the `Space` key, allowing it to pass to the parent element instead.

- Does it resolve any reported issue?
Not any that I am aware of.

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Hopefully 2.3.

- If not a bug fix, why is this PR needed? What usecases does it solve?
It makes it easier and quicker to go to the next or previous tab.

## To do

This PR is ready for Review.

- [x] Add demo video?
- [x] Discuss changes regarding event handling but unrelated to the tab cycling

## Preview



https://github.com/user-attachments/assets/9b69ec84-0d7c-4c03-9f13-13bdbcb39426





## How to test

Open Luanti → try switching forth and back using the keyboard shortcut.
