### PR TITLE
SDL3: Add text composition event

### DIFF
--- a/irr/include/CGUIEditBox.h
+++ b/irr/include/CGUIEditBox.h
@@ -148,10 +148,14 @@ protected:
 	void setTextRect(s32 line);
 	//! returns the line number that the cursor is on
 	s32 getLineFromPos(s32 pos);
+	//! inserts a string to the edit box; used by inputString and composeString
+	bool insertString(const core::stringw &str);
 	//! adds a letter to the edit box
 	void inputChar(wchar_t c);
 	//! adds a string to the edit box
 	void inputString(const core::stringw &str);
+	//! compose a string before it is added
+	void composeString(const core::stringw &str);
 	//! calculates the current scroll position
 	void calculateScrollPos();
 	//! calculated the FrameRect

--- a/irr/include/IEventReceiver.h
+++ b/irr/include/IEventReceiver.h
@@ -35,6 +35,13 @@ enum EEVENT_TYPE
 	/** This event is created when multiple characters are sent at a time (e.g. using an IME). */
 	EET_STRING_INPUT_EVENT,
 
+	//! A string composition event.
+	/** This event is created when the user "composes" characters (e.g. using an IME) before entering
+	the complete text.
+	See https://wiki.libsdl.org/SDL2/SDL_TextEditingExtEvent
+	*/
+	EET_STRING_COMPOSITION_EVENT,
+
 	//! A touch input event.
 	EET_TOUCH_INPUT_EVENT,
 
@@ -380,6 +387,19 @@ struct SEvent
 		core::stringw *Str;
 	};
 
+	//! String composition event.
+	struct SStringComposition
+	{
+		//! The string that is composed.
+		core::stringw *Str;
+
+		//! The position within the composition where further text would be inserted.
+		s32 Start;
+
+		//! The number of characters that would be replaced by further typing.
+		s32 Length;
+	};
+
 	//! Any kind of touch event.
 	struct STouchInput
 	{
@@ -530,6 +550,7 @@ struct SEvent
 		struct SMouseInput MouseInput;
 		struct SKeyInput KeyInput;
 		struct SStringInput StringInput;
+		struct SStringComposition StringComposition;
 		struct STouchInput TouchInput;
 		struct SAccelerometerEvent AccelerometerEvent;
 		struct SGyroscopeEvent GyroscopeEvent;

--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -233,6 +233,10 @@ bool CGUIEditBox::OnEvent(const SEvent &event)
 			inputString(*event.StringInput.Str);
 			return true;
 			break;
+		case EET_STRING_COMPOSITION_EVENT:
+			composeString(*event.StringComposition.Str);
+			return true;
+			break;
 		default:
 			break;
 		}
@@ -1367,10 +1371,10 @@ void CGUIEditBox::inputChar(wchar_t c)
 	inputString(s);
 }
 
-void CGUIEditBox::inputString(const core::stringw &str)
+bool CGUIEditBox::insertString(const core::stringw &str)
 {
 	if (!isEnabled() || !IsWritable)
-		return;
+		return false;
 
 	core::stringw s;
 	u32 len = str.size();
@@ -1429,7 +1433,25 @@ void CGUIEditBox::inputString(const core::stringw &str)
 	}
 
 	BlinkStartTime = os::Timer::getTime();
+	return true;
+}
+
+void CGUIEditBox::inputString(const core::stringw &str)
+{
+	if (!insertString(str))
+		return;
 	setTextMarkers(0, 0);
+
+	breakText();
+	calculateScrollPos();
+	sendGuiEvent(EGET_EDITBOX_CHANGED);
+}
+
+void CGUIEditBox::composeString(const core::stringw &str)
+{
+	if (!insertString(str))
+		return;
+	setTextMarkers(CursorPos-str.size(), CursorPos);
 
 	breakText();
 	calculateScrollPos();

--- a/irr/src/CGUIEnvironment.cpp
+++ b/irr/src/CGUIEnvironment.cpp
@@ -550,6 +550,7 @@ bool CGUIEnvironment::postEventFromUser(const SEvent &event)
 			}
 		}
 	} break;
+	case EET_STRING_COMPOSITION_EVENT: [[fallthrough]];
 	case EET_STRING_INPUT_EVENT:
 		if (Focus && Focus->OnEvent(event))
 			return true;

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -435,7 +435,7 @@ CIrrDeviceSDL::CIrrDeviceSDL(const SIrrlichtCreationParameters &param) :
 
 		// Set IME hints
 #ifdef _IRR_USE_SDL3_
-		SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "0");
+		SDL_SetHint(SDL_HINT_IME_IMPLEMENTED_UI, "composition");
 #else
 		SDL_SetHint(SDL_HINT_IME_INTERNAL_EDITING, "1");
 #endif
@@ -1023,6 +1023,20 @@ bool CIrrDeviceSDL::run()
 			delete irrevent.StringInput.Str;
 			irrevent.StringInput.Str = NULL;
 		} break;
+
+#ifdef _IRR_USE_SDL3_
+		case SDL_EVENT_TEXT_EDITING: {
+			irrevent.EventType = EET_STRING_COMPOSITION_EVENT;
+			irrevent.StringComposition.Str = new core::stringw();
+			core::utf8ToWString(*irrevent.StringInput.Str, SDL_event.edit.text);
+			irrevent.StringComposition.Start = SDL_event.edit.start;
+			irrevent.StringComposition.Length = SDL_event.edit.length;
+			postEventFromUser(irrevent);
+			delete irrevent.StringInput.Str;
+			irrevent.StringInput.Str = NULL;
+			break;
+		}
+#endif
 
 		case SDL_EVENT_KEY_DOWN:
 		case SDL_EVENT_KEY_UP: {


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  Add text composition/edit events to Luanti.
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  IMO this is a minor quality of life improvement as some dead/compose keys do not show the status of text composition otherwise.

## To do

This PR is a Work in Progress.

- [x] Introduce text composition event to Irrlicht.
- Correctly handle text coposition:
  - [ ] Restore selected text when composition is canceled.
  - [ ] Correctly handle overwrite mode.
  - [ ] Correctly place the cursor within text composition.
- Make UI elements use text composition:
  - [x] `CGUIEditBox`
  - [ ] Chat console
- [ ] Code refactoring?

## How to test

Enter text using an IME / compose key / dead key and observe that "partial" input is also shown in the input box.