### PR TITLE
Use unique_ptr for trivial ownership

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -212,6 +212,9 @@ void Client::loadMods()
 	// complain about mods with unsatisfied dependencies
 	if (!modconf.isConsistent()) {
 		errorstream << modconf.getUnsatisfiedModsError() << std::endl;
+		delete m_script;
+		m_script = nullptr;
+		m_env.setScript(nullptr);
 		return;
 	}
 
@@ -351,6 +354,9 @@ Client::~Client()
 	m_item_visuals_manager->clear();
 
 	guiScalingCacheClear();
+
+	m_minimap.reset();
+	m_media_downloader.reset();
 
 	// Write the changes and delete
 	if (m_mod_storage_database)

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -183,8 +183,8 @@ void Client::loadMods()
 		return;
 	}
 
-	m_script = std::make_unique<ClientScripting>(this);
-	m_env.setScript(m_script.get());
+	m_script = new ClientScripting(this);
+	m_env.setScript(m_script);
 	m_script->setEnv(&m_env);
 
 	// Load builtin
@@ -312,7 +312,8 @@ void Client::Stop()
 		m_localdb.reset();
 	}
 
-	m_script.reset();
+	if (m_mods_loaded)
+		delete m_script;
 }
 
 bool Client::isShutdown()

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -407,7 +407,7 @@ public:
 		m_chat_queue.push(cec);
 	}
 
-	ClientScripting *getScript() { return m_script.get(); }
+	ClientScripting *getScript() { return m_script; }
 	bool modsLoaded() const { return m_mods_loaded; }
 
 	void pushToEventQueue(ClientEvent *event);
@@ -579,7 +579,7 @@ private:
 	u16 m_cache_save_interval;
 
 	// Client modding
-	std::unique_ptr<ClientScripting> m_script = nullptr;
+	ClientScripting *m_script = nullptr;
 	ModStorageDatabase *m_mod_storage_database = nullptr;
 	float m_mod_storage_save_timer = 10.0f;
 	std::vector<ModSpec> m_mods;

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -363,7 +363,7 @@ public:
 		return getProtoVersion() != 0; // (set in TOCLIENT_HELLO)
 	}
 
-	Minimap* getMinimap() { return m_minimap; }
+	Minimap* getMinimap() { return m_minimap.get(); }
 	void setCamera(Camera* camera) { m_camera = camera; }
 
 	Camera* getCamera () { return m_camera; }
@@ -407,7 +407,7 @@ public:
 		m_chat_queue.push(cec);
 	}
 
-	ClientScripting *getScript() { return m_script; }
+	ClientScripting *getScript() { return m_script.get(); }
 	bool modsLoaded() const { return m_mods_loaded; }
 
 	void pushToEventQueue(ClientEvent *event);
@@ -494,7 +494,7 @@ private:
 	std::string m_address_name;
 	ELoginRegister m_allow_login_or_register = ELoginRegister::Any;
 	Camera *m_camera = nullptr;
-	Minimap *m_minimap = nullptr;
+	std::unique_ptr<Minimap> m_minimap;
 
 	// Server serialization version
 	u8 m_server_ser_ver;
@@ -504,7 +504,7 @@ private:
 	u16 m_proto_ver = 0;
 
 	bool m_update_wielded_item = false;
-	Inventory *m_inventory_from_server = nullptr;
+	std::unique_ptr<Inventory> m_inventory_from_server;
 	float m_inventory_from_server_age = 0.0f;
 	s32 m_mapblock_limit_logged = 0;
 	PacketCounter m_packetcounter;
@@ -543,7 +543,7 @@ private:
 
 	std::vector<std::string> m_remote_media_servers;
 	// Media downloader, only exists during init
-	ClientMediaDownloader *m_media_downloader;
+	std::unique_ptr<ClientMediaDownloader> m_media_downloader;
 	// Pending downloads of dynamic media (key: token)
 	std::vector<std::pair<u32, std::shared_ptr<SingleMediaDownloader>>> m_pending_media_downloads;
 
@@ -574,12 +574,12 @@ private:
 	LocalClientState m_state;
 
 	// Used for saving server map to disk client-side
-	MapDatabase *m_localdb = nullptr;
+	std::unique_ptr<MapDatabase> m_localdb;
 	IntervalLimiter m_localdb_save_interval;
 	u16 m_cache_save_interval;
 
 	// Client modding
-	ClientScripting *m_script = nullptr;
+	std::unique_ptr<ClientScripting> m_script = nullptr;
 	ModStorageDatabase *m_mod_storage_database = nullptr;
 	float m_mod_storage_save_timer = 10.0f;
 	std::vector<ModSpec> m_mods;

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -120,7 +120,6 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 {
 	removeAll();
 
-	delete m_selected_item;
 	delete m_form_src;
 	delete m_text_dst;
 }
@@ -3757,7 +3756,7 @@ void GUIFormSpecMenu::updateSelectedItem()
 
 			} else {
 				// Grab selected item from the crafting result list
-				m_selected_item = new GUIInventoryList::ItemSpec(s);
+				m_selected_item = std::make_unique<GUIInventoryList::ItemSpec>(s);
 				m_selected_amount = item.count;
 				m_selected_dragging = false;
 			}
