### PR TITLE
Lua API: Unify server env checks and fix missing ones

### DIFF
--- a/src/script/lua_api/l_auth.cpp
+++ b/src/script/lua_api/l_auth.cpp
@@ -15,14 +15,8 @@
 // common start: ensure auth db
 AuthDatabase *ModApiAuth::getAuthDb(lua_State *L)
 {
-	ServerEnvironment *server_environment =
-			dynamic_cast<ServerEnvironment *>(getEnv(L));
-	if (!server_environment) {
-		luaL_error(L, "Attempt to access an auth function but the auth"
-			" system is yet not initialized. This causes bugs.");
-		return nullptr;
-	}
-	return server_environment->getAuthDatabase();
+	GET_ENV_PTR_NO_MAP_LOCK;
+	return env->getAuthDatabase();
 }
 
 void ModApiAuth::pushAuthEntry(lua_State *L, const AuthEntry &authEntry)

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -1158,7 +1158,6 @@ int ModApiEnv::l_raycast(lua_State *L)
 int ModApiEnv::l_load_area(lua_State *L)
 {
 	GET_ENV_PTR;
-	MAP_LOCK_REQUIRED;
 
 	Map *map = &(env->getMap());
 	v3s16 bp1 = getNodeBlockPos(check_v3s16(L, 1));
@@ -1373,7 +1372,8 @@ int ModApiEnv::l_forceload_free_block(lua_State *L)
 // get_translated_string(lang_code, string)
 int ModApiEnv::l_get_translated_string(lua_State * L)
 {
-	GET_ENV_PTR;
+	NO_MAP_LOCK_REQUIRED;
+
 	std::string lang_code = luaL_checkstring(L, 1);
 	std::string string = luaL_checkstring(L, 2);
 

--- a/src/script/lua_api/l_internal.h
+++ b/src/script/lua_api/l_internal.h
@@ -44,8 +44,10 @@
 #define GET_ENV_PTR_NO_MAP_LOCK                              \
 	DEBUG_ASSERT_NO_CLIENTAPI;                               \
 	ServerEnvironment *env = (ServerEnvironment *)getEnv(L); \
-	if (env == NULL)                                         \
-		return 0
+	if (!env) {                                              \
+		luaL_error(L, "Calling this function during script init is disallowed."); \
+		return 0;                                            \
+	} do {} while (0)
 
 // Retrieve ServerEnvironment pointer as `env`
 #define GET_ENV_PTR         \

--- a/src/script/lua_api/l_internal.h
+++ b/src/script/lua_api/l_internal.h
@@ -47,7 +47,8 @@
 	if (!env) {                                              \
 		log_deprecated(L, "Calling this function during script init is disallowed.", 1); \
 		return 0;                                            \
-	} do {} while (0)
+	} \
+	((void)0)
 
 // Retrieve ServerEnvironment pointer as `env`
 #define GET_ENV_PTR         \

--- a/src/script/lua_api/l_internal.h
+++ b/src/script/lua_api/l_internal.h
@@ -45,7 +45,7 @@
 	DEBUG_ASSERT_NO_CLIENTAPI;                               \
 	ServerEnvironment *env = (ServerEnvironment *)getEnv(L); \
 	if (!env) {                                              \
-		luaL_error(L, "Calling this function during script init is disallowed."); \
+		log_deprecated(L, "Calling this function during script init is disallowed.", 1); \
 		return 0;                                            \
 	} do {} while (0)
 

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1650,13 +1650,13 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 int ModApiMapgen::l_create_schematic(lua_State *L)
 {
 	MAP_LOCK_REQUIRED;
+	GET_ENV_PTR;
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
 
 	const char *filename = luaL_checkstring(L, 4);
 	CHECK_SECURE_PATH(L, filename, true);
 
-	Map *map = &(getEnv(L)->getMap());
 	Schematic schem;
 
 	v3s16 p1 = check_v3s16(L, 1);
@@ -1694,7 +1694,7 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 		}
 	}
 
