### PR TITLE
allow main keymap for close world to be configured

### DIFF
--- a/builtin/common/settings/components.lua
+++ b/builtin/common/settings/components.lua
@@ -433,6 +433,7 @@ end
 function make.key(setting)
 	local btn_bind = "bind_" .. setting.name
 	local btn_clear = "unbind_" .. setting.name
+
 	local function add_conflict_warnings(fs, height)
 		local value = core.settings:get(setting.name)
 		if value == "" then
@@ -449,8 +450,8 @@ function make.key(setting)
 			if o.type == "key" and o.name ~= setting.name and
 					core.are_keycodes_equal(core.settings:get(o.name), value) then
 
-				local is_current_close_world = setting.name == "keymap_close_world"
-				local is_other_close_world = o.name == "keymap_close_world"
+				local is_current_close_world = setting.name == "keymap_close_world" or "main_keymap_close_world"
+				local is_other_close_world = o.name == "keymap_close_world" or "main_keymap_close_world"
 				local is_current_critical = critical_keys[setting.name]
 				local is_other_critical = critical_keys[o.name]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -273,6 +273,10 @@ keymap_increase_viewing_range_min (Increase view range) key SYSTEM_SCANCODE_46
 
 keymap_decrease_viewing_range_min (Decrease view range) key SYSTEM_SCANCODE_45
 
+#    First key bind for closing your world.
+#    Requires the selected key + secondary modifier key to work.
+main_keymap_close_world (Main world leave key) key
+
 #    Modifier key bind for closing your world.
 #    Requires ESC + the selected key to work.
 keymap_close_world (Return to Main Menu) key

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -275,7 +275,7 @@ keymap_decrease_viewing_range_min (Decrease view range) key SYSTEM_SCANCODE_45
 
 #    First key bind for closing your world.
 #    Requires the selected key + secondary modifier key to work.
-main_keymap_close_world (Main world leave key) key
+main_keymap_close_world (Main world leave key) key SYSTEM_SCANCODE_41
 
 #    Modifier key bind for closing your world.
 #    Requires ESC + the selected key to work.

--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -153,13 +153,13 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 			return true;
 
 		} else if (keyCode == getKeySetting("keymap_close_world")) {
-			close_world_down = event.KeyInput.PressedDown;
+			secondary_close_world_down = event.KeyInput.PressedDown;
 
-		} else if (keyCode == EscapeKey) {
-			esc_down = event.KeyInput.PressedDown;
+		} else if (keyCode == getKeySetting("main_keymap_close_world")) {
+			main_close_world_down = event.KeyInput.PressedDown;
 		}
 
-		if (esc_down && close_world_down) {
+		if (main_close_world_down && secondary_close_world_down) {
 			g_gamecallback->disconnect();
 			return true;
 		}

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -128,8 +128,8 @@ private:
 	// Intentionally not reset by clearInput/releaseAllKeys.
 	bool fullscreen_is_down = false;
 
-	bool close_world_down = false;
-	bool esc_down = false;
+	bool main_close_world_down = false;
+	bool secondary_close_world_down = false;
 
 	PointerType last_pointer_type = PointerType::Mouse;
 };

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -187,6 +187,7 @@ void set_default_settings()
 	USEKEY2("keymap_fullscreen", "SYSTEM_SCANCODE_68", "KEY_F11");
 	USEKEY2("keymap_increase_viewing_range_min", "SYSTEM_SCANCODE_46", "+");
 	USEKEY2("keymap_decrease_viewing_range_min", "SYSTEM_SCANCODE_45", "-");
+	USEKEY2("main_keymap_close_world", "SYSTEM_SCANCODE_41", "KEY_ESC");
 	settings->setDefault("keymap_close_world", "");
 	USEKEY2("keymap_slot1", "SYSTEM_SCANCODE_30", "KEY_KEY_1");
 	USEKEY2("keymap_slot2", "SYSTEM_SCANCODE_31", "KEY_KEY_2");


### PR DESCRIPTION
Since #16250 has been merged. I've been told that left-handed players are still having trouble because ESC is still hardcoded, so I have opened this pr to make it fully configurable.

- Goal of the PR
  Allow main keymap for the close world key combination to be configured
- How does the PR work?
It merely allows users to configure the main keybinding for world escape just like the secondary.
- Does it resolve any reported issue?
None on the github.

## To do

Ready for Review.


## How to test

Go to settings, play around with the close world keymaps, ensure everything works.