### PR TITLE
Use MapBlock::copyTo to fill MeshMakeData

### DIFF
--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -51,15 +51,6 @@ void MeshMakeData::fillBlockDataBegin(const v3s16 &blockpos)
 	m_vmanip.addArea(voxel_area);
 }
 
-void MeshMakeData::fillBlockData(const v3s16 &bp, MapNode *data)
-{
-	v3s16 data_size(MAP_BLOCKSIZE, MAP_BLOCKSIZE, MAP_BLOCKSIZE);
-	VoxelArea data_area(v3s16(0,0,0), data_size - v3s16(1,1,1));
-
-	v3s16 blockpos_nodes = bp * MAP_BLOCKSIZE;
-	m_vmanip.copyFrom(data, data_area, v3s16(0,0,0), blockpos_nodes, data_size);
-}
-
 void MeshMakeData::fillSingleNode(MapNode data, MapNode padding)
 {
 	m_blockpos = {0, 0, 0};

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -60,7 +60,6 @@ struct MeshMakeData
 		Copy block data manually (to allow optimizations by the caller)
 	*/
 	void fillBlockDataBegin(const v3s16 &blockpos);
-	void fillBlockData(const v3s16 &bp, MapNode *data);
 
 	/*
 		Prepare block data for rendering a single node located at (0,0,0).

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -193,7 +193,7 @@ void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 	for (pos.Y = q->p.Y - 1; pos.Y <= q->p.Y + mesh_grid.cell_size; pos.Y++) {
 		MapBlock *block = q->map_blocks[i++];
 		if (block)
-			data->fillBlockData(pos, block->getData());
+			block->copyTo(data->m_vmanip);
 	}
 
 	data->setCrack(q->crack_level, q->crack_pos);


### PR DESCRIPTION
After #16286, we can just `MapBlock::copyTo" to copy a block's data into the MeshMakeData.
This gets rid of one unnecessary use of `MapBlock::getData`.

I have closed #16152 for now, but it is conceivable that we add locking `MapBlock::copyFrom` to fix the problems there.

## To do

This PR is Ready for Review.

## How to test

Load any world. Everything should (and will :) ) just continue to work.