### PR TITLE
Revert changes to special 'Proceed' button handling

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4849,9 +4849,14 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 			s32 caller_id = event.GUIEvent.Caller->getID();
 
 			if (caller_id == 257) {
-				acceptInput(quit_mode_accept);
-				m_text_dst->gotText(L"ExitButton");
-				quitMenu();
+				if (m_allowclose) {
+					acceptInput(quit_mode_accept);
+					quitMenu();
+				}
+				else {
+					acceptInput();
+					m_text_dst->gotText(L"ExitButton");
+				}
 				return true;
 			}
 


### PR DESCRIPTION
## Goal of the PR
Fix issue https://github.com/luanti-org/luanti/issues/16187 

## How does the PR work?
`caller_id == 257`  is the ID given to the special "Proceed" button on size-less forms, which when pressed sends a close signal.

The issue was that the previous changes also send the button's text to the fields, with the same key ("text") as the text field itself - preventing things like signs working. 

Reverting those changes seems to fix this, and since this part of the code is only in the branch for `caller_id == 257` it should not affect other forms.

## Does it resolve any reported issue?
https://github.com/luanti-org/luanti/issues/16187

## How to test

Startup base `minetest_game`, place wood or steel sign, try to write something.