### PR TITLE
Fix cleaning of CRLF

### DIFF
--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -1107,7 +1107,7 @@ void CGUIEditBox::breakText()
 				// TODO: I (Michael) think that we shouldn't change the text given by the user for whatever reason.
 				// Instead rework the cursor positioning to be able to handle this (but not in stable release
 				// branch as users might already expect this behavior).
-				Text.erase(i + 1);
+				Text.erase(i);
 				--size;
 				if (CursorPos > i)
 					--CursorPos;

--- a/src/gui/guiEditBoxWithScrollbar.cpp
+++ b/src/gui/guiEditBoxWithScrollbar.cpp
@@ -340,7 +340,7 @@ void GUIEditBoxWithScrollBar::breakText()
 				// TODO: I (Michael) think that we shouldn't change the text given by the user for whatever reason.
 				// Instead rework the cursor positioning to be able to handle this (but not in stable release
 				// branch as users might already expect this behavior).
-				Text.erase(i + 1);
+				Text.erase(i);
 				--size;
 				if (m_cursor_pos > i)
 					--m_cursor_pos;


### PR DESCRIPTION
#  Goal of the PR

Fixes incorrect cleaning up of CRLF on Windows input text.

Fixes https://github.com/luanti-org/luanti/issues/16207

# How does the PR work?

String with CR+LF (\r+\n) where wrongly fixed into \r, which is enough to display them correctly, but the missing \n became important once the text was saved/reloaded.

By removing the \r instead of the \n, then the text is displayed correctly and saved correctly.

# Does it resolve any reported issue?
 
https://github.com/luanti-org/luanti/issues/16207

# Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?

Not really, UI improvement?

# Other

This PR is Ready for Review.


## How to test

See issue ticket, for exact workflow, but in short, in MinetestGame, create a book, paste some text with \r\n EOF, save, close, reopen the book.
