### PR TITLE
Revert "Detect mouse moving out of inventory slot (#16101)"

### DIFF
--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -203,9 +203,9 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 	if (!hovered || hovered->getID() == -1)
 		hovered = m_fs_menu;
 
-	IsVisible = was_visible;
-
 	bool ret = hovered->OnEvent(event);
+
+	IsVisible = was_visible;
 
 	return ret;
 }

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -205,6 +205,9 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 
 	bool ret = hovered->OnEvent(event);
 
+	// Set visible again *after* processing the event. Otherwise, hovered could
+	// be another GUIInventoryList, which will call this one again, resulting in
+	// an infinite loop.
 	IsVisible = was_visible;
 
 	return ret;


### PR DESCRIPTION
This reverts commit 81d62d01d119a5d519b923b839ea4c08900e1d1f from #16101.

Fixes #16271.
Reopens #16100.

The code was like this on purpose. In #9287 I apparently also tried it without leaving the element invisible, but noticed loops: https://github.com/luanti-org/luanti/pull/9287/commits/823db991d317b97ac91301b1f884c50e55b52a24

Description of the bug:
* You hover over a list element A.
* A makes itself invisible to get the next element at pointer (here list element B).
* A makes itself visible again.
* A does tail-call onEvent on B. (=> no stack overflow)
* B does the same.

A proper fix for #16100 can come afterwards. Let's just revert first, to spare everyone from headaches and stress.

(Sorry for not intervening in #16101 already. But I didn't really understand the bug it was trying to fix or how, so I didn't want to look at it, nor properly noticed that I'm kind of responsible for the ugly code it was touching. Also sorry for my bad code.)

## To do

This PR is a Ready for Review.

## How to test

* In devtest, use the node meta editor to set the `formspec` meta field of a node to:
```
formspec_version[6]
size[15,15]
list[current_player;main;0,5;8,4;]
list[current_player;main;0,5;8,4;]
```
* Rightclick the node.
* Hover your mouse over the overlapping lists.
* In master: Freezes.