### PR TITLE
Fix some misinformation in `world_format.md`

### DIFF
--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -401,7 +401,7 @@ See below for description.
   Luanti will correct lighting in the day light bank when the block at
   `(1, 0, 0)` is also loaded.
 
-Timestamp and node ID mappings were introduced in map format version 29.
+Timestamp and node ID mappings come here if map format version >= 29.
 * `u32` timestamp
     * Timestamp when last saved, as seconds from starting the game.
     * `0xffffffff` = invalid/unknown timestamp, nothing should be done with the time
@@ -482,14 +482,6 @@ Timestamp and node ID mappings were introduced in map format version 29.
             * `s32` timeout * 1000
             * `s32` elapsed * 1000
 
-* Since map format version 25:
-    * `u8` length of the data of a single timer (always 2+4+4=10)
-    * `u16` `num_of_timers`
-    * foreach `num_of_timers`:
-        * `u16` timer position (`(z*16*16 + y*16 + x)`)
-        * `s32` timeout * 1000
-        * `s32` elapsed * 1000
-
 `u8` static object version:
 * Always 0
 
@@ -515,6 +507,14 @@ Before map format version 29:
         * `u16` `id`
         * `u16` `name_len`
         * `u8[name_len]` `name`
+
+Since map format version 25:
+    * `u8` length of the data of a single timer (always 2+4+4=10)
+    * `u16` `num_of_timers`
+    * foreach `num_of_timers`:
+        * `u16` timer position (`(z*16*16 + y*16 + x)`)
+        * `s32` timeout * 1000
+        * `s32` elapsed * 1000
 
 End of File (EOF).
 

--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -482,6 +482,8 @@ Timestamp and node ID mappings come here if map format version >= 29.
             * `s32` timeout * 1000
             * `s32` elapsed * 1000
 
+* Map format version >= 25: see below
+
 `u8` static object version:
 * Always 0
 
@@ -508,7 +510,7 @@ Before map format version 29:
         * `u16` `name_len`
         * `u8[name_len]` `name`
 
-Since map format version 25:
+Since map format version 25, node timers come here:
     * `u8` length of the data of a single timer (always 2+4+4=10)
     * `u16` `num_of_timers`
     * foreach `num_of_timers`:


### PR DESCRIPTION
Node timers come later in version >= 25.

## To do

This PR is a Ready for Review.

## How to test

Compare with `MapBlock::deSerialize()`.
