### PR TITLE
Hide menu header on tabview:hide()

### DIFF
--- a/builtin/fstk/tabview.lua
+++ b/builtin/fstk/tabview.lua
@@ -225,7 +225,14 @@ end
 local function hide_tabview(self)
 	self.hidden=true
 
-	--call on_change as we're not gonna show self tab any longer
+	-- hide the menu header image as well
+	if  core.settings:get_bool("touch_gui") then
+		if mm_game_theme and mm_game_theme.clear_single then
+			mm_game_theme.clear_single("header")
+		end
+	end
+
+	-- call on_change as we're not gonna show self tab any longer
 	if self.tablist[self.last_tab_index].on_change ~= nil then
 		self.tablist[self.last_tab_index].on_change("LEAVE",
 				self.current_tab, nil)

--- a/builtin/fstk/tabview.lua
+++ b/builtin/fstk/tabview.lua
@@ -226,10 +226,8 @@ local function hide_tabview(self)
 	self.hidden=true
 
 	-- hide the menu header image as well
-	if  core.settings:get_bool("touch_gui") then
-		if mm_game_theme and mm_game_theme.clear_single then
-			mm_game_theme.clear_single("header")
-		end
+	if mm_game_theme and mm_game_theme.clear_single then
+		mm_game_theme.clear_single("header")
 	end
 
 	-- call on_change as we're not gonna show self tab any longer

--- a/builtin/mainmenu/game_theme.lua
+++ b/builtin/mainmenu/game_theme.lua
@@ -51,6 +51,8 @@ function mm_game_theme.set_game(gamedetails)
 	assert(gamedetails ~= nil)
 
 	if mm_game_theme.gameid == gamedetails.id then
+		-- still restore header in case it was cleared
+		mm_game_theme.set_game_single("header", gamedetails)
 		return
 	end
 	mm_game_theme.gameid = gamedetails.id


### PR DESCRIPTION
While working on #16164, I discovered that the main menu header stays visible in dialogs.
I find this annoying and partly confusing for two reasons:
    - It's confusing when the game's logotype is still visible in the exit confirmation dialog.
    - On mobile it takes up unnecessary space, as it is hardly visible anyways.

- Goal of the PR
Hide the main menu header during dialogs and restore it properly when returning to the tab view.

- How does the PR work?
In the `hide_tabview` function, it clears the header by calling `mm_game_theme.clear_single("header")`.
The `mm_game_theme.set_game` function now restores the header image even if the selected game has not changed by calling `mm_game_theme.set_game_single("header", gamedetails)` before returning early. This is needed when closing the exit confirmation dialog and returning to the main menu.

- Does it resolve any reported issue?
Nope.

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Maybe 2.3

- If not a bug fix, why is this PR needed? What usecases does it solve?
It's somewhat of a bug fix.

## To do

This PR is ready for review.

## How to test

Open a dialog → observe that the menu header doesn't appear in any dialog screen.
