### PR TITLE
Make `max_formspec_size` clearer

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -5925,8 +5925,8 @@ Utilities
       },
 
       -- Estimated maximum formspec size before Luanti will start shrinking the
-      -- formspec to fit. For a fullscreen formspec, use this formspec size and
-      -- `padding[0,0]`. `bgcolor[;true]` is also recommended.
+      -- formspec to fit. For a fullscreen formspec, use the size returned by
+      -- this table  and `padding[0,0]`. `bgcolor[;true]` is also recommended.
       max_formspec_size = {
           x = 20,
           y = 11.25


### PR DESCRIPTION
I was confused because initially I had thought that 20 and 11.25 were universal values. I think this makes it clearer?

## To do

This PR is Ready for Review.

## How to test

:eye: 
