### PR TITLE
Add mapgen descriptions

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -82,6 +82,7 @@ local function create_world_formspec(dialogdata)
 
 	local current_mg = dialogdata.mg
 	local mapgens = core.get_mapgen_names()
+	local mapgens_descriptions = core.get_mapgen_descriptions()
 
 	local flags = dialogdata.flags
 
@@ -109,6 +110,7 @@ local function create_world_formspec(dialogdata)
 		if #allowed_mapgens > 0 then
 			for i = #mapgens, 1, -1 do
 				if table.indexof(allowed_mapgens, mapgens[i]) == -1 then
+					table.remove(mapgens_descriptions, i)
 					table.remove(mapgens, i)
 				end
 			end
@@ -117,6 +119,7 @@ local function create_world_formspec(dialogdata)
 		if #disallowed_mapgens > 0 then
 			for i = #mapgens, 1, -1 do
 				if table.indexof(disallowed_mapgens, mapgens[i]) > 0 then
+					table.remove(mapgens_descriptions, i)
 					table.remove(mapgens, i)
 				end
 			end
@@ -129,6 +132,7 @@ local function create_world_formspec(dialogdata)
 	end
 
 	local mglist = ""
+	local mgdescription = ""
 	local selindex
 	do -- build the list of mapgens
 		local i = 1
@@ -138,6 +142,7 @@ local function create_world_formspec(dialogdata)
 				first_mg = v
 			end
 			if current_mg == v then
+				mgdescription = mapgens_descriptions[k]
 				selindex = i
 			end
 			i = i + 1
@@ -287,12 +292,13 @@ local function create_world_formspec(dialogdata)
 
 	retval = retval ..
 		"label[0,2;" .. fgettext("Mapgen") .. "]"..
-		"dropdown[0,2.5;6.3;dd_mapgen;" .. mglist .. ";" .. selindex .. "]"
+		"dropdown[0,2.5;6.3;dd_mapgen;" .. mglist .. ";" .. selindex .. "]"..
+		"textarea[0.5,3.2;6,2;;;" .. core.formspec_escape(fgettext(mgdescription)) .. "]"
 
 	-- Warning when making a devtest world
 	if game.id == "devtest" then
 		retval = retval ..
-			"container[0,3.5]" ..
+			"container[0,4.7]" ..
 			"box[0,0;5.8,1.7;#ff8800]" ..
 			"textarea[0.4,0.1;6,1.8;;;"..
 			fgettext("Development Test is meant for developers.") .. "]" ..

--- a/src/mapgen/mapgen.cpp
+++ b/src/mapgen/mapgen.cpp
@@ -62,6 +62,7 @@ const FlagDesc flagdesc_gennotify[] = {
 struct MapgenDesc {
 	const char *name;
 	bool is_user_visible;
+	const char *description;
 };
 
 ////
@@ -75,14 +76,14 @@ struct MapgenDesc {
 // Of the remaining, v5 last due to age, v7 first due to being the default.
 // The order of 'enum MapgenType' in mapgen.h must match this order.
 static MapgenDesc g_reg_mapgens[] = {
-	{"v7",         true},
-	{"valleys",    true},
-	{"carpathian", true},
-	{"v5",         true},
-	{"flat",       true},
-	{"fractal",    true},
-	{"singlenode", true},
-	{"v6",         true},
+	{"v7",         true,	"Default mapgen with large complex mountins and plains."},
+	{"valleys",    true,	"Large valleys with complex terrain and rivers."},
+	{"carpathian", true,	"Realistic looking world with vast plains."},
+	{"v5",         true,	"Old mapgen."},
+	{"flat",       true,	"World Flat terrain."},
+	{"fractal",    true,	"Wold with fractal structure."},
+	{"singlenode", true,	"Empty world, use for lua defined mapgens."},
+	{"v6",         true,	"Simple mapgen with few features, not recommended."},
 };
 
 static_assert(
@@ -204,6 +205,14 @@ void Mapgen::getMapgenNames(std::vector<const char *> *mgnames, bool include_hid
 	for (u32 i = 0; i != ARRLEN(g_reg_mapgens); i++) {
 		if (include_hidden || g_reg_mapgens[i].is_user_visible)
 			mgnames->push_back(g_reg_mapgens[i].name);
+	}
+}
+
+void Mapgen::getMapgenDescriptions(std::vector<const char *> *mgdescriptions, bool include_hidden)
+{
+	for (u32 i = 0; i != ARRLEN(g_reg_mapgens); i++) {
+		if (include_hidden || g_reg_mapgens[i].is_user_visible)
+			mgdescriptions->push_back(g_reg_mapgens[i].description);
 	}
 }
 

--- a/src/mapgen/mapgen.h
+++ b/src/mapgen/mapgen.h
@@ -243,6 +243,7 @@ public:
 		EmergeParams *emerge);
 	static MapgenParams *createMapgenParams(MapgenType mgtype);
 	static void getMapgenNames(std::vector<const char *> *mgnames, bool include_hidden);
+	static void getMapgenDescriptions(std::vector<const char *> *mgdescriptions, bool include_hidden);
 	static void setDefaultSettings(Settings *settings);
 
 private:

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -660,6 +660,22 @@ int ModApiMainMenu::l_get_mapgen_names(lua_State *L)
 	return 1;
 }
 
+/******************************************************************************/
+int ModApiMainMenu::l_get_mapgen_descriptions(lua_State *L)
+{
+	std::vector<const char *> descriptions;
+	bool include_hidden = lua_isboolean(L, 1) && readParam<bool>(L, 1);
+	Mapgen::getMapgenDescriptions(&descriptions, include_hidden);
+
+	lua_newtable(L);
+	for (size_t i = 0; i != descriptions.size(); i++) {
+		lua_pushstring(L, descriptions[i]);
+		lua_rawseti(L, -2, i + 1);
+	}
+
+	return 1;
+}
+
 
 /******************************************************************************/
 int ModApiMainMenu::l_get_user_path(lua_State *L)
@@ -1059,6 +1075,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(set_background);
 	API_FCT(set_topleft_text);
 	API_FCT(get_mapgen_names);
+	API_FCT(get_mapgen_descriptions);
 	API_FCT(get_user_path);
 	API_FCT(get_modpath);
 	API_FCT(get_modpaths);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -51,6 +51,8 @@ private:
 
 	static int l_get_mapgen_names(lua_State *L);
 
+	static int l_get_mapgen_descriptions(lua_State *L);
+
 	static int l_get_language(lua_State *L);
 
 	//packages


### PR DESCRIPTION
Adds mapgen description when creating a world. Closes #1033

## To do

Ready for Review.

## How to test

Pull, compile, create world in desired game, observe descriptions.
