### PR TITLE
MapBlock::getData be gone

### DIFF
--- a/src/dummymap.h
+++ b/src/dummymap.h
@@ -31,9 +31,11 @@ public:
 		for (s16 y = bpmin.Y; y <= bpmax.Y; y++) {
 			MapBlock *block = getBlockNoCreateNoEx({x, y, z});
 			if (block) {
-				auto *data = block->getData();
-				for (size_t i = 0; i < MapBlock::nodecount; i++)
-					data[i] = n;
+				for (s16 xn=0; xn < MAP_BLOCKSIZE; xn++)
+				for (s16 yn=0; yn < MAP_BLOCKSIZE; yn++)
+				for (s16 zn=0; zn < MAP_BLOCKSIZE; zn++) {
+					block->setNodeNoCheck(xn, yn, zn, n);
+				}
 				block->expireIsAirCache();
 			}
 		}

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -80,11 +80,6 @@ public:
 		raiseModified(MOD_STATE_WRITE_NEEDED, MOD_REASON_REALLOCATE);
 	}
 
-	MapNode* getData()
-	{
-		return data;
-	}
-
 	////
 	//// Modification tracking methods
 	////

--- a/src/unittest/test_mapblock.cpp
+++ b/src/unittest/test_mapblock.cpp
@@ -68,10 +68,12 @@ void TestMapBlock::testSaveLoad(IGameDef *gamedef, const u8 version)
 		MapBlock block({}, gamedef);
 		// Fill with data
 		PcgRandom r(seed);
-		for (size_t i = 0; i < MapBlock::nodecount; ++i) {
+		for (s16 x=0; x < MAP_BLOCKSIZE; x++)
+		for (s16 y=0; y < MAP_BLOCKSIZE; y++)
+		for (s16 z=0; z < MAP_BLOCKSIZE; z++) {
 			u32 rval = r.next();
-			block.getData()[i] =
-				MapNode(rval % max, (rval >> 16) & 0xff, (rval >> 24) & 0xff);
+			block.setNodeNoCheck(x, y, z,
+					MapNode(rval % max, (rval >> 16) & 0xff, (rval >> 24) & 0xff));
 		}
 
 		// Serialize
@@ -85,11 +87,13 @@ void TestMapBlock::testSaveLoad(IGameDef *gamedef, const u8 version)
 
 		// Check data
 		PcgRandom r(seed);
-		for (size_t i = 0; i < MapBlock::nodecount; ++i) {
+		for (s16 x=0; x < MAP_BLOCKSIZE; x++)
+		for (s16 y=0; y < MAP_BLOCKSIZE; y++)
+		for (s16 z=0; z < MAP_BLOCKSIZE; z++) {
 			u32 rval = r.next();
 			auto expect =
 				MapNode(rval % max, (rval >> 16) & 0xff, (rval >> 24) & 0xff);
-			UASSERT(block.getData()[i] == expect);
+			UASSERT(block.getNodeNoCheck(x, y, z) == expect);
 		}
 	}
 }
@@ -104,8 +108,11 @@ void TestMapBlock::testSave29(IGameDef *gamedef)
 	{
 		// Prepare test block
 		MapBlock block({}, gamedef);
-		for (size_t i = 0; i < MapBlock::nodecount; ++i)
-			block.getData()[i] = MapNode(CONTENT_AIR);
+		for (s16 x=0; x < MAP_BLOCKSIZE; x++)
+		for (s16 y=0; y < MAP_BLOCKSIZE; y++)
+		for (s16 z=0; z < MAP_BLOCKSIZE; z++) {
+			block.setNodeNoCheck(x, y, z, MapNode(CONTENT_AIR));
+		}
 		block.setNode({0, 0, 0}, MapNode(t_CONTENT_STONE));
 
 		block.serialize(ss, 29, true, -1);
@@ -294,8 +301,11 @@ void TestMapBlock::testLoad20(IGameDef *gamedef)
 	UASSERTEQ(auto, get_node(10, 6, 4), "air");
 	UASSERTEQ(auto, get_node(11, 6, 3), "default:furnace");
 
-	for (size_t i = 0; i < MapBlock::nodecount; ++i)
-		UASSERT(block.getData()[i].getContent() != CONTENT_IGNORE);
+	for (s16 x=0; x < MAP_BLOCKSIZE; x++)
+	for (s16 y=0; y < MAP_BLOCKSIZE; y++)
+	for (s16 z=0; z < MAP_BLOCKSIZE; z++) {
+		UASSERT(block.getNodeNoCheck(x, y, z).getContent() != CONTENT_IGNORE);
+	}
 
 	// metadata is also translated
 	auto *meta = block.m_node_metadata.get({11, 6, 3});


### PR DESCRIPTION
This just gets rid of `MapBlock::getData`. That API leaked internals of a MapBlock.

## To do

This PR is Ready for Review.

## How to test

This was only used in tests now, so run all unittests, should still work.
