### PR TITLE
[no sq] Improve some deprecation warnings

### DIFF
--- a/src/script/common/c_converter.h
+++ b/src/script/common/c_converter.h
@@ -121,9 +121,6 @@ void push_v2f(lua_State *L, v2f p);
 void push_aabb3f_vector(lua_State *L, const std::vector<aabb3f> &boxes,
 		f32 divisor = 1.0f);
 
-void warn_if_field_exists(lua_State *L, int table, const char *fieldname,
-		std::string_view name, std::string_view message);
-
 size_t write_array_slice_float(lua_State *L, int table_index, float *data,
 		v3u16 data_size, v3u16 slice_offset, v3u16 slice_size);
 

--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -119,8 +119,10 @@ void script_error(lua_State *L, int pcall_result, const char *mod, const char *f
 	lua_Debug ar;
 	if (lua_getstack(L, stack_depth, &ar)) {
 		FATAL_ERROR_IF(!lua_getinfo(L, "Sl", &ar), "lua_getinfo() failed");
-		ret.append(" (at ").append(ar.short_src).append(":"
-			+ std::to_string(ar.currentline) + ")");
+		ret.append(" (at ");
+		// Use the full path for files, only use the shortened source for strings
+		ret.append(ar.source[0] == '@' ? &ar.source[1] : ar.short_src);
+		ret.append(":" + std::to_string(ar.currentline) + ")");
 	} else {
 		ret.append(" (at ?:?)");
 	}

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1346,30 +1346,43 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	ore->flags          = 0;
 
 	//// Get noise_threshold
-	warn_if_field_exists(L, index, "noise_threshhold", "ore " + ore->name,
-		"Deprecated: new name is \"noise_threshold\".");
-
-	float nthresh;
-	if (!getfloatfield(L, index, "noise_threshold", nthresh) &&
-			!getfloatfield(L, index, "noise_threshhold", nthresh))
-		nthresh = 0;
-	ore->nthresh = nthresh;
+	{
+		float nthresh;
+		if (getfloatfield(L, index, "noise_threshold", nthresh)) {
+		} else if (getfloatfield(L, index, "noise_threshhold", nthresh)) {
+			log_deprecated(L, "Field \"noise_threshhold\" on ore " + ore->name +
+					" is deprecated, use \"noise_threshold\" instead.", 2);
+		} else {
+			nthresh = 0;
+		}
+		ore->nthresh = nthresh;
+	}
 
 	//// Get y_min/y_max
-	warn_if_field_exists(L, index, "height_min", "ore " + ore->name,
-		"Deprecated: new name is \"y_min\".");
-	warn_if_field_exists(L, index, "height_max", "ore " + ore->name,
-		"Deprecated: new name is \"y_max\".");
 
-	int ymin, ymax;
-	if (!getintfield(L, index, "y_min", ymin) &&
-		!getintfield(L, index, "height_min", ymin))
-		ymin = -31000;
-	if (!getintfield(L, index, "y_max", ymax) &&
-		!getintfield(L, index, "height_max", ymax))
-		ymax = 31000;
-	ore->y_min = ymin;
-	ore->y_max = ymax;
+	{
+		int ymin;
+		if (getintfield(L, index, "y_min", ymin)) {
+		} else if (getintfield(L, index, "height_min", ymin)) {
+			log_deprecated(L, "Field \"height_min\" on ore " + ore->name +
+					" is deprecated, use \"y_min\" instead.", 2);
+		} else {
+			ymin = -31000;
+		}
+		ore->y_min = ymin;
+	}
+
+	{
+		int ymax;
+		if (getintfield(L, index, "y_max", ymax)) {
+		} else if (getintfield(L, index, "height_max", ymax)) {
+			log_deprecated(L, "Field \"height_max\" on ore " + ore->name +
+					" is deprecated, use \"y_max\" instead.", 2);
+		} else {
+			ymax = 31000;
+		}
+		ore->y_max = ymax;
+	}
 
 	if (ore->clust_scarcity <= 0 || ore->clust_num_ores <= 0) {
 		errorstream << "register_ore: clust_scarcity and clust_num_ores"
@@ -1391,8 +1404,8 @@ int ModApiMapgen::l_register_ore(lua_State *L)
 	if (read_noiseparams(L, -1, &ore->np)) {
 		ore->flags |= OREFLAG_USE_NOISE;
 	} else if (ore->needs_noise) {
-		log_deprecated(L,
-			"register_ore: ore type requires 'noise_params' but it is not specified, falling back to defaults");
+		log_deprecated(L, "register_ore: ore type requires 'noise_params'"
+				" but it is not specified, falling back to defaults", 2);
 	}
 	lua_pop(L, 1);
 


### PR DESCRIPTION
First commit: Make sure to use full paths. Shortened paths are nasty because you can't click on them. (If we want shorter paths, we should probably support shortening to a path relative to the CWD (I'm willing to implement this if someone asks for it). But I think this is fine as is.)

Second commit: Does what it says, improves some deprecation warnings, mostly by adding source locations. (And if you have info log level enabled, as they now use `log_deprecated` as they should, you'll get a proper backtrace.)

We can then get rid of `warn_if_field_exists`. (I think this is an abstraction not really worth having; without the abstraction, the code is only a wee bit more verbose, and definitely much more clear as to what message will be generated; and also more flexible.)

Taken together these make going from these deprecation warnings to places in games pretty seamless. (I used this to work on https://github.com/appgurueu/citysim_game/tree/maintenance)

## How to test

Trigger the warnings.