-	if (!schem.getSchematicFromMap(map, p1, p2)) {
+	if (!schem.getSchematicFromMap(&env->getMap(), p1, p2)) {
 		errorstream << "create_schematic: failed to get schematic "
 			"from map" << std::endl;
 		return 0;

--- a/src/script/lua_api/l_mapgen.cpp
+++ b/src/script/lua_api/l_mapgen.cpp
@@ -1649,7 +1649,6 @@ int ModApiMapgen::l_generate_decorations(lua_State *L)
 // create_schematic(p1, p2, probability_list, filename, y_slice_prob_list)
 int ModApiMapgen::l_create_schematic(lua_State *L)
 {
-	MAP_LOCK_REQUIRED;
 	GET_ENV_PTR;
 
 	const NodeDefManager *ndef = getServer(L)->getNodeDefManager();
@@ -1715,8 +1714,6 @@ int ModApiMapgen::l_create_schematic(lua_State *L)
 //     replacements, force_placement, flagstring)
 int ModApiMapgen::l_place_schematic(lua_State *L)
 {
-	MAP_LOCK_REQUIRED;
-
 	GET_ENV_PTR;
 
 	ServerMap *map = &(env->getServerMap());

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -770,7 +770,7 @@ int ObjectRef::l_get_bone_overrides(lua_State *L)
 // set_attach(self, parent, bone, position, rotation, force_visible)
 int ObjectRef::l_set_attach(lua_State *L)
 {
-	GET_ENV_PTR;
+	GET_ENV_PTR_NO_MAP_LOCK;
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ObjectRef *parent_ref = checkObject<ObjectRef>(L, 2);
 	ServerActiveObject *sao = getobject(ref);
@@ -797,7 +797,7 @@ int ObjectRef::l_set_attach(lua_State *L)
 // get_attach(self)
 int ObjectRef::l_get_attach(lua_State *L)
 {
-	GET_ENV_PTR;
+	GET_ENV_PTR_NO_MAP_LOCK;
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
@@ -825,7 +825,7 @@ int ObjectRef::l_get_attach(lua_State *L)
 // get_children(self)
 int ObjectRef::l_get_children(lua_State *L)
 {
-	GET_ENV_PTR;
+	GET_ENV_PTR_NO_MAP_LOCK;
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)
@@ -898,7 +898,7 @@ int ObjectRef::l_get_properties(lua_State *L)
 // set_observers(self, observers)
 int ObjectRef::l_set_observers(lua_State *L)
 {
-	GET_ENV_PTR;
+	GET_ENV_PTR_NO_MAP_LOCK;
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
 	ServerActiveObject *sao = getobject(ref);
 	if (sao == nullptr)

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -47,8 +47,7 @@ int ModApiServer::l_get_server_uptime(lua_State *L)
 // get_server_max_lag()
 int ModApiServer::l_get_server_max_lag(lua_State *L)
 {
-	NO_MAP_LOCK_REQUIRED;
-	GET_ENV_PTR;
+	GET_ENV_PTR_NO_MAP_LOCK;
 	lua_pushnumber(L, env->getMaxLagEstimate());
 	return 1;
 }

--- a/src/script/lua_api/l_server.cpp
+++ b/src/script/lua_api/l_server.cpp
@@ -124,35 +124,34 @@ int ModApiServer::l_get_player_privs(lua_State *L)
 // get_player_ip()
 int ModApiServer::l_get_player_ip(lua_State *L)
 {
-	NO_MAP_LOCK_REQUIRED;
-
-	Server *server = getServer(L);
+	GET_ENV_PTR_NO_MAP_LOCK;
 
 	const char *name = luaL_checkstring(L, 1);
-	RemotePlayer *player = server->getEnv().getPlayer(name);
+	RemotePlayer *player = env->getPlayer(name);
 	if (!player) {
 		lua_pushnil(L); // no such player
 		return 1;
 	}
 
-	lua_pushstring(L, server->getPeerAddress(player->getPeerId()).serializeString().c_str());
+	lua_pushstring(L, env->getGameDef()->getPeerAddress(
+		player->getPeerId()).serializeString().c_str()
+	);
 	return 1;
 }
 
 // get_player_information(name)
 int ModApiServer::l_get_player_information(lua_State *L)
 {
-	NO_MAP_LOCK_REQUIRED;
-
-	Server *server = getServer(L);
+	GET_ENV_PTR_NO_MAP_LOCK;
 
 	const char *name = luaL_checkstring(L, 1);
-	RemotePlayer *player = server->getEnv().getPlayer(name);
+	RemotePlayer *player = env->getPlayer(name);
 	if (!player) {
 		lua_pushnil(L); // no such player
 		return 1;
 	}
 
+	Server *server = env->getGameDef();
 	ClientInfo info;
 	if (!server->getClientInfo(player->getPeerId(), info)) {
 		warningstream << FUNCTION_NAME << ": no client info?!" << std::endl;
@@ -271,15 +270,14 @@ int ModApiServer::l_get_player_information(lua_State *L)
 // get_player_window_information(name)
 int ModApiServer::l_get_player_window_information(lua_State *L)
 {
-	NO_MAP_LOCK_REQUIRED;
-
-	Server *server = getServer(L);
+	GET_ENV_PTR_NO_MAP_LOCK;
 
 	const char *name = luaL_checkstring(L, 1);
-	RemotePlayer *player = server->getEnv().getPlayer(name);
+	RemotePlayer *player = env->getPlayer(name);
 	if (!player)
 		return 0;
 
+	Server *server = env->getGameDef();
 	auto dynamic = server->getClientDynamicInfo(player->getPeerId());
 
 	if (!dynamic || dynamic->render_target_size == v2u32())
@@ -331,19 +329,16 @@ int ModApiServer::l_get_ban_description(lua_State *L)
 // ban_player()
 int ModApiServer::l_ban_player(lua_State *L)
 {
-	NO_MAP_LOCK_REQUIRED;
+	GET_ENV_PTR_NO_MAP_LOCK;
 
-	if (!getEnv(L))
-		throw LuaError("Can't ban player before server has started up");
-
-	Server *server = getServer(L);
 	const char *name = luaL_checkstring(L, 1);
-	RemotePlayer *player = server->getEnv().getPlayer(name);
+	RemotePlayer *player = env->getPlayer(name);
 	if (!player) {
 		lua_pushboolean(L, false); // no such player
 		return 1;
 	}
 
+	Server *server = env->getGameDef();
 	std::string ip_str = server->getPeerAddress(player->getPeerId()).serializeString();
 	server->setIpBanned(ip_str, name);
 	lua_pushboolean(L, true);
@@ -353,10 +348,7 @@ int ModApiServer::l_ban_player(lua_State *L)
 // disconnect_player(name[, reason[, reconnect]]) -> success
 int ModApiServer::l_disconnect_player(lua_State *L)
 {
-	NO_MAP_LOCK_REQUIRED;
-
-	if (!getEnv(L))
-		throw LuaError("Can't kick player before server has started up");
+	GET_ENV_PTR_NO_MAP_LOCK;
 
 	const char *name = luaL_checkstring(L, 1);
 	std::string message;
@@ -365,9 +357,7 @@ int ModApiServer::l_disconnect_player(lua_State *L)
 	else
 		message.append("Disconnected.");
 
-	Server *server = getServer(L);
-
-	RemotePlayer *player = server->getEnv().getPlayer(name);
+	RemotePlayer *player = env->getPlayer(name);
 	if (!player) {
 		lua_pushboolean(L, false); // No such player
 		return 1;
@@ -375,6 +365,7 @@ int ModApiServer::l_disconnect_player(lua_State *L)
 
 	bool reconnect = readParam<bool>(L, 3, false);
 
+	Server *server = env->getGameDef();
 	server->DenyAccess(player->getPeerId(), SERVER_ACCESSDENIED_CUSTOM_STRING, message, reconnect);
 	lua_pushboolean(L, true);
 	return 1;
@@ -382,15 +373,12 @@ int ModApiServer::l_disconnect_player(lua_State *L)
 
 int ModApiServer::l_remove_player(lua_State *L)
 {
-	NO_MAP_LOCK_REQUIRED;
+	GET_ENV_PTR_NO_MAP_LOCK;
 	std::string name = luaL_checkstring(L, 1);
-	ServerEnvironment *s_env = dynamic_cast<ServerEnvironment *>(getEnv(L));
-	if (!s_env)
-		throw LuaError("Can't remove player before server has started up");
 
-	RemotePlayer *player = s_env->getPlayer(name.c_str());
+	RemotePlayer *player = env->getPlayer(name.c_str());
 	if (!player)
-		lua_pushinteger(L, s_env->removePlayerFromDatabase(name) ? 0 : 1);
+		lua_pushinteger(L, env->removePlayerFromDatabase(name) ? 0 : 1);
 	else
 		lua_pushinteger(L, 2);
 


### PR DESCRIPTION
A few functions tried to dereference a ServerEnvironment nullptr by calling 'getEnv()'. This change makes use of the macro where possible.

Fixes #16456. The additional `luaL_error` call is very likely to reveal more mod bugs.

## To do

This PR is Ready for Review.

## How to test

```lua
core.get_player_information("hello")
core.get_player_ip("hello")
core.get_player_window_information("hello")
core.create_schematic(nil, nil, nil, "hello")
```
