### PR TITLE
Mapgen selection and init code

### DIFF
--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -80,8 +80,17 @@ local mgv6_biomes = {
 
 local function create_world_formspec(dialogdata)
 
-	local current_mg = dialogdata.mg
+	local current_mapgen = dialogdata.mg
 	local mapgens = core.get_mapgen_names()
+	local lua_mapgens = core.get_lua_mapgen_descriptions()
+	for k, v in pairs(lua_mapgens) do
+		mapgens[#mapgens+1] = k
+	end
+
+	local current_mapgen_internal = dialogdata.mg
+	if lua_mapgens[current_mapgen_internal] then
+		current_mapgen_internal = "singlenode"
+	end
 
 	local flags = dialogdata.flags
 
@@ -137,7 +146,7 @@ local function create_world_formspec(dialogdata)
 			if not first_mg then
 				first_mg = v
 			end
-			if current_mg == v then
+			if current_mapgen == v then
 				selindex = i
 			end
 			i = i + 1
@@ -145,7 +154,7 @@ local function create_world_formspec(dialogdata)
 		end
 		if not selindex then
 			selindex = 1
-			current_mg = first_mg
+			current_mapgen = first_mg
 		end
 		mglist = mglist:sub(1, -2)
 	end
@@ -254,7 +263,7 @@ local function create_world_formspec(dialogdata)
 	local str_flags, str_spflags
 	local label_flags, label_spflags = "", ""
 	y = y + 0.3
-	str_flags, y = mg_main_flags(current_mg, y)
+	str_flags, y = mg_main_flags(current_mapgen_internal, y)
 	if str_flags ~= "" then
 		label_flags = "label[0,"..y_start..";" .. fgettext("Mapgen flags") .. "]"
 		y_start = y + 0.4
@@ -262,7 +271,7 @@ local function create_world_formspec(dialogdata)
 		y_start = 0.0
 	end
 	y = y_start + 0.3
-	str_spflags = mg_specific_flags(current_mg, y)
+	str_spflags = mg_specific_flags(current_mapgen_internal, y)
 	if str_spflags ~= "" then
 		label_spflags = "label[0,"..y_start..";" .. fgettext("Mapgen-specific flags") .. "]"
 	end
@@ -370,11 +379,20 @@ local function create_world_buttonhandler(this, fields)
 		if message == nil then
 			this.data.seed = fields["te_seed"] or ""
 			this.data.mg = fields["dd_mapgen"]
+			local mapgen_internal = this.data.mg
+			local mapgen = nil
+
+			local lua_mapgens = core.get_lua_mapgen_descriptions()
+			if lua_mapgens[this.data.mg] then
+				mapgen_internal = "singlenode"
+				mapgen = this.data.mg
+			end
 
 			-- actual names as used by engine
 			local settings = {
 				fixed_map_seed = this.data.seed,
-				mg_name = this.data.mg,
+				mg_name = mapgen_internal,
+				lua_mapgen = mapgen,
 				mg_flags = table_to_flags(this.data.flags.main),
 				mgv5_spflags = table_to_flags(this.data.flags.v5),
 				mgv6_spflags = table_to_flags(this.data.flags.v6),

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -403,6 +403,40 @@ Any mod can redefine `experimental:tnt` by using the name
 when registering it. For this to work correctly, that mod must have
 `experimental` as a dependency.
 
+Lua-defined Mapgens
+====
+
+Except what is refrenced here, lua-defined mapgens are identical to mods.
+
+mapgen load path
+-------------
+
+Paths are relative to the directories listed in the [Paths] section above.
+* `mapgens/`
+
+Mapgen directory structure
+-----------------------
+
+    mapgens
+    ├── mapgenname
+    │   ├── mapgen.conf
+    │   ├── init.lua
+    │   └── <custom data and code>
+    └── another
+
+### mapgen.conf
+
+A `Settings` file that provides meta information about the mapgen.
+
+* `name`: The mapgen name. Allows Luanti to determine the mapgen name even if the
+          folder is wrongly named.
+* `title`: A human-readable title to address the mapgen. See [Translating content meta](#translating-content-meta).
+* `description`: Description of mapgen. See [Translating content meta](#translating-content-meta).
+* `author`: The author's ContentDB username.
+* `release`: Ignore this: Should only ever be set by ContentDB, as it is an
+             internal ID used to track versions.
+* `textdomain`: Textdomain used to translate title and description. Defaults to mapgen.
+  See [Translating content meta](#translating-content-meta).
 
 
 

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -109,6 +109,8 @@ of manually putting one, as different OSs use different delimiters. E.g.
 * `handle:stop()` or `core.sound_stop(handle)`
 * `core.get_mapgen_names([include_hidden=false])` -> table of map generator algorithms
     registered in the core (possible in async calls)
+* `core.get_lua_mapgen_descriptions()` -> map of `[mapgen_name] = mapgen_description` as listed
+    in `mapgen.conf`.
 * `core.get_cache_path()` -> path of cache
 * `core.get_temp_path([param])` (possible in async calls)
   * `param`=true: returns path to a newly created temporary file

--- a/mapgens/mapgens_here.txt
+++ b/mapgens/mapgens_here.txt
@@ -1,0 +1,1 @@
+Put lua mapgens in this directory.

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -112,6 +112,39 @@ void ModConfiguration::addGameMods(const SubgameSpec &gamespec)
 	m_last_mod = gamespec.last_mod;
 }
 
+void ModConfiguration::addMapgenFromConfig(
+		const std::string &settings_path,
+		const std::unordered_map<std::string, std::string> &mapgenPaths)
+{
+	Settings conf;
+	conf.readConfigFile(settings_path.c_str());
+
+	if (!conf.exists("mapgen"))
+		return;
+
+	const std::string mapgen = conf.get("mapgen");
+
+	// List of enabled mapgens
+	std::vector<ModSpec> mapgen_mod;
+
+	/*
+	 * Iterate through all installed mapgens
+	 *
+	 * If the mod is enabled, add it to `mapgen_mod` and break
+	 */
+	for (const auto &mapgenPath : mapgenPaths) {
+		std::vector<ModSpec> addon_mods_in_path = flattenMods(getModsInPath(mapgenPath.second, mapgenPath.first));
+		for (const auto &mod : addon_mods_in_path) {
+			if (mod.name == mapgen) {
+				mapgen_mod.push_back(mod);
+				break;
+			}
+		}
+	}
+
+	addMods(mapgen_mod);
+}
+
 void ModConfiguration::addModsFromConfig(
 		const std::string &settings_path,
 		const std::unordered_map<std::string, std::string> &modPaths)

--- a/src/content/mod_configuration.h
+++ b/src/content/mod_configuration.h
@@ -67,6 +67,15 @@ public:
 			const std::unordered_map<std::string, std::string> &modPaths);
 
 	/**
+	 * Adds mods specified by a world.mt config
+	 *
+	 * @param settings_path Path to world.mt
+	 * @param mapgenPaths Map from virtual name to mapgen path
+	 */
+	void addMapgenFromConfig(const std::string &settings_path,
+			const std::unordered_map<std::string, std::string> &mapgenPaths);
+			
+	/**
 	 * Call this function once all mods have been added
 	 */
 	void checkConflictsAndDeps();

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -37,6 +37,9 @@ struct ModSpec
 	bool part_of_modpack = false;
 	bool is_modpack = false;
 
+	// lua-defined mapgen
+	bool is_mapgen = false;
+
 	/**
 	 * A constructed canonical path to represent this mod's location.
 	 * This intended to be used as an identifier for a modpath that tolerates file movement,

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -19,6 +19,7 @@ struct SubgameSpec
 	int release;
 	std::string first_mod; // "" <=> no mod
 	std::string last_mod; // "" <=> no mod
+	std::string lua_mapgen; // "" <=> use internal
 	std::string path;
 	std::string gamemods_path;
 
@@ -26,6 +27,7 @@ struct SubgameSpec
 	 * Map from virtual path to mods path
 	 */
 	std::unordered_map<std::string, std::string> addon_mods_paths;
+	std::unordered_map<std::string, std::string> mapgen_paths;
 
 	// For logging purposes
 	std::vector<const char *> deprecation_msgs;
@@ -36,14 +38,18 @@ struct SubgameSpec
 			const std::string &title = "",
 			const std::string &author = "", int release = 0,
 			const std::string &first_mod = "",
-			const std::string &last_mod = "") :
+			const std::string &last_mod = "",
+			const std::string &lua_mapgen = "",
+			const std::unordered_map<std::string, std::string> &mapgen_paths = {}) :
 			id(id),
 			title(title), author(author), release(release),
 			first_mod(first_mod),
 			last_mod(last_mod),
+			lua_mapgen(lua_mapgen),
 			path(path),
 			gamemods_path(gamemods_path),
-			addon_mods_paths(addon_mods_paths)
+			addon_mods_paths(addon_mods_paths),
+			mapgen_paths(mapgen_paths)
 	{
 	}
 
@@ -88,4 +94,4 @@ std::vector<WorldSpec> getAvailableWorlds();
 // loads the subgame's config and creates world directory
 // and world.mt if they don't exist
 void loadGameConfAndInitWorld(const std::string &path, const std::string &name,
-		const SubgameSpec &gamespec, bool create_world);
+		const SubgameSpec &gamespec, bool create_world, const std::string &lua_mapgen);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -593,7 +593,10 @@ int ModApiMainMenu::l_create_world(lua_State *L)
 
 	// Create world if it doesn't exist
 	try {
-		loadGameConfAndInitWorld(path, name, *game_it, true);
+		std::string lua_mapgen = "";
+		if (use_settings.find("lua_mapgen") != use_settings.end())
+			lua_mapgen = use_settings["lua_mapgen"];
+		loadGameConfAndInitWorld(path, name, *game_it, true, lua_mapgen);
 		lua_pushnil(L);
 	} catch (const BaseException &e) {
 		auto err = std::string("Failed to initialize world: ") + e.what();
@@ -660,6 +663,21 @@ int ModApiMainMenu::l_get_mapgen_names(lua_State *L)
 	return 1;
 }
 
+/******************************************************************************/
+int ModApiMainMenu::l_get_lua_mapgen_descriptions(lua_State *L)
+{
+	std::vector<ModSpec> addon_mods_in_path = flattenMods(getModsInPath(porting::path_share + DIR_DELIM + "mapgens" + DIR_DELIM, "mapgen/"));
+
+	lua_newtable(L);
+	for (const auto &mod : addon_mods_in_path) {
+		if (mod.is_mapgen) {
+			lua_pushstring(L, mod.desc.c_str());
+			lua_setfield(L, -2, mod.name.c_str());
+		}
+	}
+
+	return 1;
+}
 
 /******************************************************************************/
 int ModApiMainMenu::l_get_user_path(lua_State *L)
@@ -1059,6 +1077,7 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(set_background);
 	API_FCT(set_topleft_text);
 	API_FCT(get_mapgen_names);
+	API_FCT(get_lua_mapgen_descriptions);
 	API_FCT(get_user_path);
 	API_FCT(get_modpath);
 	API_FCT(get_modpaths);
@@ -1100,6 +1119,7 @@ void ModApiMainMenu::InitializeAsync(lua_State *L, int top)
 	API_FCT(get_worlds);
 	API_FCT(get_games);
 	API_FCT(get_mapgen_names);
+	API_FCT(get_lua_mapgen_descriptions);
 	API_FCT(get_user_path);
 	API_FCT(get_modpath);
 	API_FCT(get_modpaths);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -51,6 +51,8 @@ private:
 
 	static int l_get_mapgen_names(lua_State *L);
 
+	static int l_get_lua_mapgen_descriptions(lua_State *L);
+
 	static int l_get_language(lua_State *L);
 
 	//packages

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -447,7 +447,7 @@ void Server::init()
 	try {
 		loadGameConfAndInitWorld(m_path_world,
 				fs::GetFilenameFromPath(m_path_world.c_str()),
-				m_gamespec, false);
+				m_gamespec, false, "");
 	} catch (const BaseException &e) {
 		throw ServerError(std::string("Failed to initialize world: ") + e.what());
 	}

