### PR TITLE
Allow float values for HTTPRequest.timeout

### DIFF
--- a/src/script/lua_api/l_http.cpp
+++ b/src/script/lua_api/l_http.cpp
@@ -39,8 +39,9 @@ void ModApiHttp::read_http_fetch_request(lua_State *L, HTTPFetchRequest &req)
 	getstringfield(L, 1, "url", req.url);
 	getstringfield(L, 1, "user_agent", req.useragent);
 	req.multipart = getboolfield_default(L, 1, "multipart", false);
-	if (getintfield(L, 1, "timeout", req.timeout))
-		req.timeout *= 1000;
+	float timeout_sec = 0;
+	if (getfloatfield(L, 1, "timeout", timeout_sec))
+		req.timeout = timeout_sec * 1000;
 
 	lua_getfield(L, 1, "method");
 	if (lua_isstring(L, -1))


### PR DESCRIPTION
Allows setting timeout to values less than 1 second.

Reads specified value as float, before converting it to milliseconds.

Before this, it was read as int, which caused values < 1.0 to become integer 0, which makes timeout infinite instead.

# Why:
CURL allows specifying timeouts in fractions of a second, so there are mods in the wild that set this value to something like 0.8, expecting for fetch request to time out in less than a second. Instead, this parameter gets converted to integer and becomes 0, causing the connection to potentially get stuck forever. Setting lower timeout, users expect connections timing out faster, instead they potentially get connection pool filled with stuck connections, and no new connections can be created.

This change is minimal, since timeout already gets passed to CURL in milliseconds as CURLOPT_TIMEOUT_MS, and only lua value conversion is slightly incorrect.


This PR is Ready for Review.

## How to test

Simple python server that will just keep connections open without sending anything:
```python
import socket
import time

if __name__ == "__main__":
    s = socket.socket(
        family = socket.AF_INET,
        type = socket.SOCK_STREAM
    )
    s.bind(("localhost", 8000))
    s.listen()
    while True:
        print(time.time(), "sleeping...")
        time.sleep(60)
```

Simple mod that will create a bunch of fetch requests with a specified timeout:
```lua
local test_http = _G.test_http or {}
_G.test_http = test_http

test_http.http = test_http.http or core.request_http_api()

local http = test_http.http
assert(http)

local TIMEOUT = 0.5


function test_http.do_test()
    for i=1,100 do
        print(i, "sent")

        http.fetch(
            {
                url = "http://127.0.0.1:8000",
                timeout = TIMEOUT,
            },
            function(result)
                print(string.format("%s %s timeout:%s", i, "done", result.timeout))
            end
        )
    end
end


function test_http.run_command(name, param)
    dofile(core.get_modpath("test_http") .. "/init.lua")
    test_http.do_test()
end

core.register_chatcommand("test_http", {
        privs = { server = true },
        func = test_http.run_command,
})
```

### Expected behavior:
Fetch requests are attempted in groups of size of the pool, and time out after TIMEOUT=0.5s.

### Current behavior:
Fetch requests with timeout 0.5 get infinitely stuck, and after pool is filled, new requests are not even attempted.

