### PR TITLE
Don't force-enable tileable_horizontal/vertical for solid nodes

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -464,8 +464,6 @@ void MapblockMeshGenerator::drawSolidNode()
 		for (auto &layer : tiles[face].layers) {
 			if (backface_culling)
 				layer.material_flags |= MATERIAL_FLAG_BACKFACE_CULLING;
-			layer.material_flags |= MATERIAL_FLAG_TILEABLE_HORIZONTAL;
-			layer.material_flags |= MATERIAL_FLAG_TILEABLE_VERTICAL;
 		}
 		if (!data->m_smooth_lighting) {
 			lights[face] = getFaceLight(cur_node.n, neighbor, nodedef);


### PR DESCRIPTION
See https://github.com/luanti-org/luanti/pull/16091#issuecomment-2848860251

MTG already correctly sets `tileable_vertical = false` for `default:dirt_with_grass` and friends. Devtest does too:

https://github.com/luanti-org/luanti/blob/fde6384a099143a4a3033e090d61296b1d15f051/games/devtest/mods/basenodes/init.lua#L32

I assume this already worked in the engine at some point, probably until #13216. However, in recent times, the way texture coordinates were set meant disabling it couldn't work and it had to be force-enabled, until #16091 fixed that.

With texture filtering enabled, this PR changes this:

MTG dirt-with-snow, visible "texture border" artifacts caused by the texture being sampled as if it repeats past the ege
<img alt="screenshot" src="https://github.com/user-attachments/assets/caa49f6c-dd13-469a-87c4-b30a7ac6e69b" width="512" />

into this:

MTG dirt-with-snow, no "texture border" artifacts
<img alt="screenshot" src="https://github.com/user-attachments/assets/f9baa0e2-7120-4ab4-8827-b9d9a9116baa" width="512" />

## To do

This PR is a Ready for Review.

## How to test

1. Enable texture filtering, verify that "texture border" artifacts for nodes that correctly set `tileable_vertical = false` are gone

2. Verify that nothing is broken