### PR TITLE
Add texture refcounting grab/drop to MenuTextureSource

### DIFF
--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -53,6 +53,7 @@ MenuTextureSource::~MenuTextureSource()
 
 	for (const auto &it: m_to_delete) {
 		m_driver->removeTexture(it);
+		it->drop();
 	}
 	m_to_delete.clear();
 
@@ -82,8 +83,10 @@ video::ITexture *MenuTextureSource::getTexture(const std::string &name, u32 *id)
 	retval = m_driver->addTexture(name.c_str(), image);
 	image->drop();
 
-	if (retval)
+	if (retval) {
+		retval->grab();
 		m_to_delete.push_back(retval);
+	}
 	return retval;
 }
 


### PR DESCRIPTION
## Goal of the PR
Fix crash described in https://github.com/luanti-org/luanti/issues/16188

## How does the PR work?
Texture information was internally deleted due to refcounting, which caused the `deleteTexture` calls to crash due to missing names. 
This PR adds the grab/drop calls to the appropriate places to prevent that from happening.
 
## Does it resolve any reported issue?
Yes:  https://github.com/luanti-org/luanti/issues/16188

## How to test
1. Run debug build on windows - start new game