### PR TITLE
Formspec: Implement Ctrl+Shift+Left/Right text selection

### DIFF
--- a/src/gui/guiEditBox.h
+++ b/src/gui/guiEditBox.h
@@ -135,6 +135,10 @@ protected:
 	virtual s32 getCursorPos(s32 x, s32 y) = 0;
 
 	bool processKey(const SEvent &event);
+	//! KEY_LEFT / KEY_RIGHT inputs
+	void processKeyLR(const SEvent::SKeyInput &input, s32 &new_mark_begin,
+			s32 &new_mark_end);
+
 	virtual void inputString(const core::stringw &str);
 	virtual void inputChar(wchar_t c);
 


### PR DESCRIPTION
This is a quality-of-life improvement to edit text more easily. Here I tried to mimic the logic of Firefox.

This does NOT implement text selection of single-line input boxes. This shall be addressed by merging `GUIEditBox` into `CGUIEditBox` in a future PR. (yes we have some duplicate code)

## To do

This PR is Ready for Review.

## How to test

1. Either use the server list description box to navigate, or edit mainmenu/tab_local.lua:
```Lua
	elseif is_world_selected then
		retval = retval ..
				"button[10.1875,5.925;4.9375,0.8;play;" .. fgettext("Play Game") .. "]"
	end

local text = [[
01""field[0,".. y .. ";3,0.75;te_serveraddr;"
02      download .doc file (zipped)
03https://a.domain.tld/word-bar/aaa.jpeg?key_text=value%20what%20ever
04 AAA000... AA00.. A0. A. .A .A0
05
06頂とょんき回独サ午映就
07Chuchichäschtli
08
09
10
11
12
13
]]
	--text = "sasasas aaaa dd"

	retval = "textarea[1,1;8,3;mytext;Title Name;" .. core.formspec_escape(text) .. "]"

	return retval
```
2. Use the Shift+Left/Right, Ctrl+Shift+Left/Right key combinations to select text.
3. It must feel rather consistent with other apps.