@@ -3799,8 +3798,7 @@ ItemStack GUIFormSpecMenu::verifySelectedItem()
 		}
 
 		// selection was not valid
-		delete m_selected_item;
-		m_selected_item = nullptr;
+		m_selected_item.reset();
 		m_selected_amount = 0;
 		m_selected_dragging = false;
 	}
@@ -4333,7 +4331,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 					shift_move_amount = button == BET_RIGHT ? 1 : count;
 				} else {
 					// No shift: select item
-					m_selected_item = new GUIInventoryList::ItemSpec(s);
+					m_selected_item = std::make_unique<GUIInventoryList::ItemSpec>(s);
 					m_selected_amount = count;
 					m_selected_dragging = button != BET_WHEEL_DOWN;
 				}
@@ -4528,7 +4526,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 
 			} else if (m_held_mouse_button == BET_LEFT) {
 				// Start picking up items
-				m_selected_item = new GUIInventoryList::ItemSpec(s);
+				m_selected_item = std::make_unique<GUIInventoryList::ItemSpec>(s);
 				m_selected_amount = s_count;
 				m_selected_dragging = true;
 			}
@@ -4835,8 +4833,7 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		// and we are not left-dragging, deselect
 		if (m_selected_amount == 0 && !m_left_dragging) {
 			m_selected_swap.clear();
-			delete m_selected_item;
-			m_selected_item = nullptr;
+			m_selected_item.reset();
 			m_selected_amount = 0;
 			m_selected_dragging = false;
 		}

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -236,7 +236,7 @@ public:
 
 	const GUIInventoryList::ItemSpec *getSelectedItem() const
 	{
-		return m_selected_item;
+		return m_selected_item.get();
 	}
 
 	u16 getSelectedAmount() const
@@ -346,7 +346,7 @@ protected:
 	std::vector<gui::IGUIElement *> m_clickthrough_elements;
 	std::vector<std::pair<std::string, GUIScrollContainer *>> m_scroll_containers;
 
-	GUIInventoryList::ItemSpec *m_selected_item = nullptr;
+	std::unique_ptr<GUIInventoryList::ItemSpec> m_selected_item;
 	u16 m_selected_amount = 0;
 	bool m_selected_dragging = false;
 	ItemStack m_selected_swap;

--- a/src/map_settings_manager.cpp
+++ b/src/map_settings_manager.cpp
@@ -21,15 +21,13 @@ MapSettingsManager::MapSettingsManager(const std::string &map_meta_path):
 	 * 1: defaults set by scripts (override_meta = false)
 	 * 2: settings present in map_meta.txt or overridden by scripts
 	 */
-	m_defaults = new Settings("", &m_hierarchy, 1);
-	m_map_settings = new Settings("[end_of_params]", &m_hierarchy, 2);
+	m_defaults = std::make_unique<Settings>("", &m_hierarchy, 1);
+	m_map_settings = std::make_unique<Settings>("[end_of_params]", &m_hierarchy, 2);
 }
 
 
 MapSettingsManager::~MapSettingsManager()
 {
-	delete m_defaults;
-	delete m_map_settings;
 	delete mapgen_params;
 }
 
@@ -109,8 +107,8 @@ bool MapSettingsManager::saveMapMeta()
 		return false;
 	}
 
-	mapgen_params->MapgenParams::writeParams(m_map_settings);
-	mapgen_params->writeParams(m_map_settings);
+	mapgen_params->MapgenParams::writeParams(m_map_settings.get());
+	mapgen_params->writeParams(m_map_settings.get());
 
 	if (!m_map_settings->updateConfigFile(m_map_meta_path.c_str())) {
 		errorstream << "saveMapMeta: could not write "
@@ -150,8 +148,8 @@ MapgenParams *MapSettingsManager::makeMapgenParams()
 	params->mgtype = mgtype;
 
 	// Load the rest of the mapgen params from our active settings
-	params->MapgenParams::readParams(m_map_settings);
-	params->readParams(m_map_settings);
+	params->MapgenParams::readParams(m_map_settings.get());
+	params->readParams(m_map_settings.get());
 
 	// Hold onto our params
 	mapgen_params = params;

--- a/src/map_settings_manager.h
+++ b/src/map_settings_manager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include "settings.h"
 

--- a/src/map_settings_manager.h
+++ b/src/map_settings_manager.h
@@ -57,6 +57,6 @@ private:
 	std::string m_map_meta_path;
 
 	SettingsHierarchy m_hierarchy;
-	Settings *m_defaults;
-	Settings *m_map_settings;
+	std::unique_ptr<Settings> m_defaults;
+	std::unique_ptr<Settings> m_map_settings;
 };

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -311,7 +311,7 @@ void Client::handleCommand_BlockData(NetworkPacket* pkt)
 	}
 
 	if (m_localdb) {
-		ServerMap::saveBlock(block, m_localdb);
+		ServerMap::saveBlock(block, m_localdb.get());
 	}
 
 	/*
@@ -335,8 +335,7 @@ void Client::handleCommand_Inventory(NetworkPacket* pkt)
 
 	m_update_wielded_item = true;
 
-	delete m_inventory_from_server;
-	m_inventory_from_server = new Inventory(player->inventory);
+	m_inventory_from_server = std::make_unique<Inventory>(player->inventory);
 	m_inventory_from_server_age = 0.0;
 }
 

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -336,7 +336,7 @@ void Client::handleCommand_Inventory(NetworkPacket* pkt)
 	m_update_wielded_item = true;
 
 	m_inventory_from_server = std::make_unique<Inventory>(player->inventory);
-	m_inventory_from_server_age = 0.0;
+	m_inventory_from_server_age = 0.0f;
 }
 
 void Client::handleCommand_TimeOfDay(NetworkPacket* pkt)

--- a/src/nodemetadata.cpp
+++ b/src/nodemetadata.cpp
@@ -18,13 +18,10 @@
 */
 
 NodeMetadata::NodeMetadata(IItemDefManager *item_def_mgr):
