### PR TITLE
Updated inverted camera controls

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -160,11 +160,6 @@ safe_dig_and_place (Safe digging and placing) bool false
 
 [*Keyboard and Mouse]
 
-#    Invert vertical mouse movement.
-#
-#    Requires: keyboard_mouse
-invert_mouse (Invert mouse) bool false
-
 #    Mouse sensitivity multiplier.
 #
 #    Requires: keyboard_mouse
@@ -492,6 +487,12 @@ arm_inertia (Arm inertia) bool true
 view_bobbing_amount (View bobbing factor) float 1.0 0.0 7.9
 
 [**Camera]
+
+#    Invert vertical camera movement.
+invert_camera (Invert camera) bool false
+
+#    Inverts the 3rd person front-facing camera.
+invert_third_person_front (Invert 3rd person front) bool true
 
 #    Field of view in degrees.
 fov (Field of view) int 72 45 160

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -263,6 +263,8 @@ void set_default_settings()
 	settings->setDefault("autosave_screensize", "true");
 	settings->setDefault("fullscreen", bool_to_cstr(has_touch));
 	settings->setDefault("vsync", "false");
+	settings->setDefault("invert_camera", "false");
+	settings->setDefault("invert_third_person_front", "true");
 	settings->setDefault("fov", "72");
 	settings->setDefault("leaves_style", "fancy");
 	settings->setDefault("connected_glass", "false");
@@ -355,7 +357,6 @@ void set_default_settings()
 	settings->setDefault("shadow_sky_body_orbit_tilt", "0.0");
 
 	// Input
-	settings->setDefault("invert_mouse", "false");
 	settings->setDefault("enable_hotbar_mouse_wheel", "true");
 	settings->setDefault("invert_hotbar_mouse_wheel", "false");
 	settings->setDefault("mouse_sensitivity", "0.2");


### PR DESCRIPTION
## Goal of the PR

- Adds parity/bug-fixes between mouse, gamepad, and touchscreen inverted-camera controls. And allows for easier camera inversion settings

## What does it do?

- Implements https://github.com/luanti-org/luanti/issues/14838
- Fixes a bug where the 3rd Person Front-Facing Camera is un-inverted when "invert mouse" is enabled
- Since the 3rd Person Front-Facing Camera was originally un-inverted on non-mouse controls, adding a new option allows for parity by default, while allowing for players to keep previous behavior by disabling "Invert 3rd person front"
- Since "invert mouse" no longer only affects the mouse, it is renamed to "Invert camera", and moved under "Camera" settings (iirc it wasn't used for anything else)

## To do

Ready for Review.

## How to test

**Invert Mouse Bug:**
1. Go into the 3rd Person Front-Facing Camera and move the mouse around.
2. Enable "invert mouse" in the settings. Move the mouse around, and it is un-inverted.
3. Use my updated version, repeat, and it is fixed.

**New Inverted Settings:**

1. On mouse, gamepad, and touchscreen, move the camera vertically.
2. Enable "Invert camera" and again move the camera.
3. Disable "Invert 3rd person front" and again move the camera in the 3rd Person Front-Facing Camera.
4. Test the different combination to see it works on all input methods.