### PR TITLE
Add documentation index for `doc/` as `README.md`, and small docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Further documentation
 - Forum: https://forum.luanti.org/
 - GitHub: https://github.com/luanti-org/luanti/
 - [Developer documentation](doc/developing/)
+- [Documentation index](doc/README.md)
 - [doc/](doc/) directory of source distribution
 
 Default controls

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Further documentation
 - Forum: https://forum.luanti.org/
 - GitHub: https://github.com/luanti-org/luanti/
 - [Developer documentation](doc/developing/)
-- [Documentation index](doc/README.md)
 - [doc/](doc/) directory of source distribution
 
 Default controls

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,29 +1,37 @@
 # Documentation Index
 
-The following is a list of documentation files and a brief description to aid
-in locating documentation (sorted alphabetically).
+The following is a list of documentation files and a brief description, if
+    applicable, to aid in locating documentation (sorted alphabetically
+    per-section).
 
 ## Lua
 
-- [Builtin Entities](builtin_entities.md): Documentation of core engine entities.
-- [Client-side API](client_lua_api.md): Documentation on client side lua API
-    enviorment.
-- [Formspec Toolkit API](fst_api.txt): Documentation on formspec toolkit.
-- [Menu API](menu_lua_api.md): Documentation lua API for menu enviorment.
-- [Mod API](lua_api.md): Documentation on lua API for mod enviorment.
+- [Builtin Entities](builtin_entities.md): Internal predefined engine entities.
+- [Client-side API](client_lua_api.md): Client side enviorment's Lua API.
+- [Formspec Toolkit API](fst_api.txt)
+- [Menu API](menu_lua_api.md): Lua API for the creation of engine menus, not the
+    mod API.
+- [Mod APIs](lua_api.md): Lua APIs avalible within the mod enviorment and mapgen
+    enviorment. Contains infromation related to texturing and structure of games,
+    mods, and texture packs. **Related**: [Texture Packs](texture_packs.md) and
+    [World Format](world_format.md).
 
 ## Formats and Content
 
-- [Texture Packs](texture_packs.md): Documentation on Luanti's texture packs system.
-- [World Format](world_format.md): Documentation on Luanti world format.
+- [Texture Packs](texture_packs.md): Layout and description of Luanti's texture
+    packs structure and configuration. Related information can be found in the
+    [mod API](lua_api.md).
+- [World Format](world_format.md): Layout and description of Luanti's world
+    format. Documents the structure of the dirrectories and the files therein,
+    including the structure of the internal world related databases.
 
 ## Protocals
 
-- [Protocol](protocol.txt): Documentation on Luanti's network protocol.
+- [Protocol](protocol.txt): *Rough* outline of Luanti's network protocol.
 
 ## Misc.
 
