### PR TITLE
ParticleSpawner: Fix crash caused by empty texture

### DIFF
--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -83,7 +83,6 @@ u32 PcgRandom::range(u32 bound)
 	if (bound == 0)
 		return next();
 
-	// Optimization: only one value is possible.
 	if (bound == 1)
 		return 0;
 

--- a/src/noise.cpp
+++ b/src/noise.cpp
@@ -83,6 +83,10 @@ u32 PcgRandom::range(u32 bound)
 	if (bound == 0)
 		return next();
 
+	// Optimization: only one value is possible.
+	if (bound == 1)
+		return 0;
+
 	/*
 		This is an optimization of the expression:
 		  0x100000000ull % bound


### PR DESCRIPTION
no_texture.png is now used as a fallback (if available), like already seen with registered items with empty 'inventory_image'.

Fixes #16345

## To do

This PR is Ready for Review.

## How to test

1. Use 3rd person perspective
2. Use the worldedit commands mod
3. `//lua pos=player:get_pos(); pos.y=pos.y+2; core.add_particlespawner{pos=pos,time=4,animation={type="vertical_frames"}}`
4. A particle must show up on top of your head, indicating failure by using `no_texture.png`.