-	m_inventory(new Inventory(item_def_mgr))
+	m_inventory(std::make_unique<Inventory>(item_def_mgr))
 {}
 
-NodeMetadata::~NodeMetadata()
-{
-	delete m_inventory;
-}
+NodeMetadata::~NodeMetadata() = default;
 
 void NodeMetadata::serialize(std::ostream &os, u8 version, bool disk) const
 {

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -6,6 +6,7 @@
 
 #include <unordered_set>
 #include <map>
+#include <memory>
 #include "metadata.h"
 
 /*

--- a/src/nodemetadata.h
+++ b/src/nodemetadata.h
@@ -35,7 +35,7 @@ public:
 	// The inventory
 	Inventory *getInventory()
 	{
-		return m_inventory;
+		return m_inventory.get();
 	}
 
 	inline bool isPrivate(const std::string &name) const
@@ -50,7 +50,7 @@ public:
 private:
 	int countNonPrivate() const;
 
-	Inventory *m_inventory;
+	std::unique_ptr<Inventory> m_inventory;
 	std::unordered_set<std::string> m_privatevars;
 };
 

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -169,8 +169,6 @@ public:
 	Pathfinder() = delete;
 	Pathfinder(Map *map, const NodeDefManager *ndef) : m_map(map), m_ndef(ndef) {}
 
-	~Pathfinder();
-
 	/**
 	 * path evaluation function
 	 * @param env environment to look for path
@@ -307,7 +305,7 @@ private:
 	/** contains all map data already collected and analyzed.
 		Access it via the getIndexElement/getIdxElem methods. */
 	friend class GridNodeContainer;
-	GridNodeContainer *m_nodes_container = nullptr;
+	std::unique_ptr<GridNodeContainer> m_nodes_container;
 
 	Map *m_map = nullptr;
 
@@ -639,11 +637,10 @@ std::vector<v3s16> Pathfinder::getPath(v3s16 source,
 	m_max_index_y = diff.Y;
 	m_max_index_z = diff.Z;
 
-	delete m_nodes_container;
 	if (diff.getLength() > 5) {
-		m_nodes_container = new MapGridNodeContainer(this);
+		m_nodes_container = std::make_unique<MapGridNodeContainer>(this);
 	} else {
-		m_nodes_container = new ArrayGridNodeContainer(this, diff);
+		m_nodes_container = std::make_unique<ArrayGridNodeContainer>(this, diff);
 	}
 #ifdef PATHFINDER_DEBUG
 	printType();
@@ -799,10 +796,6 @@ std::vector<v3s16> Pathfinder::getPath(v3s16 source,
 	return retval;
 }
 
-Pathfinder::~Pathfinder()
-{
-	delete m_nodes_container;
-}
 /******************************************************************************/
 v3s16 Pathfinder::getRealPos(v3s16 ipos)
 {


### PR DESCRIPTION
**Goal of the PR**

Better code quality and memory management.

**How does the PR work?**

Some raw pointers that were trivially owned by a unique object could be replaced by unique_ptr.

This is both for maintenability (ownership intent is clearer with unique_ptr, and prevent future introduction of bugs or memory leaks), and fix potential memory leaks.

This on PR only changes some trivial ownership where the same class created and deleted the pointee. If this is accepted, there is also work to do in this direction for pointees created by one class and deleted by another one too.

## To note

* The usage of `Client::m_localdb` is very suspicious. It seems it was leaking to start. And message in infostream seemed misleading.
* There is a potential memory leak with `Client::m_script`, in case `modconf.isConsistent()` is _false_ line  213 `m_mods_loaded` stays _false_ and `m_script` is never deleted.

**Does it resolve any reported issue?**

Uhm, maintainabilty?

**Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?**

2.2 Refactoring

**If not a bug fix, why is this PR needed? What usecases does it solve?**

improves the code

**How to test**

No behavior change is expected...



