### PR TITLE
Add formspec box color documentation to style section

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3612,6 +3612,8 @@ Some types may inherit styles from parent types.
 * animated_image
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
 * box
+    * **Note**: In order for any of the styling options to take effect,
+                the `color` field in the box element must be left unspecified.
     * noclip - boolean, set to true to allow the element to exceed formspec bounds.
         * Defaults to false in formspec_version version 3 or higher
     * **Note**: `colors`, `bordercolors`, and `borderwidths` accept multiple input types:


### PR DESCRIPTION
When you use styling for a box element, you may miss that you have to remove the color specification, if you only read the documentation about styling, and not for the element itself.

So with this PR it is documented at two places such that people don't miss it that easily anymore.

The first existing one is here:
https://github.com/luanti-org/luanti/blob/36b5374715f1aae7fb1ca6fabe4ea4a24895512e/doc/lua_api.md?plain=1#L3324
(IMO, documenting it in the styling section is more important, but it doesn't hurt to have it two times, I think.)


This is actually a problem, see here: https://forum.luanti.org/viewtopic.php?t=31937

## To do

This PR is Ready for Review.

## How to test

Read