### PR TITLE
Fix: add 'luanti' to Linux .desktop file to fix WM confusion

### DIFF
--- a/misc/org.luanti.luanti.desktop
+++ b/misc/org.luanti.luanti.desktop
@@ -11,5 +11,5 @@ Terminal=false
 Type=Application
 Categories=Game;Simulation;
 StartupNotify=false
-StartupWMClass=Luanti
+StartupWMClass=Luanti;luanti
 Keywords=sandbox;world;mining;crafting;blocks;nodes;multiplayer;roleplaying;minetest;


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- This PR is intended to fix a bug causing Luanti's desktop file to improperly assign the StartupWMClass, causing the DE to get confused and give it a generic icon

## To do

Ready for Review.

- [x ] Add 'luanti' to StartupWMClass

## How to test

1. Compile and install Luanti on a Linux distribution (this was tested on Fedora 42)
2. Notice that the desktop environment (tested on GNOME + Wayland) assigns the correct icon & grouping for application

This was tested on the following system:

OS: Fedora 42 Workstation, GNOME, Wayland
GPU: NVIDIA GTX 1650 Super
- Luanti was using the Wayland SDL driver