### PR TITLE
[no squash] Small extension to `core.dynamic_add_media()`

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7373,8 +7373,10 @@ Server
         * `filedata`: the data of the file to be sent [*]
         * `to_player`: name of the player the media should be sent to instead of
                        all players (optional)
-        * `ephemeral`: boolean that marks the media as ephemeral,
-                       it will not be cached on the client (optional, default false)
+        * `ephemeral`: if true the server will create a copy of the file and
+                       forget about it once delivered (optional boolean, default false)
+        * `client_cache`: hint whether the client should save the media in its cache
+                          (optional boolean, default `!ephemeral`, added in 5.14.0)
         * Exactly one of the parameters marked [*] must be specified.
     * `callback`: function with arguments `name`, which is a player name
     * Pushes the specified media file to client(s) as detailed below.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7377,7 +7377,7 @@ Server
                        it will not be cached on the client (optional, default false)
         * Exactly one of the parameters marked [*] must be specified.
     * `callback`: function with arguments `name`, which is a player name
-    * Pushes the specified media file to client(s). (details below)
+    * Pushes the specified media file to client(s) as detailed below.
       The file must be a supported image, sound or model format.
       Dynamically added media is not persisted between server restarts.
     * Returns false on error, true if the request was accepted
@@ -7386,19 +7386,17 @@ Server
     * Details/Notes:
       * If `ephemeral`=false and `to_player` is unset the file is added to the media
         sent to clients on startup, this means the media will appear even on
-        old clients if they rejoin the server.
+        old clients (<5.3.0) if they rejoin the server.
       * If `ephemeral`=false the file must not be modified, deleted, moved or
-        renamed after calling this function.
-      * Regardless of any use of `ephemeral`, adding media files with the same
-        name twice is not possible/guaranteed to work. An exception to this is the
-        use of `to_player` to send the same, already existent file to multiple
-        chosen players.
+        renamed after calling this function. This is allowed otherwise.
+      * Adding media files with the same name twice is not possible.
+        An exception to this is the use of `to_player` to send the same,
+        already existent file to multiple chosen players (`ephemeral`=false only).
       * You can also call this at startup time. In that case `callback` MUST
         be `nil` and you cannot use `ephemeral` or `to_player`, as these logically
         do not make sense.
     * Clients will attempt to fetch files added this way via remote media,
-      this can make transfer of bigger files painless (if set up). Nevertheless
-      it is advised not to use dynamic media for big media files.
+      this can make transfer of bigger files painless (if set up).
 
 IPC
 ---

--- a/games/devtest/mods/unittests/misc.lua
+++ b/games/devtest/mods/unittests/misc.lua
@@ -52,6 +52,7 @@ local function test_dynamic_media(cb, player)
 	local ok = core.dynamic_add_media({
 		filepath = path,
 		to_player = player:get_player_name(),
+		client_cache = false,
 	}, function(name)
 		if not call_ok then
 			return cb("impossible condition")

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -567,6 +567,7 @@ int ModApiServer::l_dynamic_add_media(lua_State *L)
 	} else {
 		tmp = readParam<std::string>(L, 1);
 		args.filepath = tmp;
+		log_deprecated(L, "Deprecated call to core.dynamic_add_media() with string argument", 1, true);
 	}
 	if (at_startup) {
 		if (!lua_isnoneornil(L, 2))

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -564,6 +564,7 @@ int ModApiServer::l_dynamic_add_media(lua_State *L)
 			args.data.reset();
 		getstringfield(L, 1, "to_player", args.to_player);
 		getboolfield(L, 1, "ephemeral", args.ephemeral);
+		args.client_cache = getboolfield_default(L, 1, "client_cache", !args.ephemeral);
 	} else {
 		tmp = readParam<std::string>(L, 1);
 		args.filepath = tmp;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -3782,10 +3782,10 @@ bool Server::dynamicAddMedia(const DynamicMediaArgs &a)
 	if (m_env) {
 		NetworkPacket pkt(TOCLIENT_MEDIA_PUSH, 0);
 		pkt << raw_hash << filename;
-		// NOTE: the meaning of a.ephemeral was accidentally inverted between proto 39 and 40,
+		// NOTE: the meaning of this bit was accidentally inverted between proto 39 and 40,
 		// when dynamic_add_media v2 was added. As of 5.12.0 the server sends it correctly again.
 		// Compatibility code on the client-side was not added.
-		pkt << static_cast<bool>(!a.ephemeral);
+		pkt << static_cast<bool>(a.client_cache);
 
 		NetworkPacket legacy_pkt = pkt;
 

--- a/src/server.h
+++ b/src/server.h
@@ -94,6 +94,8 @@ struct MediaInfo
 	std::string sha1_digest;
 	// true = not announced in TOCLIENT_ANNOUNCE_MEDIA (at player join)
 	bool no_announce;
+	// if true, this is an ephemeral entry. used by dynamic media.
+	bool ephemeral;
 	// does what it says. used by some cases of dynamic media.
 	bool delete_at_shutdown;
 
@@ -102,6 +104,7 @@ struct MediaInfo
 		path(path_),
 		sha1_digest(sha1_digest_),
 		no_announce(false),
+		ephemeral(false),
 		delete_at_shutdown(false)
 	{
 	}

--- a/src/server.h
+++ b/src/server.h
@@ -302,6 +302,7 @@ public:
 		u32 token;
 		std::string to_player;
 		bool ephemeral = false;
+		bool client_cache = true;
 	};
 	bool dynamicAddMedia(const DynamicMediaArgs &args);
 


### PR DESCRIPTION
minor refactor and a small feature

Note: I didn't add a `core.features` entry because presence of the feature is essentially inconsequential for mods.

## To do

This PR is Ready for Review.

## How to test

```lua
core.register_on_joinplayer(function(player)
	core.after(1, function()
		local s = "i am a banana"
		local ret = core.dynamic_add_media({
			filename = "dummy.obj",
			filedata = s,
			client_cache = false,
			to_player = player:get_player_name()
		}, function() end)
		print("ret=" .. tostring(ret))
		print("sha1=" .. core.sha1(s))
	end)
end)
```

you should **not** find a file with the printed sha1 hash in your media cache
