### PR TITLE
Android: open input dialog on double tap with physical keyboard.

### DIFF
--- a/src/gui/modalMenu.cpp
+++ b/src/gui/modalMenu.cpp
@@ -246,8 +246,9 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 #ifdef __ANDROID__
 	// display software keyboard when clicking edit boxes
 	if (event.EventType == EET_MOUSE_INPUT_EVENT &&
-			event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN &&
-			!porting::hasPhysicalKeyboardAndroid()) {
+			((event.MouseInput.Event == EMIE_LMOUSE_PRESSED_DOWN &&
+			!porting::hasPhysicalKeyboardAndroid()) ||
+			event.MouseInput.Event == EMIE_LMOUSE_DOUBLE_CLICK)) {
 		gui::IGUIElement *hovered =
 			Environment->getRootGUIElement()->getElementFromPoint(
 				core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
@@ -276,7 +277,9 @@ bool GUIModalMenu::preprocessEvent(const SEvent &event)
 
 			porting::showTextInputDialog("",
 					wide_to_utf8(((gui::IGUIEditBox *) hovered)->getText()), type);
-			return retval;
+			// Since we have opened the dialog, we have to return true to mark
+			// the event as handled (avoids double-opening).
+			return true;
 		}
 	}
 


### PR DESCRIPTION
This change makes it possible to open the input dialog, even when having a physical keyboard connected, by double tapping on an input field.

- How does the PR work?
It adds another condition to check for double taps while a physical keyboard is connected and changes the return value for the event handling to avoid opening the input dialog twice.
- Does it resolve any reported issue?
Nope.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
It's a very niche use case, but some keyboards might not (at all or easily) feature the desired characters.

Thanks, @grorp!

## How to test

Double tap on text fields/edit boxes; the input dialog should show up.

