### PR TITLE
Add keybinding for world close key

### DIFF
--- a/builtin/common/settings/components.lua
+++ b/builtin/common/settings/components.lua
@@ -438,11 +438,28 @@ function make.key(setting)
 		if value == "" then
 			return height
 		end
+
+		local critical_keys = {
+			keymap_drop = true,
+			keymap_dig = true,
+			keymap_place = true,
+		}
+
 		for _, o in ipairs(core.full_settingtypes) do
-			if o.type == "key" and o.name ~= setting.name and core.are_keycodes_equal(core.settings:get(o.name), value) then
-				table.insert(fs, ("label[0,%f;%s]"):format(height + 0.3,
-						core.colorize(mt_color_orange, fgettext([[Conflicts with "$1"]], fgettext(o.readable_name)))))
-				height = height + 0.6
+			if o.type == "key" and o.name ~= setting.name and
+					core.are_keycodes_equal(core.settings:get(o.name), value) then
+
+				local is_current_close_world = setting.name == "keymap_close_world"
+				local is_other_close_world = o.name == "keymap_close_world"
+				local is_current_critical = critical_keys[setting.name]
+				local is_other_critical = critical_keys[o.name]
+
+				if (is_other_critical or is_current_critical) or
+						(not is_current_close_world and not is_other_close_world) then
+					table.insert(fs, ("label[0,%f;%s]"):format(height + 0.3,
+							core.colorize(mt_color_orange, fgettext([[Conflicts with "$1"]], fgettext(o.readable_name)))))
+					height = height + 0.6
+				end
 			end
 		end
 		return height
@@ -454,12 +471,12 @@ function make.key(setting)
 
 		get_formspec = function(self, avail_w)
 			self.resettable = core.settings:has(setting.name)
-			local btn_bind_width = math.max(2.5, avail_w/2)
+			local btn_bind_width = math.max(2.5, avail_w / 2)
 			local value = core.settings:get(setting.name)
 			local fs = {
 				("label[0,0.4;%s]"):format(get_label(setting)),
 				("button_key[%f,0;%f,0.8;%s;%s]"):format(
-						btn_bind_width, btn_bind_width-0.8,
+						btn_bind_width, btn_bind_width - 0.8,
 						btn_bind, core.formspec_escape(value)),
 				("image_button[%f,0;0.8,0.8;%s;%s;]"):format(avail_w - 0.8,
 						core.formspec_escape(defaulttexturedir .. "clear.png"),

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -273,6 +273,10 @@ keymap_increase_viewing_range_min (Increase view range) key SYSTEM_SCANCODE_46
 
 keymap_decrease_viewing_range_min (Decrease view range) key SYSTEM_SCANCODE_45
 
+#    Modifier key bind for closing your world.
+#    Requires ESC + the selected key to work.
+keymap_close_world (Return to Main Menu) key
+
 keymap_slot1 (Hotbar slot 1) key SYSTEM_SCANCODE_30
 
 keymap_slot2 (Hotbar slot 2) key SYSTEM_SCANCODE_31

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -137,6 +137,7 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	// This is separate from other keyboard handling so that it also works in menus.
 	if (event.EventType == EET_KEY_INPUT_EVENT) {
 		KeyPress keyCode(event.KeyInput);
+
 		if (keyCode == getKeySetting("keymap_fullscreen")) {
 			if (event.KeyInput.PressedDown && !fullscreen_is_down) {
 				IrrlichtDevice *device = RenderingEngine::get_raw_device();
@@ -150,8 +151,15 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			}
 			fullscreen_is_down = event.KeyInput.PressedDown;
 			return true;
-		} else if (keyCode == EscapeKey &&
-				event.KeyInput.PressedDown && event.KeyInput.Shift) {
+
+		} else if (keyCode == getKeySetting("keymap_close_world")) {
+			close_world_down = event.KeyInput.PressedDown;
+
+		} else if (keyCode == EscapeKey) {
+			esc_down = event.KeyInput.PressedDown;
+		}
+
+		if (esc_down && close_world_down) {
 			g_gamecallback->disconnect();
 			return true;
 		}

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -128,6 +128,9 @@ private:
 	// Intentionally not reset by clearInput/releaseAllKeys.
 	bool fullscreen_is_down = false;
 
+	bool close_world_down = false;
+	bool esc_down = false;
+
 	PointerType last_pointer_type = PointerType::Mouse;
 };
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -187,6 +187,7 @@ void set_default_settings()
 	USEKEY2("keymap_fullscreen", "SYSTEM_SCANCODE_68", "KEY_F11");
 	USEKEY2("keymap_increase_viewing_range_min", "SYSTEM_SCANCODE_46", "+");
 	USEKEY2("keymap_decrease_viewing_range_min", "SYSTEM_SCANCODE_45", "-");
+	settings->setDefault("keymap_close_world", "");
 	USEKEY2("keymap_slot1", "SYSTEM_SCANCODE_30", "KEY_KEY_1");
 	USEKEY2("keymap_slot2", "SYSTEM_SCANCODE_31", "KEY_KEY_2");
 	USEKEY2("keymap_slot3", "SYSTEM_SCANCODE_32", "KEY_KEY_3");


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
   Allow players to configure what keybind combination they use for leaving the world. ESC key is required, any other key will work.
- How does the PR work?
It merely adds a new keybinding, and then checks to make sure that ESC + that keybinding is clicked.
- Does it resolve any reported issue?
Yes:
closes https://github.com/luanti-org/luanti/issues/16201
closes https://github.com/luanti-org/luanti/issues/16243
- If not a bug fix, why is this PR needed? What usecases does it solve?
It improves playability for some players.

## To do

Ready for Review.

## How to test.
Just play around with the keybindings while in your world

## Notes.

I know there was talk about allowing the keybinding to be configured would be too niche, however. I opted to do it this way, so that players can have the choice.