### PR TITLE
Fix downward shadows at time 12000

### DIFF
--- a/irr/include/matrix4.h
+++ b/irr/include/matrix4.h
@@ -303,12 +303,14 @@ public:
 	CMatrix4<T> &buildProjectionMatrixOrthoRH(f32 widthOfViewVolume, f32 heightOfViewVolume, f32 zNear, f32 zFar, bool zClipFromZero = true);
 
 	//! Builds a left-handed look-at matrix.
+	//! NOTE: upVector must not be collinear to the postion-to-target vector
 	CMatrix4<T> &buildCameraLookAtMatrixLH(
 			const vector3df &position,
 			const vector3df &target,
 			const vector3df &upVector);
 
 	//! Builds a right-handed look-at matrix.
+	//! NOTE: upVector must not be collinear to the postion-to-target vector
 	CMatrix4<T> &buildCameraLookAtMatrixRH(
 			const vector3df &position,
 			const vector3df &target,

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -68,11 +68,15 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position
 	v3f eye = center_scene - eye_displacement;
+	v3f up = v3f(0.0f, 1.0f, 0.0f);
+	// eye_displacement and up shall not be collinear
+	if (core::equals(eye_displacement.crossProduct(up).getLengthSQ(), 0.f))
+		up = v3f(1.0f, 0.0f, 0.0f);
 	future_frustum.player = cam_pos_scene;
 	future_frustum.position = center_world - eye_displacement;
 	future_frustum.length = length;
 	future_frustum.radius = radius;
-	future_frustum.ViewMat.buildCameraLookAtMatrixLH(eye, center_scene, v3f(0.0f, 1.0f, 0.0f));
+	future_frustum.ViewMat.buildCameraLookAtMatrixLH(eye, center_scene, up);
 	future_frustum.ProjOrthMat.buildProjectionMatrixOrthoLH(radius, radius,
 			0.0f, length, false);
 }

--- a/src/client/shadows/dynamicshadows.cpp
+++ b/src/client/shadows/dynamicshadows.cpp
@@ -68,8 +68,10 @@ void DirectionalLight::createSplitMatrices(const Camera *cam)
 	// we must compute the viewmat with the position - the camera offset
 	// but the future_frustum position must be the actual world position
 	v3f eye = center_scene - eye_displacement;
-	v3f up = v3f(0.0f, 1.0f, 0.0f);
+	v3f up(0.0f, 1.0f, 0.0f);
 	// eye_displacement and up shall not be collinear
+	// At noon, light points straight down, the "up" vector can be anything
+	// that is not along the up axis
 	if (core::equals(eye_displacement.crossProduct(up).getLengthSQ(), 0.f))
 		up = v3f(1.0f, 0.0f, 0.0f);
 	future_frustum.player = cam_pos_scene;


### PR DESCRIPTION
## Goal of the PR

Fix issue https://github.com/luanti-org/luanti/issues/16103 , by avoiding calling `buildCameraLookAtMatrixLH` with inconsistent parameters.

## How does the PR work?

For projecting shadows, we call `buildCameraLookAtMatrixLH(eye, center_scene, v3f(0, 1, 0));` to compute the light-pov matrix. Except this method can only build a projection matrix if the given axis "eye-target" and "up" are not collinear. 

Which was the case at midday, so this method was failing with providing a wrong matrix (mostly filled by 0.0), by providing another "up" axis in this specific case fixes the edge case.

Note: all calls to `buildCameraLookAtMatrixLH` were checked, there are only 2 of them and the other occurences already has some safety mechanism around this method.

## Does it resolve any reported issue?

Yes https://github.com/luanti-org/luanti/issues/16103

## Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?

2.1 Rendering

## How to test

Follow the steps in the "issue" ticket, but in short, enable dynamic shadows at exactly time=12'000
