### PR TITLE
Don't break when multiple dialogs are shown on startup

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -118,7 +118,7 @@ function ui.update()
 
 		if (active_toplevel_ui_elements > 1) then
 			core.log("warning", "more than one active ui "..
-				"element, self most likely isn't intended")
+				"element, this most likely isn't intended")
 		end
 
 		if (active_toplevel_ui_elements == 0) then

--- a/builtin/mainmenu/dlg_rebind_keys.lua
+++ b/builtin/mainmenu/dlg_rebind_keys.lua
@@ -33,13 +33,13 @@ end
 
 local function buttonhandler(this, fields)
 	if fields.reconfigure then
+		local parent = this.parent
+
 		close_dialog(this)
 
-		local maintab = ui.find_by_name("maintab")
-
 		local dlg = create_settings_dlg("controls_keyboard_and_mouse")
-		dlg:set_parent(maintab)
-		maintab:hide()
+		dlg:set_parent(parent)
+		parent:hide()
 		dlg:show()
 
 		return true
@@ -74,7 +74,7 @@ local function create_rebind_keys_dlg()
 	return dlg
 end
 
-function migrate_keybindings()
+function migrate_keybindings(parent)
 	-- Show migration dialog if the user upgraded from an earlier version
 	-- and this has not yet been shown before, *or* if keys settings had to be changed
 	if core.is_first_run then
@@ -95,14 +95,14 @@ function migrate_keybindings()
 	end
 
 	if not has_migration then
-		return
+		return parent
 	end
 
-	local maintab = ui.find_by_name("maintab")
-
 	local dlg = create_rebind_keys_dlg()
-	dlg:set_parent(maintab)
-	maintab:hide()
+	dlg:set_parent(parent)
+	parent:hide()
 	dlg:show()
 	ui.update()
+
+	return dlg
 end

--- a/builtin/mainmenu/dlg_reinstall_mtg.lua
+++ b/builtin/mainmenu/dlg_reinstall_mtg.lua
@@ -11,7 +11,7 @@
 
 local SETTING_NAME = "no_mtg_notification"
 
-function check_reinstall_mtg()
+function check_reinstall_mtg(parent)
 	-- used to be in minetest.conf
 	if core.settings:get_bool(SETTING_NAME) then
 		cache_settings:set_bool(SETTING_NAME, true)
@@ -19,14 +19,14 @@ function check_reinstall_mtg()
 	end
 
 	if cache_settings:get_bool(SETTING_NAME) then
-		return
+		return parent
 	end
 
 	local games = core.get_games()
 	for _, game in ipairs(games) do
 		if game.id == "minetest" then
 			cache_settings:set_bool(SETTING_NAME, true)
-			return
+			return parent
 		end
 	end
 
@@ -40,16 +40,16 @@ function check_reinstall_mtg()
 	end
 	if not mtg_world_found then
 		cache_settings:set_bool(SETTING_NAME, true)
-		return
+		return parent
 	end
 
-	local maintab = ui.find_by_name("maintab")
-
 	local dlg = create_reinstall_mtg_dlg()
-	dlg:set_parent(maintab)
-	maintab:hide()
+	dlg:set_parent(parent)
+	parent:hide()
 	dlg:show()
 	ui.update()
+
+	return dlg
 end
 
 local function get_formspec(dialogdata)
@@ -74,22 +74,22 @@ end
 
 local function buttonhandler(this, fields)
 	if fields.reinstall then
+		local parent = this.parent
+
 		-- Don't set "no_mtg_notification" here so that the dialog will be shown
 		-- again if downloading MTG fails for whatever reason.
 		this:delete()
 
-		local maintab = ui.find_by_name("maintab")
-
 		local dlg = create_contentdb_dlg(nil, "minetest/minetest")
-		dlg:set_parent(maintab)
-		maintab:hide()
+		dlg:set_parent(parent)
+		parent:hide()
 		dlg:show()
 
 		return true
 	end
 
 	if fields.dismiss then
-		cache_settings:set_bool("no_mtg_notification", true)
+		cache_settings:set_bool(SETTING_NAME, true)
 		this:delete()
 		return true
 	end

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -115,7 +115,7 @@ local function init_globals()
 	-- synchronous, chain parents to only show one at a time
 	local parent = tv_main
 	parent = migrate_keybindings(parent)
-	parent = check_reinstall_mtg(parent)
+	check_reinstall_mtg(parent)
 
 	-- asynchronous, will only be shown if we're still on "maintab"
 	check_new_version()

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -112,8 +112,12 @@ local function init_globals()
 	tv_main:show()
 	ui.update()
 
-	check_reinstall_mtg()
-	migrate_keybindings()
+	-- synchronous, chain parents to only show one at a time
+	local parent = tv_main
+	parent = migrate_keybindings(parent)
+	parent = check_reinstall_mtg(parent)
+
+	-- asynchronous, will only be shown if we're still on "maintab"
 	check_new_version()
 end
 


### PR DESCRIPTION
fixes this (saw it being reported on Discord or Matrix or similar):

![overlapping "reinstall MTG" and "keybindings changed" dialogs](https://github.com/user-attachments/assets/0101038e-30e3-42fa-b921-dd89cb13991f)

Now, the dialogs are chained, with the MTG dialog being shown last (which means the user sees it first)

## To do

This PR is a Ready for Review.

## How to test

1. Edit your `.minetest/cache/common.conf` to remove the `no_keycode_migration_warning` and `no_mtg_notification` entries
2. Delete MTG
3. See both dialogs on startup

Ensure
1. they chain properly
2. nothing breaks when you click the "Open Settings" or "Reinstall" buttons, the dialogs still chain properly
3. nothing breaks if you swap the order of the dialogs, they still chain properly