### PR TITLE
Permit invoking core.generate_decorations so as to generate biomes respecting the biome map

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6732,10 +6732,16 @@ Environment access
     * Generate all registered ores within the VoxelManip `vm` and in the area
       from `pos1` to `pos2`.
     * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
-* `core.generate_decorations(vm[, pos1, pos2])`
+* `core.generate_decorations(vm[, pos1, pos2, [use_mapgen_biomes]])`
     * Generate all registered decorations within the VoxelManip `vm` and in the
       area from `pos1` to `pos2`.
     * `pos1` and `pos2` are optional and default to mapchunk minp and maxp.
+    * `use_mapgen_biomes` means that decoration generation should
+       respect the biome map of the most recently generated MapChunk,
+       as returned by `get_mapgen_object`.  It is an error to set this
+       parameter in combination with `pos1` or `pos2` positions other
+       than the extents of the most recently generated MapChunk.
+
 * `core.clear_objects([options])`
     * Clear all objects in the environment
     * Takes an optional table as an argument with the field `mode`.

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1611,7 +1611,7 @@ int ModApiMapgen::l_generate_ores(lua_State *L)
 }
 
 
-// generate_decorations(vm, p1, p2)
+// generate_decorations(vm, p1, p2, use_mapgen_biomes)
 int ModApiMapgen::l_generate_decorations(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1621,26 +1621,48 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 		return 0;
 
 	DecorationManager *decomgr;
-	if (auto mg = getMapgen(L))
+	Mapgen mg, *mgp = NULL;
+	bool use_mapgen_biomes = lua_isboolean (L, 4) && readParam<bool> (L, 4);
+	MMVManip *oldvm, *vm = checkObject<LuaVoxelManip>(L, 1)->vm;
+	if (auto mg = getMapgen(L)) {
 		decomgr = mg->m_emerge->decomgr;
-	else
+		if (use_mapgen_biomes) {
+			mgp = mg;
+			oldvm = mgp->vm;
+		}
+	} else {
 		decomgr = emerge->decomgr;
+	}
+	if (!mgp) {
+		mgp = &mg;
+		// Intentionally truncates to s32, see Mapgen::Mapgen()
+		mg.seed = (s32)emerge->mgparams->seed;
+		mg.ndef = emerge->ndef;
+		oldvm = NULL;
+	}
 
-	Mapgen mg;
-	// Intentionally truncates to s32, see Mapgen::Mapgen()
-	mg.seed = (s32)emerge->mgparams->seed;
-	mg.vm   = checkObject<LuaVoxelManip>(L, 1)->vm;
-	mg.ndef = emerge->ndef;
-
-	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) :
-			mg.vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
-	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) :
-			mg.vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 default_pmin = vm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 default_pmax = vm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+	v3s16 pmin = lua_istable(L, 2) ? check_v3s16(L, 2) : default_pmin;
+	v3s16 pmax = lua_istable(L, 3) ? check_v3s16(L, 3) : default_pmax;
+	if (use_mapgen_biomes && !oldvm) {
+		throw LuaError("use_mapgen_biomes called before any MapChunks have been generated");
+	} else if (use_mapgen_biomes) {
+		v3s16 required_pmin
+			= oldvm->m_area.MinEdge + v3s16(1,1,1) * MAP_BLOCKSIZE;
+		v3s16 required_pmax
+			= oldvm->m_area.MaxEdge - v3s16(1,1,1) * MAP_BLOCKSIZE;
+		if (pmin != required_pmin || pmax != required_pmax) {
+			throw LuaError("use_mapgen_biomes specified alongside non-default extents");
+		}
+	}
 	sortBoxVerticies(pmin, pmax);
 
 	u32 blockseed = Mapgen::getBlockSeed(pmin, mg.seed);
 
-	decomgr->placeAllDecos(&mg, blockseed, pmin, pmax);
+	mgp->vm = vm;
+	decomgr->placeAllDecos(mgp, blockseed, pmin, pmax);
+	mgp->vm = oldvm;
 
 	return 0;
 }


### PR DESCRIPTION
Cherry picked from https://codeberg.org/halon/Minetest, submitting on behalf of halon / repetetivestrain.

Makes core.generate_decorations() accept a new argument USE_MAPGEN_BIOMES.  Verifies fitness of P1 and P2 and specify the current Mapgen object if possible.

