### PR TITLE
Add a `core.get_global_time()` function

### DIFF
--- a/builtin/common/after.lua
+++ b/builtin/common/after.lua
@@ -114,6 +114,10 @@ end
 local time = 0.0
 local time_next = math.huge
 
+function core.get_global_time()
+	return time
+end
+
 core.register_globalstep(function(dtime)
 	time = time + dtime
 

--- a/builtin/common/tests/after_spec.lua
+++ b/builtin/common/tests/after_spec.lua
@@ -111,4 +111,31 @@ describe("after", function()
 		do_step(math.max(unpack(t)))
 		assert.equal(#t, i)
 	end)
+
+	it("is in time interval, according to core.get_global_time()", function()
+		do_step(0.1 + math.random() * 0.001)
+
+		local num_executed = 0
+		local t0 = core.get_global_time()
+
+		for i = 0, 2.00001, 0.05 do
+			core.after(i, function()
+				local actual_time = core.get_global_time() - t0
+				assert(actual_time >= i)
+				if i >= 0.1 then
+					assert(actual_time < i + 0.1)
+				end
+				num_executed = num_executed + 1
+			end)
+		end
+
+		for i = 1, 25 do
+			do_step(0.1 + math.random() * 0.001)
+		end
+
+		assert(core.get_global_time() - t0 >= 25 * 0.1)
+		assert(core.get_global_time() - t0 < 26 * 0.1)
+
+		assert.equal(num_executed, 41)
+	end)
 end)

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6114,8 +6114,11 @@ Global callback registration functions
 Call these functions only at load time!
 
 * `core.register_globalstep(function(dtime))`
-    * Called every server step, usually interval of 0.1s.
+    * Called every server step, usually interval of around 0.1s, but can be much
+      higher or lower.
     * `dtime` is the time since last execution in seconds.
+    * More precisely, it's the time between the start of the current and the last
+      server step, excluding the time when the game was paused (in singleplayer).
 * `core.register_on_mods_loaded(function())`
     * Called after mods have finished loading and before the media is cached or the
       aliases handled.
@@ -7138,13 +7141,15 @@ Timing
     * Optional: Variable number of arguments that are passed to `func`
     * Jobs set for earlier times are executed earlier. If multiple jobs expire
       at exactly the same time, then they are executed in registration order.
-    * `time` is a lower bound. The job is executed in the first server-step that
-      started at least `time` seconds after the last time a server-step started,
-      measured with globalstep dtime.
-    * If `time` is `0`, the job is executed in the next step.
-
+    * `time` is a lower bound. The job is executed in the globalstep of the
+      first server-step that started at least `time` seconds after the last time
+      a server-step started, measured with globalstep dtime (see
+      `core.get_global_time`).
+    * If `time` is `0`, the job is executed in the next globalstep.
 * `job:cancel()`
     * Cancels the job function from being called
+* `core.get_global_time()`: returns sum of globalstep dtimes.
+    * See `core.register_globalstep`.
 
 Async environment
 -----------------


### PR DESCRIPTION
Fixes #15047.

(I have the feeling I forgot something. Idk what.)

## To do

This PR is a Ready for Review.

## How to test

* `$ busted builtin`
* `/lua local t0 = core.get_global_time() core.after(1, function() core.log(core.get_global_time() - t0) end)`