--- a/src/server/mods.cpp
+++ b/src/server/mods.cpp
@@ -23,6 +23,7 @@ ServerModManager::ServerModManager(const std::string &worldpath, SubgameSpec gam
 
 	// Load normal mods
 	std::string worldmt = worldpath + DIR_DELIM + "world.mt";
+	configuration.addMapgenFromConfig(worldmt, gamespec.mapgen_paths);
 	configuration.addModsFromConfig(worldmt, gamespec.addon_mods_paths);
 	configuration.checkConflictsAndDeps();
 }


### PR DESCRIPTION
This adds an interface for Lua-defined mapgens as outlined in #16240. This is still a work in progress and any input is welcomed.

- Goal of the PR:
    Add lua-defined mapgens as true mapgens to a game.
- How does the PR work? 
    It adds a interface for selecting lua-defined mapgens, and the loading mechanic.
- Does it resolve any reported issue?
    Yes, it solves #16240
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
    Kinda(?) It sets up a ground for `Internal code refactoring` related to mapgens by allowing pure lua mapgens.
- If not a bug fix, why is this PR needed? What usecases does it solve?
    It allows for engine mapgens be made in lua, and allows the community to make their own mapgens without having to hack together a mod. This mainly applies when a mapgen is not part of a game's own code-base. It also technically allows for a migration of current mapgens to lua, but that seems unlikely to happen

## To do

This PR is a Work in Progress

- [ ] Make a POC mapgen for testing (not in PR).
- [ ] Wait for #16237 and add description display when merged.
- [ ] Add mapgen settings and flags in the menu.
- [ ] Other minor tweaks that I haven't thought of yet.

## How to test

I will make a basic mapgen later to test, this is TODO