-- [Android information](android.md): Documentation relating to Luanti on the Android platform.
-- [Docker Server](docker_server.md): Documentation on Luanti's Docker server.
-- [Luanti Development Direction](direction.md): Official Luanti development direction information.
-- [Major Breakages List](breakages.md): Documentation of breaking changes.
+- [Android Information](android.md)
+- [Docker Server](docker_server.md)
+- [Luanti Development Direction](direction.md)
+- [List of Major Breakages](breakages.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@ The following is a list of documentation files and a brief description, if
 
 ## Lua
 
-- [Builtin Entities](builtin_entities.md): Internal predefined engine entities.
+- [Builtin Entities](builtin_entities.md): Doc for predefined engine entities, i.e. dropped items and falling nodes.
 - [Client-side API](client_lua_api.md): Client side enviorment's Lua API.
 - [Formspec Toolkit API](fst_api.txt)
 - [Menu API](menu_lua_api.md): Lua API for the creation of engine menus, not the

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,42 +1,60 @@
-# Documentation Index
+# Documentation
 
-The following is a list of documentation files and a brief description to aid
-    in locating documentation (sorted alphabetically per-section).
+This directory contains mostly reference documentation for the Luanti engine.
+For a less prescriptive and more guiding documentation, also look at:
+https://docs.luanti.org
 
-## Lua
+Note that the inner workings of the engine are not well documented. It's most
+often better to read the code.
 
-- [builtin_entities.md](builtin_entities.md): Doc for predefined engine
-    entities, i.e. dropped items and falling nodes.
-- [client_lua_api.md](client_lua_api.md): Client side enviorment's Lua API.
-- [fst_api.txt](fst_api.txt): Formspec Toolkit API, this is for the engine's
-    menus (Manu menu, world creation dialogs, etc.)
-- [menu_lua_api.md](menu_lua_api.md): Lua API for the creation of engine menus,
-    not the mod API.
-- [lua_api.md](lua_api.md): Lua APIs for server mods. Documents the normal mod
-    enviorment and mapgen enviorment and contains infromation related to
-    texturing and structure of games, mods, and texture packs.
+Markdown files are written in a way that they can also be read in plain text.
+When modifying, please keep it that way!
 
-## Formats and Content
+Here is a list with descriptions of relevant files:
+
+## Server Modding
+
+- [lua_api.md](lua_api.md): Server Modding API reference. (Not only the Lua part,
+    but also file structure and everything else.)
+    If you want to make a mod or game, look here!
+    A rendered version is also available at <https://api.luanti.org/>.
+- [builtin_entities.md](builtin_entities.md): Doc for entities predefined by the
+    engine (in builtin), i.e. dropped items and falling nodes.
+
+## Client-Side Content
 
 - [texture_packs.md](texture_packs.md): Layout and description of Luanti's
-    texture packs structure and configuration. Related information can be
-    found in the [mod API](lua_api.md).
-- [world_format.md](world_format.md): Layout and description of Luanti's world
-    format. Documents the structure of the dirrectories and the files therein,
-    including the structure of the internal world related databases.
-    **Important**: Due to incompleatness of this documentation, it is
-    recommended to read the serialize and deserialize functions in C++ to
-    better understand this documentation.
+    texture packs structure and configuration.
+- [client_lua_api.md](client_lua_api.md): Client-Provided Client-Side Modding
+    (CPCSM) API reference.
+
+## Mainmenu scripting
+
+- [menu_lua_api.md](menu_lua_api.md): API reference for the mainmenu scripting
+    environment.
+- [fst_api.txt](fst_api.txt): Formspec Toolkit API, included in builtin for the
+    main menu.
+
+## Formats and Protocols
+
+- [world_format.md](world_format.md): Structure of Luanti world directories and
+    format of the files therein.
+    Note: If you want to write your own deserializer, it will be easier to read
+    the `serialize()` and `deSerialize()` functions of the various structures in
+    C++, e.g. `MapBlock::deSerialize()`.
 - [protocol.txt](protocol.txt): *Rough* outline of Luanti's network protocol.
 
 ## Misc.
 
-- [android.md](android.md) Android related information.
-- [breakages.md](breakages.md) List of major breakages.
-- [compiling/](compiling/) Compilation information and instructions.
-- [developing/](developing/) Extra information about Luanti development, e.g.
-    OS-related information.
-- [direction.md](direction.md) Information related to the future direction of
-    Luanti.
-- [docker_server.md](docker_server.md) Infromation about Docker server images.
-- [ides/](ides/) Information about IDE configuration.
+- [compiling/](compiling/): Compilation instructions, and options.
+- [ides/](ides/): Instructions for configuring certain IDEs for engine development.
+- [developing/](developing/): Information about Luanti development.
+    Note: [developing/profiling.md](developing/profiling.md) can be useful for
+    modders and server owners!
+- [android.md](android.md): Android quirks.
+- [direction.md](direction.md): Information related to the future direction of
+    Luanti. Commonly referred to as the roadmap document.
+- [breakages.md](breakages.md): List of planned breakages for the next major
+    release, i.e. 6.0.0.
+- [docker_server.md](docker_server.md): Information about our Docker server
+    images in the ghcr.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,29 @@
+# Documentation Index
+
+The following is a list of documentation files and a brief description to aid
+in locating documentation (sorted alphabetically).
+
+## Lua
+
+- [Builtin Entities](builtin_entities.md): Documentation of core engine entities.
+- [Client-side API](client_lua_api.md): Documentation on client side lua API
+    enviorment.
+- [Formspec Toolkit API](fst_api.txt): Documentation on formspec toolkit.
+- [Menu API](menu_lua_api.md): Documentation lua API for menu enviorment.
+- [Mod API](lua_api.md): Documentation on lua API for mod enviorment.
+
+## Formats and Content
+
+- [Texture Packs](texture_packs.md): Documentation on Luanti's texture packs system.
+- [World Format](world_format.md): Documentation on Luanti world format.
+
+## Protocals
+
+- [Protocol](protocol.txt): Documentation on Luanti's network protocol.
+
+## Misc.
+
+- [Android information](android.md): Documentation relating to Luanti on the Android platform.
+- [Docker Server](docker_server.md): Documentation on Luanti's Docker server.
+- [Luanti Development Direction](direction.md): Official Luanti development direction information.
+- [Major Breakages List](breakages.md): Documentation of breaking changes.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,37 +1,42 @@
 # Documentation Index
 
-The following is a list of documentation files and a brief description, if
-    applicable, to aid in locating documentation (sorted alphabetically
-    per-section).
+The following is a list of documentation files and a brief description to aid
+    in locating documentation (sorted alphabetically per-section).
 
 ## Lua
 
-- [Builtin Entities](builtin_entities.md): Doc for predefined engine entities, i.e. dropped items and falling nodes.
-- [Client-side API](client_lua_api.md): Client side enviorment's Lua API.
-- [Formspec Toolkit API](fst_api.txt)
-- [Menu API](menu_lua_api.md): Lua API for the creation of engine menus, not the
-    mod API.
-- [Mod APIs](lua_api.md): Lua APIs avalible within the mod enviorment and mapgen
-    enviorment. Contains infromation related to texturing and structure of games,
-    mods, and texture packs. **Related**: [Texture Packs](texture_packs.md) and
-    [World Format](world_format.md).
+- [builtin_entities.md](builtin_entities.md): Doc for predefined engine
+    entities, i.e. dropped items and falling nodes.
+- [client_lua_api.md](client_lua_api.md): Client side enviorment's Lua API.
+- [fst_api.txt](fst_api.txt): Formspec Toolkit API, this is for the engine's
+    menus (Manu menu, world creation dialogs, etc.)
+- [menu_lua_api.md](menu_lua_api.md): Lua API for the creation of engine menus,
+    not the mod API.
+- [lua_api.md](lua_api.md): Lua APIs for server mods. Documents the normal mod
+    enviorment and mapgen enviorment and contains infromation related to
+    texturing and structure of games, mods, and texture packs.
 
 ## Formats and Content
 
-- [Texture Packs](texture_packs.md): Layout and description of Luanti's texture
-    packs structure and configuration. Related information can be found in the
-    [mod API](lua_api.md).
-- [World Format](world_format.md): Layout and description of Luanti's world
+- [texture_packs.md](texture_packs.md): Layout and description of Luanti's
+    texture packs structure and configuration. Related information can be
+    found in the [mod API](lua_api.md).
+- [world_format.md](world_format.md): Layout and description of Luanti's world
     format. Documents the structure of the dirrectories and the files therein,
     including the structure of the internal world related databases.
-
-## Protocals
-
-- [Protocol](protocol.txt): *Rough* outline of Luanti's network protocol.
+    **Important**: Due to incompleatness of this documentation, it is
+    recommended to read the serialize and deserialize functions in C++ to
+    better understand this documentation.
+- [protocol.txt](protocol.txt): *Rough* outline of Luanti's network protocol.
 
 ## Misc.
 
-- [Android Information](android.md)
-- [Docker Server](docker_server.md)
-- [Luanti Development Direction](direction.md)
-- [List of Major Breakages](breakages.md)
+- [android.md](android.md) Android related information.
+- [breakages.md](breakages.md) List of major breakages.
+- [compiling/](compiling/) Compilation information and instructions.
+- [developing/](developing/) Extra information about Luanti development, e.g.
+    OS-related information.
+- [direction.md](direction.md) Information related to the future direction of
+    Luanti.
+- [docker_server.md](docker_server.md) Infromation about Docker server images.
+- [ides/](ides/) Information about IDE configuration.

--- a/doc/developing/README.md
+++ b/doc/developing/README.md
@@ -2,7 +2,7 @@
 
 ## Luanti Documentation
 
-Some important development docs are found in the Luanti Documentation: https://docs.luanti.org/
+Some important development docs are found on the docs site: https://docs.luanti.org/
 
 Notable pages:
 
@@ -11,13 +11,14 @@ Notable pages:
 - [Changelog](https://docs.luanti.org/about/changelog/)
 - [Organisation](https://docs.luanti.org/for-engine-devs/organization/)
 - [Code style guidelines](https://docs.luanti.org/for-engine-devs/code-style-guidelines/)
+  and [Lua code style guidelines](https://docs.luanti.org/for-engine-devs/lua-code-style-guidelines/)
 
 ## In this folder
 
-- [Developing minetestserver with Docker](docker.md)
-- [Android tips & tricks](android.md)
-- [OS/library compatibility policy](os-compatibility.md)
-- [Profiling instructions](profiling.md)
+- [docker.md](docker.md): Developing minetestserver with Docker
+- [android.md](android.md): Android tips & tricks
+- [os-compatibility.md](os-compatibility.md): OS/library compatibility policy
+- [profiling.md](profiling.md): Profiling instructions
 
 ## IRC
 

--- a/doc/developing/README.md
+++ b/doc/developing/README.md
@@ -17,7 +17,7 @@ Notable pages:
 - [Developing minetestserver with Docker](docker.md)
 - [Android tips & tricks](android.md)
 - [OS/library compatibility policy](os-compatibility.md)
-- [Miscellaneous](misc.md)
+- [Profiling instructions](profiling.md)
 
 ## IRC
 

--- a/doc/developing/profiling.md
+++ b/doc/developing/profiling.md
@@ -1,4 +1,4 @@
-# Miscellaneous
+# Profiling
 
 ## Profiling Luanti on Linux with perf
 

--- a/doc/fst_api.txt
+++ b/doc/fst_api.txt
@@ -3,8 +3,10 @@ Formspec toolkit api 0.0.3
 
 Formspec toolkit is a set of functions to create basic ui elements.
 
+You can find the files in builtin/fstk/.
 
-File: fst/ui.lua
+
+File: fstk/ui.lua
 ----------------
 
 ui.lua adds base ui interface to add additional components to.
@@ -25,7 +27,7 @@ ui.find_by_name(name) --> returns component or nil
 ^ find a component within ui
 ^ name: name of component to look for
 
-File: fst/tabview.lua
+File: fstk/tabview.lua
 ---------------------
 
 tabview_create(name, size, tabheaderpos) --> returns tabview component
@@ -92,7 +94,7 @@ methods:
       * icon: path to icon
       * on_click(tabview): callback function
 
-File: fst/dialog.lua
+File: fstk/dialog.lua
 ---------------------
 Only one dialog can be shown at a time. If a dialog is closed it's parent is
 gonna be activated and shown again.
@@ -129,7 +131,7 @@ members:
 - parent
   ^ parent component to return to on exit
 
-File: fst/buttonbar.lua
+File: fstk/buttonbar.lua
 -----------------------
 
 buttonbar_create(name, pos, size, bgcolor, cbf_buttonhandler)

--- a/doc/protocol.txt
+++ b/doc/protocol.txt
@@ -3,7 +3,8 @@ Updated 2011-06-18
 
 A custom protocol over UDP.
 Integers are big endian.
-Refer to connection.{h,cpp} for further reference.
+Refer to network/mtp/internal.h, network/networkprotocol.{h,cpp}, and
+server/clientiface.h for further reference.
 
 Initialization:
 - A dummy reliable packet with peer_id=PEER_ID_INEXISTENT=0 is sent to the server:


### PR DESCRIPTION
Adds a documenation index as `doc/README.md`.

- Goal of the PR
    Add documentation index.
- How does the PR work?
    It adds a `README.md` to `doc/`
- Does it resolve any reported issue?
    Yes, #16252.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
    I think so, it helps to `ensure sustainable development`, mentioned under `Internal code refactoring`.
- If not a bug fix, why is this PR needed? What usecases does it solve?
    It helps developers find documenation.

## To do

Ready for Review.

## How to test

Read documentation.
