### PR TITLE
Add core.get_mapgen_chunksize()

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6666,6 +6666,8 @@ Environment access
       of the *active* mapgen setting `"mapgen_limit"`.
     * `chunksize` is an optional number. If it is absent, its value is that
       of the *active* mapgen setting `"chunksize"`.
+* `core.get_mapgen_chunksize()`
+    * Returns the currently active chunksize of the mapgen, as a vector.
 * `core.get_mapgen_setting(name)`
     * Gets the *active* mapgen setting (or nil if none exists) in string
       format with the following order of precedence:

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6668,6 +6668,7 @@ Environment access
       of the *active* mapgen setting `"chunksize"`.
 * `core.get_mapgen_chunksize()`
     * Returns the currently active chunksize of the mapgen, as a vector.
+      The size is specified in blocks.
 * `core.get_mapgen_setting(name)`
     * Gets the *active* mapgen setting (or nil if none exists) in string
       format with the following order of precedence:

--- a/games/devtest/mods/unittests/inside_mapgen_env.lua
+++ b/games/devtest/mods/unittests/inside_mapgen_env.lua
@@ -29,6 +29,6 @@ if core.ipc_cas("unittests:mg_once", nil, true) then
 end
 
 core.register_on_generated(function(vm, pos1, pos2, blockseed)
-	local n = tonumber(core.get_mapgen_setting("chunksize")) * 16 - 1
-	assert(pos2:subtract(pos1) == vector.new(n, n, n))
+	local cs = core.get_mapgen_chunksize()
+	assert(pos2:subtract(pos1) == cs:multiply(core.MAP_BLOCKSIZE):subtract(1))
 end)

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -865,13 +865,32 @@ int ModApiMapgen::l_get_mapgen_edges(lua_State *L)
 	} else {
 		std::string chunksize_str;
 		settingsmgr->getMapSetting("chunksize", &chunksize_str);
-		chunksize = stoi(chunksize_str, -32768, 32767);
+		chunksize = stoi(chunksize_str, 1, 10);
 	}
 
 	std::pair<s16, s16> edges = get_mapgen_edges(mapgen_limit, chunksize);
 	push_v3s16(L, v3s16(1, 1, 1) * edges.first);
 	push_v3s16(L, v3s16(1, 1, 1) * edges.second);
 	return 2;
+}
+
+// get_mapgen_chunksize()
+int ModApiMapgen::l_get_mapgen_chunksize(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+
+	const MapSettingsManager *settingsmgr = getEmergeManager(L)->map_settings_mgr;
+
+	// MapSettingsManager::makeMapgenParams cannot be used here because it would
+	// make mapgen settings immutable from then on. Mapgen settings should stay
+	// mutable until after mod loading ends.
+
+	std::string chunksize_str;
+	settingsmgr->getMapSetting("chunksize", &chunksize_str);
+	s16 chunksize = stoi(chunksize_str, 1, 10);
+
+	push_v3s16(L, {chunksize, chunksize, chunksize});
+	return 1;
 }
 
 // get_mapgen_setting(name)
@@ -2025,6 +2044,7 @@ void ModApiMapgen::Initialize(lua_State *L, int top)
 	API_FCT(get_mapgen_params);
 	API_FCT(set_mapgen_params);
 	API_FCT(get_mapgen_edges);
+	API_FCT(get_mapgen_chunksize);
 	API_FCT(get_mapgen_setting);
 	API_FCT(set_mapgen_setting);
 	API_FCT(get_mapgen_setting_noiseparams);
@@ -2067,6 +2087,7 @@ void ModApiMapgen::InitializeEmerge(lua_State *L, int top)
 	API_FCT(get_seed);
 	API_FCT(get_mapgen_params);
 	API_FCT(get_mapgen_edges);
+	API_FCT(get_mapgen_chunksize);
 	API_FCT(get_mapgen_setting);
 	API_FCT(get_mapgen_setting_noiseparams);
 	API_FCT(get_noiseparams);

--- a/src/script/lua_api/l_mapgen.h
+++ b/src/script/lua_api/l_mapgen.h
@@ -56,6 +56,9 @@ private:
 	// get_mapgen_edges([mapgen_limit[, chunksize]])
 	static int l_get_mapgen_edges(lua_State *L);
 
+	// get_mapgen_chunksize()
+	static int l_get_mapgen_chunksize(lua_State *L);
+
 	// get_seed([add])
 	static int l_get_seed(lua_State *L);
 


### PR DESCRIPTION
Mods often manually parse the `chunksize` setting. If we want to ever change how this works (soon :wink:) breakage will instantly occur.
With this API function it's both easier and future-compatible for mods.

## To do

This PR is Ready for Review.

## How to test

`//lua =core.get_mapgen_chunksize()`
