### PR TITLE
Print Luanti version after ascii art

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -586,14 +586,16 @@ void Server::start()
 		R"(| | |_| | (_| | | | | |_| |)",
 		R"(|_|\__,_|\__,_|_| |_|\__|_|)",
 	};
-
 	if (!m_admin_chat) {
 		// we're not printing to rawstream to avoid it showing up in the logs.
 		// however it would then mess up the ncurses terminal (m_admin_chat),
 		// so we skip it in that case.
-		for (auto line : art)
-			std::cerr << line << std::endl;
+		for (size_t i = 0; i < ARRLEN(art); ++i)
+			std::cerr << art[i] << (i == ARRLEN(art) - 1 ? "" : "\n");
+		// add a "tail" with the engine version
+		std::cerr << "  ___ " << g_version_hash << std::endl;
 	}
+
 	actionstream << "World at [" << m_path_world << "]" << std::endl;
 	actionstream << "Server for gameid=\"" << m_gamespec.id
 			<< "\" listening on ";


### PR DESCRIPTION
Motivation: people often share their debug.txt for troubleshooting and then may or may not share the rest of useful information one might want, so we add the most important piece of information (version string) right in the middle of it.

How it looks:
```
2025-05-30 20:13:19: WARNING[ServerStart]: get_biome_list: failed to get biome 'nether_caverns'
2025-05-30 20:13:19: WARNING[ServerStart]: get_biome_list: failed to get biome 'savanna'
 _                   _   _ 
| |_   _  __ _ _ __ | |_(_)
| | | | |/ _` | '_ \| __| |
| | |_| | (_| | | | | |_| |
|_|\__,_|\__,_|_| |_|\__|_|  ___ 5.13.0-dev-535d75756-dirty
2025-05-30 20:13:19: ACTION[ServerStart]: World at [/somewhere/over/the/rainbow]
2025-05-30 20:13:19: ACTION[ServerStart]: Server for gameid="minetest" listening on 127.0.0.1:56992.
```

ASCII art critique welcome (maybe `__|` is better than `___`? or `~~~`? or just spaces?)