### PR TITLE
Fix macOS workflow homebrew conflict error

### DIFF
--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -35,7 +35,7 @@ install_linux_deps() {
 # macOS build only
 install_macos_deps() {
 	# Uninstall the bundled cmake, it is outdated, and brew does not want to install the newest version with this one present since they are from different taps.
-	brew uninstall cmake
+	brew uninstall cmake || :
 
 	local pkgs=(
 		cmake gettext freetype gmp jpeg-turbo jsoncpp leveldb

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -34,6 +34,9 @@ install_linux_deps() {
 
 # macOS build only
 install_macos_deps() {
+	# Uninstall the bundled cmake, it is outdated, and brew does not want to install the newest version with this one present since they are from different taps.
+	brew uninstall cmake
+	
 	local pkgs=(
 		cmake gettext freetype gmp jpeg-turbo jsoncpp leveldb
 		libogg libpng libvorbis luajit zstd sdl2

--- a/util/ci/common.sh
+++ b/util/ci/common.sh
@@ -36,7 +36,7 @@ install_linux_deps() {
 install_macos_deps() {
 	# Uninstall the bundled cmake, it is outdated, and brew does not want to install the newest version with this one present since they are from different taps.
 	brew uninstall cmake
-	
+
 	local pkgs=(
 		cmake gettext freetype gmp jpeg-turbo jsoncpp leveldb
 		libogg libpng libvorbis luajit zstd sdl2


### PR DESCRIPTION
### Summary

* **Goal of the PR**
  Fix macOS workflows failing to compile due to outdated bundled `cmake`.

* **How does the PR work?**
  Adds a step to uninstall the system-bundled `cmake` in the macOS dependencies install script so that Homebrew can properly install the latest version.

* **Does it resolve any reported issue?**
  Fixes workflow compilation errors on macOS.

---

## To do

This PR is **Ready for Review**

* [x] Verify macOS workflow compiles successfully

---

## How to test

Run the macOS GitHub Actions workflow. It should complete without build errors related to `cmake`.
