### PR TITLE
GUIInventoryList: Override `isPointInside()`

### DIFF
--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -185,32 +185,13 @@ bool GUIInventoryList::OnEvent(const SEvent &event)
 
 	m_hovered_i = getItemIndexAtPos(v2s32(event.MouseInput.X, event.MouseInput.Y));
 
-	if (m_hovered_i != -1)
-		return IGUIElement::OnEvent(event);
+	return IGUIElement::OnEvent(event);
+}
 
-	// no item slot at pos of mouse event => allow clicking through
-	// find the element that would be hovered if this inventorylist was invisible
-	bool was_visible = IsVisible;
-	IsVisible = false;
-	IGUIElement *hovered =
-		Environment->getRootGUIElement()->getElementFromPoint(
-			core::position2d<s32>(event.MouseInput.X, event.MouseInput.Y));
 
-	// if the player clicks outside of the formspec window, hovered is not
-	// m_fs_menu, but some other weird element (with ID -1). we do however need
-	// hovered to be m_fs_menu as item dropping when clicking outside of the
-	// formspec window is handled in its OnEvent callback
-	if (!hovered || hovered->getID() == -1)
-		hovered = m_fs_menu;
-
-	bool ret = hovered->OnEvent(event);
-
-	// Set visible again *after* processing the event. Otherwise, hovered could
-	// be another GUIInventoryList, which will call this one again, resulting in
-	// an infinite loop.
-	IsVisible = was_visible;
-
-	return ret;
+bool GUIInventoryList::isPointInside(const core::position2d<s32> &point) const
+{
+	return getItemIndexAtPos(point) != -1;
 }
 
 s32 GUIInventoryList::getItemIndexAtPos(v2s32 p) const

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -70,9 +70,11 @@ public:
 		const Options &options,
 		gui::IGUIFont *font);
 
-	virtual void draw() override;
+	void draw() override;
 
-	virtual bool OnEvent(const SEvent &event) override;
+	bool OnEvent(const SEvent &event) override;
+
+	bool isPointInside(const core::position2d<s32> &point) const override;
 
 	const InventoryLocation &getInventoryloc() const
 	{


### PR DESCRIPTION
* Goal: Simplify `GUIInventoryList::OnEvent`, and remove its hacks.
* Fixes #16100.
* How it works: `isPointInside()` is meant to specify the shape of the element. `IGUIElement::getElementFromPoint()` uses it. The guiinvlist now has a shape that consists only of its item slots, not the whole absoluteclippingrect.

## To do

This PR is ready for review.

~~TODO: Test more.~~

## How to test

* Do the repro steps from #16100. (~~TODO~~) Edit: j-r (author) tested.
* Drop items by clicking outside.
* Put a button behind. It should still be hovered, and clickable.
* Check what happens if the inventorylist is resized. (~~TODO~~) Edit: [Tested.](https://codeberg.org/Desour/test_tmp/src/branch/inv_resize_after_open) Everything is fine.
* Play around with overlapping guiinvlists.
  [hmmm](https://github.com/user-attachments/assets/d4a27965-a848-464f-9bfb-4c75a4ada1b8) (Seems fine.)
* More that I didn't think of.