### PR TITLE
Fix Camera's far clipping plane for for large zooms

### DIFF
--- a/src/client/camera.cpp
+++ b/src/client/camera.cpp
@@ -573,12 +573,12 @@ void Camera::updateViewingRange()
 
 	m_cameranode->setNearValue(0.1f * BS);
 
-	m_draw_control.wanted_range = std::fmin(adjustDist(viewing_range, getFovMax()), 4000);
+	m_draw_control.wanted_range = std::fmin(adjustDist(viewing_range, getFovMax()), 6000);
 	if (m_draw_control.range_all) {
 		m_cameranode->setFarValue(100000.0);
 		return;
 	}
-	m_cameranode->setFarValue((viewing_range < 2000) ? 2000 * BS : viewing_range * BS);
+	m_cameranode->setFarValue((m_draw_control.wanted_range < 2000) ? 2000 * BS : m_draw_control.wanted_range * BS);
 }
 
 void Camera::setDigging(s32 button)


### PR DESCRIPTION
With a large `viewing_range` and zoom, the effective range can be very large. (With `viewing_range`=2000, and default zoom with have an effective range of about 5200).

The camera incorrectly set the far plane to the `viewing_range`, not the effective range. In addition the effective range was limited to 4000.

This fixes both. The new range limit is 6000 - still conservative, maybe 10000 is better, but I did not want to go overboard.
For "normal" players nothing has changed.

- Goal of the PR
See description.

- How does the PR work?
Use the effective range to set the clipping plane

- Does it resolve any reported issue?
Probably not, not many folks have such large `viewing_range`s.

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?

## To do

This PR is Ready for Review.

## How to test

Somewhat hard to reproduce. Set `viewing_range` to 2000 (adjust all other settings), and look somewhere where you will be able to see something that 3000 or 4000 nodes away. Then move the mouse and notice that nodes will seem to come in and out of existence, but they will show when you enable unlimited viewing range ('R').

With this PR this will not happen. I tested this, I checked for overflows, etc, all good, and all works.
