### PR TITLE
[DRAFT] Read block data for mesh making in main client thread

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -47,7 +47,7 @@ void MeshMakeData::fillBlockDataBegin(const v3s16 &blockpos)
 	m_vmanip.clear();
 	// extra 1 block thick layer around the mesh
 	VoxelArea voxel_area(blockpos_nodes - v3s16(1,1,1) * MAP_BLOCKSIZE,
-			blockpos_nodes + v3s16(1,1,1) * (m_side_length + MAP_BLOCKSIZE) - v3s16(1,1,1));
+			blockpos_nodes + v3s16(1,1,1) * (m_side_length + MAP_BLOCKSIZE - 1));
 	m_vmanip.addArea(voxel_area);
 }
 

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -72,8 +72,6 @@ private:
 	// TODO: Add callback to update these when g_settings changes, and update all meshes
 	bool m_cache_smooth_lighting;
 	bool m_cache_enable_water_reflections;
-
-	void fillDataFromMapBlocks(QueuedMeshUpdate *q);
 };
 
 struct MeshUpdateResult


### PR DESCRIPTION
See discussion started here: https://github.com/luanti-org/luanti/pull/16152#issuecomment-2993752108

This copies block data for mesh making in the client thread instead of the mesh-making thread. Meshes are still created in the mesh-making thread(s).

This also observes that retrieving unset data in a `VoxelManipulator` already returns `CONTENT_IGNORE` as long as the inner area is sized correctly - which is the case here. So we do not need to copy `CONTENT_IGNORE` into an already existing area. That shaves 50-70%(!) of the copying work, especially with higher `client_mesh_chunk`'s.

Even with the improvement, this *is* slightly slower. (As an aside I found generally a single mesh-generation thread gives the best results, it terms of speed *and* reduced jitter).

## To do

This PR is a Work in Progress.

- [ ] Correctness Testing
- [ ] Perf Testing
- [ ] Are there other approaches?

## How to test

- Load any world. Preferably with a large viewing_range, client_mesh_chunk >= 4 and many mesh generation threads (at least the default of 4).
- Do some before and after perf, load time of the map, client jitter, etc.
- Maybe also test with one mesh-update thread, and also with 8.
