### PR TITLE
Adds back the missing endElement in parseTag for <action>

### DIFF
--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -585,6 +585,7 @@ u32 ParsedText::parseTag(const wchar_t *text, u32 cursor)
 				return 0;
 			openTag(name, attrs)->style = m_elementtags["action"];
 		}
+		endElement();
 
 	} else if (m_elementtags.count(name)) {
 		if (end) {


### PR DESCRIPTION
Before this change, <action> tags did not end until a space was found or another tag was reached. Adding that call solves the issue, and with some bold guess and seeing how spaces trigger ParsedText::ELEMENT_SEPARATOR, this patch should be the way to fix this issue.

Fix https://discord.com/channels/369122544273588224/369123175583186964/1405238765647167600

## To do

This PR is Ready for Review.

## How to test

1. Show the following hypertext on the current master: `<action>Hello</ation>World!`
    - The action tag does not end til the end of "World!"
2. Apply this patch, then do it again
    - The action tag stops right after saying "Hello".

### Examples

The following are generated from an excerpt of [_Samson_ from the Chinese Wikipedia, section _Christian interpretations_](https://zh.wikipedia.org/wiki/%E5%8F%83%E5%AD%AB#%E5%9F%BA%E7%9D%A3%E6%95%99%E8%A7%A3%E8%AE%80). Note that Chinese does not use spaces to separate words. Ignore the HTML escapes, those are my fault, not Luanti's.

Before the patch:
<img width="1109" height="285" alt="圖片" src="https://github.com/user-attachments/assets/88bc3e70-c5b3-4d06-81da-237a1f7ce047" />

After the patch:
<img width="1091" height="361" alt="螢幕截圖_20250814_100351" src="https://github.com/user-attachments/assets/32307128-c94b-4efb-b3ec-17a6d06a4c4e" />

Original text:
<img width="856" height="410" alt="圖片" src="https://github.com/user-attachments/assets/4568a1f9-8dbd-40ad-979c-6bb0f7650956" />

