### PR TITLE
Improve interop with LuaJIT (part 1 of ?): disable compatibility defines in Lua config

### DIFF
--- a/lib/lua/src/luaconf.h
+++ b/lib/lua/src/luaconf.h
@@ -341,14 +341,14 @@
 ** CHANGE it to undefined as soon as your programs use only '...' to
 ** access vararg parameters (instead of the old 'arg' table).
 */
-#define LUA_COMPAT_VARARG
+#undef LUA_COMPAT_VARARG
 
 /*
 @@ LUA_COMPAT_MOD controls compatibility with old math.mod function.
 ** CHANGE it to undefined as soon as your programs use 'math.fmod' or
 ** the new '%' operator instead of 'math.mod'.
 */
-#define LUA_COMPAT_MOD
+#undef LUA_COMPAT_MOD
 
 /*
 @@ LUA_COMPAT_LSTR controls compatibility with old long string nesting
@@ -356,14 +356,14 @@
 ** CHANGE it to 2 if you want the old behaviour, or undefine it to turn
 ** off the advisory error when nesting [[...]].
 */
-#define LUA_COMPAT_LSTR		1
+#undef LUA_COMPAT_LSTR		1
 
 /*
 @@ LUA_COMPAT_GFIND controls compatibility with old 'string.gfind' name.
 ** CHANGE it to undefined as soon as you rename 'string.gfind' to
 ** 'string.gmatch'.
 */
-#define LUA_COMPAT_GFIND
+#undef LUA_COMPAT_GFIND
 
 /*
 @@ LUA_COMPAT_OPENLIB controls compatibility with old 'luaL_openlib'
@@ -371,7 +371,7 @@
 ** CHANGE it to undefined as soon as you replace to 'luaL_register'
 ** your uses of 'luaL_openlib'
 */
-#define LUA_COMPAT_OPENLIB
+#undef LUA_COMPAT_OPENLIB
 
 
 


### PR DESCRIPTION
improves interop with LuaJIT by disabling compatibility defines/features in the Lua config (`luaconf.h`) which don't exist in LuaJIT.
This will mean that people's scripts/mods are more likely to work between builds of Luanti compiled with or without LuaJIT as there won't be as many unnecessary differences.
almost all of the "LUA_COMPAT_" defines/features don't exist in LuaJIT 2.0 except `LUA_COMPAT_MOD` and `LUA_COMPAT_GFIND` of which where then removed in LuaJIT 2.1

This PR is Ready for Review.
<!-- ^ delete one -->