### PR TITLE
Fix `model[]` not supporting float frames

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2852,12 +2852,13 @@ void GUIFormSpecMenu::parseModel(parserData *data, const std::string &element)
 	e->enableContinuousRotation(inf_rotation);
 	e->enableMouseControl(mousectrl);
 
-	s32 frame_loop_begin = 0;
-	s32 frame_loop_end = 0x7FFFFFFF;
+	f32 frame_loop_begin = 0;
+	// This will be clamped to the animation duration.
+	f32 frame_loop_end = std::numeric_limits<f32>::infinity();
 
 	if (frame_loop.size() == 2) {
-	    frame_loop_begin = stoi(frame_loop[0]);
-	    frame_loop_end = stoi(frame_loop[1]);
+	    frame_loop_begin = stof(frame_loop[0]);
+	    frame_loop_end = stof(frame_loop[1]);
 	}
 
 	e->setFrameLoop(frame_loop_begin, frame_loop_end);


### PR DESCRIPTION
When adding floating point frame support for animations, I missed that the parsing code here only reads integers.

## How to test

0. Apply

```diff
diff --git a/games/devtest/mods/testformspec/formspec.lua b/games/devtest/mods/testformspec/formspec.lua
index f2f632fa0..8ad8744d3 100644
--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -468,7 +468,7 @@ mouse control = false
 frame loop range = 0,30]
                        label[5,9.2;continuous = true
 mouse control = true]
-                       model[0.5,0.1;4,4;m1;testformspec_character.b3d;testformspec_character.png]
+                       model[0.5,0.1;4,4;m1;gltf_spider_animated.gltf;gltf_spider.png;0,180;false;false;0,0.49;1]
                        model[0.5,4.2;4,4;m2;testformspec_character.b3d;testformspec_character.png;0,180;false;false;0,30]
                        model[0.5,8.3;4,4;m3;testformspec_chest.obj;default_chest_top.png,default_chest_top.png,default_chest_side.png,default_chest_side.png,default_chest_front.png,default_chest_inside.png;30,1;true;true]
                ]],
```

1. `/test_formspec`
2. Observe twerking spider