### PR TITLE
Bump CI runners `windows-2019` to `windows-2025`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,8 +68,8 @@ jobs:
           if-no-files-found: error
 
   msvc:
-    name: VS 2019 ${{ matrix.config.arch }}-${{ matrix.type }}
-    runs-on: windows-2019
+    name: VS 2022 ${{ matrix.config.arch }}-${{ matrix.type }}
+    runs-on: windows-2025
     env:
       VCPKG_DEFAULT_TRIPLET: ${{matrix.config.vcpkg_triplet}}
     strategy:
@@ -78,12 +78,12 @@ jobs:
         config:
           - {
               arch: x86,
-              generator: "-G'Visual Studio 16 2019' -A Win32",
+              generator: "-G'Visual Studio 17 2022' -A Win32",
               vcpkg_triplet: x86-windows
             }
           - {
               arch: x64,
-              generator: "-G'Visual Studio 16 2019' -A x64",
+              generator: "-G'Visual Studio 17 2022' -A x64",
               vcpkg_triplet: x64-windows
             }
         type: [portable]


### PR DESCRIPTION
`windows-2019` runners are no longer available: https://github.com/actions/runner-images/issues/12045

Attempt to switch from Visual Studio 2019 to Visual Studio 2022 (the installed version on `windows-2022` and `windows-2025`).

Should resolve the failing Windows CI jobs.

## To do

This PR is a Work in Progress.

- [ ] Try the resulting artifacts (only tested with wine, unsuccessful due to missing DLL unlike last `windows-2019` version)
- [ ] If needed, setup VS 2019 on `windows-2025`, should match old behavior I guess.

## How to test

See the builds succeed. Download the artifacts and test.