### PR TITLE
Builtin profiler: Capture Tracy zones; And small improvements

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,6 +20,7 @@ read_globals = {
 	"profiler",
 	"Settings",
 	"ValueNoise", "ValueNoiseMap",
+	"tracy",
 
 	string = {fields = {"split", "trim"}},
 	table  = {fields = {"copy", "copy_with_metatables", "getn", "indexof", "keyof", "insert_all"}},

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -584,6 +584,7 @@ core.unregister_biome = make_wrap_deregistration(core.register_biome,
 local make_registration = builtin_shared.make_registration
 local make_registration_reverse = builtin_shared.make_registration_reverse
 
+-- keep in sync with profiler/instrumentation.lua
 core.registered_on_chat_messages, core.register_on_chat_message = make_registration()
 core.registered_on_chatcommands, core.register_on_chatcommand = make_registration()
 core.registered_globalsteps, core.register_globalstep = make_registration()

--- a/builtin/profiler/init.lua
+++ b/builtin/profiler/init.lua
@@ -31,10 +31,10 @@ function profiler.init_chatcommand()
 			local args = arg0 and string.split(arg0, " ")
 
 			if command == "dump" then
-				core.log("action", reporter.print(sampler.profile, arg0))
+				core.log("action", reporter.print(sampler.profile, arg0, false))
 				return true, S("Statistics written to action log.")
 			elseif command == "print" then
-				return true, reporter.print(sampler.profile, arg0)
+				return true, reporter.print(sampler.profile, arg0, true)
 			elseif command == "save" then
 				return reporter.save(sampler.profile, args[1] or "txt", args[2])
 			elseif command == "reset" then

--- a/builtin/profiler/init.lua
+++ b/builtin/profiler/init.lua
@@ -4,18 +4,10 @@
 
 local S = core.get_translator("__builtin")
 
-local function get_bool_default(name, default)
-	local val = core.settings:get_bool(name)
-	if val == nil then
-		return default
-	end
-	return val
-end
-
 local profiler_path = core.get_builtin_path().."profiler"..DIR_DELIM
 local profiler = {}
 local sampler = assert(loadfile(profiler_path .. "sampling.lua"))(profiler)
-local instrumentation  = assert(loadfile(profiler_path .. "instrumentation.lua"))(profiler, sampler, get_bool_default)
+local instrumentation  = assert(loadfile(profiler_path .. "instrumentation.lua"))(profiler, sampler)
 local reporter = dofile(profiler_path .. "reporter.lua")
 profiler.instrument = instrumentation.instrument
 
@@ -24,7 +16,7 @@ profiler.instrument = instrumentation.instrument
 -- Is called later, after `core.register_chatcommand` was set up.
 --
 function profiler.init_chatcommand()
-	local instrument_profiler = get_bool_default("instrument.profiler", false)
+	local instrument_profiler = core.settings:get_bool("instrument.profiler", false)
 	if instrument_profiler then
 		instrumentation.init_chatcommand()
 	end

--- a/builtin/profiler/init.lua
+++ b/builtin/profiler/init.lua
@@ -23,7 +23,10 @@ function profiler.init_chatcommand()
 
 	local param_usage = S("print [<filter>] | dump [<filter>] | save [<format> [<filter>]] | reset")
 	core.register_chatcommand("profiler", {
-		description = S("Handle the profiler and profiling data"),
+		description = S("Handle the profiler and profiling data. "
+			.. "Can output to chat (print), action log (dump), or file in world (save). "
+			.. "Format can be one of txt, csv, lua, json, json_pretty (structures may be subject to change). "
+			.. "Filter is a lua pattern used to limit output to matching mod names."),
 		params = param_usage,
 		privs = { server=true },
 		func = function(name, param)
@@ -42,9 +45,7 @@ function profiler.init_chatcommand()
 				return true, S("Statistics were reset.")
 			end
 
-			return false,
-				S("Usage: @1", param_usage) .. "\n" ..
-				S("Format can be one of txt, csv, lua, json, json_pretty (structures may be subject to change).")
+			return false
 		end
 	})
 

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -127,29 +127,29 @@ local function instrument(def)
 		return func
 	end
 
-	-- These tail-calls allows passing all return values of `func`
+	-- These tail-calls allows passing all return values of `func_o`
 	-- also called https://en.wikipedia.org/wiki/Continuation_passing_style
 	-- Compared to table creation and unpacking it won't lose `nil` returns
 	-- and is expected to be faster
-	-- `tracy_ZoneEnd_and_return` / `measure` will be executed after func(...)
+	-- `tracy_ZoneEnd_and_return` / `measure` will be executed after `func_o(...)`
 
-	local func1 = func
 	if do_tracy then
-		func1 = function(...)
+		local func_o = func
+		func = function(...)
 			tracy.ZoneBeginN(instrument_name) --TODO: longer name. *always* include source location
-			return tracy_ZoneEnd_and_return(func(...))
+			return tracy_ZoneEnd_and_return(func_o(...))
 		end
 	end
 
-	local func2 = func1
 	if do_measure then
-		func2 = function(...)
+		local func_o = func
+		func = function(...)
 			local start = time()
-			return measure(modname, instrument_name, start, func1(...))
+			return measure(modname, instrument_name, start, func_o(...))
 		end
 	end
 
-	return func2
+	return func
 end
 
 local function can_be_called(func)

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -2,7 +2,7 @@
 -- Copyright (C) 2016 T4im
 -- SPDX-License-Identifier: LGPL-2.1-or-later
 
-local format, pairs, type = string.format, pairs, type
+local format, ipairs, type = string.format, ipairs, type
 local core, get_current_modname = core, core.get_current_modname
 local profiler, sampler = ...
 

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -4,9 +4,9 @@
 
 local format, pairs, type = string.format, pairs, type
 local core, get_current_modname = core, core.get_current_modname
-local profiler, sampler, get_bool_default = ...
+local profiler, sampler = ...
 
-local instrument_builtin = get_bool_default("instrument.builtin", false)
+local instrument_builtin = core.settings:get_bool("instrument.builtin", false)
 
 local register_functions = {
 	register_globalstep = 0,
@@ -144,7 +144,7 @@ local function instrument_register(func, func_name)
 end
 
 local function init_chatcommand()
-	if get_bool_default("instrument.chatcommand", true) then
+	if core.settings:get_bool("instrument.chatcommand", true) then
 		local orig_register_chatcommand = core.register_chatcommand
 		core.register_chatcommand = function(cmd, def)
 			def.func = instrument {
@@ -160,7 +160,7 @@ end
 -- Start instrumenting selected functions
 --
 local function init()
-	if get_bool_default("instrument.entity", true) then
+	if core.settings:get_bool("instrument.entity", true) then
 		-- Explicitly declare entity api-methods.
 		-- Simple iteration would ignore lookup via __index.
 		local entity_instrumentation = {
@@ -187,7 +187,7 @@ local function init()
 		end
 	end
 
-	if get_bool_default("instrument.abm", true) then
+	if core.settings:get_bool("instrument.abm", true) then
 		-- Wrap register_abm() to automatically instrument abms.
 		local orig_register_abm = core.register_abm
 		core.register_abm = function(spec)
@@ -200,7 +200,7 @@ local function init()
 		end
 	end
 
-	if get_bool_default("instrument.lbm", true) then
+	if core.settings:get_bool("instrument.lbm", true) then
 		-- Wrap register_lbm() to automatically instrument lbms.
 		local orig_register_lbm = core.register_lbm
 		core.register_lbm = function(spec)
@@ -214,13 +214,13 @@ local function init()
 		end
 	end
 
-	if get_bool_default("instrument.global_callback", true) then
+	if core.settings:get_bool("instrument.global_callback", true) then
 		for func_name, _ in pairs(register_functions) do
 			core[func_name] = instrument_register(core[func_name], func_name)
 		end
 	end
 
-	if get_bool_default("instrument.profiler", false) then
+	if core.settings:get_bool("instrument.profiler", false) then
 		-- Measure overhead of instrumentation, but keep it down for functions
 		-- So keep the `return` for better optimization.
 		profiler.empty_instrument = instrument {

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -173,17 +173,17 @@ local function init()
 		}
 		-- Wrap register_entity() to instrument them on registration.
 		local orig_register_entity = core.register_entity
-		core.register_entity = function(name, prototype)
+		core.register_entity = function(name, def)
 			local modname = get_current_modname()
-			for _, func_name in pairs(entity_instrumentation) do
-				prototype[func_name] = instrument {
-					func = prototype[func_name],
+			for _, func_name in ipairs(entity_instrumentation) do
+				def[func_name] = instrument {
+					func = def[func_name],
 					mod = modname,
 					func_name = func_name,
-					label = prototype.label,
+					label = name,
 				}
 			end
-			orig_register_entity(name,prototype)
+			orig_register_entity(name, def)
 		end
 	end
 

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -8,29 +8,44 @@ local profiler, sampler = ...
 
 local instrument_builtin = core.settings:get_bool("instrument.builtin", false)
 
+-- keep in sync with game/register.lua
 local register_functions = {
-	register_globalstep = 0,
-	register_playerevent = 0,
-	register_on_placenode = 0,
-	register_on_dignode = 0,
-	register_on_punchnode = 0,
-	register_on_generated = 0,
-	register_on_newplayer = 0,
-	register_on_dieplayer = 0,
-	register_on_respawnplayer = 0,
-	register_on_prejoinplayer = 0,
-	register_on_joinplayer = 0,
-	register_on_leaveplayer = 0,
-	register_on_cheat = 0,
-	register_on_chat_message = 0,
-	register_on_player_receive_fields = 0,
-	register_on_craft = 0,
-	register_craft_predict = 0,
-	register_on_protection_violation = 0,
-	register_on_item_eat = 0,
-	register_on_punchplayer = 0,
-	register_on_player_hpchange = 0,
-	register_on_mapblocks_changed = 0,
+	"register_on_player_hpchange",
+
+	"register_on_chat_message",
+	"register_on_chatcommand",
+	"register_globalstep",
+	"register_playerevent",
+	"register_on_mods_loaded",
+	"register_on_shutdown",
+	"register_on_punchnode",
+	"register_on_placenode",
+	"register_on_dignode",
+	"register_on_generated",
+	"register_on_newplayer",
+	"register_on_dieplayer",
+	"register_on_respawnplayer",
+	"register_on_prejoinplayer",
+	"register_on_joinplayer",
+	"register_on_leaveplayer",
+	"register_on_player_receive_fields",
+	"register_on_cheat",
+	"register_on_craft",
+	"register_craft_predict",
+	"register_on_protection_violation",
+	"register_on_item_eat",
+	"register_on_item_pickup",
+	"register_on_punchplayer",
+	"register_on_priv_grant",
+	"register_on_priv_revoke",
+	"register_on_authplayer",
+	"register_can_bypass_userlimit",
+	"register_on_modchannel_message",
+	"register_on_player_inventory_action",
+	"register_allow_player_inventory_action",
+	"register_on_rightclickplayer",
+	"register_on_liquid_transformed",
+	"register_on_mapblocks_changed",
 }
 
 local function regex_escape(s)
@@ -135,7 +150,6 @@ local function instrument_register(func, func_name)
 	local register_name = func_name:gsub("^register_", "", 1)
 	return function(callback, ...)
 		assert_can_be_called(callback, func_name, 2)
-		register_functions[func_name] = register_functions[func_name] + 1
 		return func(instrument {
 			func = callback,
 			func_name = register_name
@@ -168,7 +182,11 @@ local function init()
 			"on_deactivate",
 			"on_step",
 			"on_punch",
+			"on_death",
 			"on_rightclick",
+			"on_attach_child",
+			"on_detach_child",
+			"on_detach",
 			"get_staticdata",
 		}
 		-- Wrap register_entity() to instrument them on registration.
@@ -215,7 +233,7 @@ local function init()
 	end
 
 	if core.settings:get_bool("instrument.global_callback", true) then
-		for func_name, _ in pairs(register_functions) do
+		for _, func_name in ipairs(register_functions) do
 			core[func_name] = instrument_register(core[func_name], func_name)
 		end
 	end
@@ -233,7 +251,6 @@ local function init()
 end
 
 return {
-	register_functions = register_functions,
 	instrument = instrument,
 	init = init,
 	init_chatcommand = init_chatcommand,

--- a/builtin/profiler/reporter.lua
+++ b/builtin/profiler/reporter.lua
@@ -168,7 +168,7 @@ local CsvFormatter = Formatter:new {
 	end
 }
 
-local function format_statistics(profile, format, filter)
+local function format_statistics(profile, format, filter, enable_translation)
 	local formatter
 	if format == "csv" then
 		formatter = CsvFormatter:new {
@@ -180,16 +180,20 @@ local function format_statistics(profile, format, filter)
 		}
 	end
 	formatter:format(filter)
-	return formatter:flush()
+	local out = formatter:flush()
+	if not enable_translation then
+		out = core.get_translated_string("en", out)
+	end
+	return out
 end
 
 ---
 -- Format the profile ready for display and
 -- @return string to be printed to the console
 --
-function reporter.print(profile, filter)
+function reporter.print(profile, filter, enable_translation)
 	if filter == "" then filter = nil end
-	return format_statistics(profile, "txt", filter)
+	return format_statistics(profile, "txt", filter, enable_translation)
 end
 
 ---
@@ -215,7 +219,7 @@ local function serialize_profile(profile, format, filter)
 		end
 	end
 	-- Fall back to textual formats.
-	return format_statistics(profile, format, filter)
+	return format_statistics(profile, format, filter, false)
 end
 
 local worldpath = core.get_worldpath()

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1943,6 +1943,14 @@ enable_mod_channels (Mod channels) [server] bool false
 #    Useful for mod developers and server operators.
 profiler.load (Load the game profiler) bool false
 
+#    Disable if you only want to instrument with Tracy.
+profiler.measure (Measure time samples) bool true
+
+#    Capture Tracy zones with the profiler's instrumentation.
+#    You need to build with Tracy to use this, see doc/developing/profiling.md
+#    for details.
+profiler.tracy (Capture Tracy zones) bool false
+
 #    The default format in which profiles are being saved,
 #    when calling `/profiler save [format]` without format.
 profiler.default_report_format (Default report format) enum txt txt,csv,lua,json,json_pretty

--- a/doc/developing/profiling.md
+++ b/doc/developing/profiling.md
@@ -101,3 +101,6 @@ See Tracy's official documentation for more information.
 
 Note: The whole Tracy Lua API is accessible to all mods. And we don't check if it
 is or becomes insecure. Run untrusted mods at your own risk.
+
+Enable `profiler.load` and `profiler.tracy` to automatically instrument mod
+callback functions.

--- a/doc/developing/profiling.md
+++ b/doc/developing/profiling.md
@@ -1,5 +1,19 @@
 # Profiling
 
+## Using builtin's mod profiler
+
+Builtin has a pr
+
+To start, enable the `profiler.load` setting.
+(There are more settings, see `profiler.*` and `instrument.*`.)
+
+Use the `profiler` chatcommand to look at the results.
+
+TODO: explain output
+(what are the mod rows, and total?)
+(what happens when a callback is not, or multiple times, called in one server step?)
+
+
 ## Profiling Luanti on Linux with perf
 
 We will be using a tool called "perf", which you can get by installing `perf` or `linux-perf` or `linux-tools-common`.

--- a/doc/developing/profiling.md
+++ b/doc/developing/profiling.md
@@ -2,16 +2,13 @@
 
 ## Using builtin's mod profiler
 
-Builtin has a pr
+Builtin has a profiler for callbacks registered by mods. It measures how much
+time each callback took per server-step (on average / min / max).
 
 To start, enable the `profiler.load` setting.
 (There are more settings, see `profiler.*` and `instrument.*`.)
 
 Use the `profiler` chatcommand to look at the results.
-
-TODO: explain output
-(what are the mod rows, and total?)
-(what happens when a callback is not, or multiple times, called in one server step?)
 
 
 ## Profiling Luanti on Linux with perf

--- a/doc/developing/profiling.md
+++ b/doc/developing/profiling.md
@@ -79,12 +79,15 @@ Build Luanti with `-DDBUILD_WITH_TRACY=1`, this will fetch Tracy for building
 the Tracy client. And use `FETCH_TRACY_GIT_TAG` to get a version matching your
 Tracy server, e.g. `-DFETCH_TRACY_GIT_TAG=v0.11.0` if it's `0.11.0`.
 
-To actually use Tracy, you also have to enable it with Tracy's build options:
-```
--DTRACY_ENABLE=1 -DTRACY_ONLY_LOCALHOST=1
-```
+To actually use Tracy, you also have to enable it with Tracy's build options
+(`-DTRACY_ENABLE=1`).
 
 See Tracy's documentation for more build options.
+
+TL;DR:
+```
+-DDBUILD_WITH_TRACY=1 -DFETCH_TRACY_GIT_TAG=<your_version> -DTRACY_ENABLE=1 -DTRACY_ONLY_LOCALHOST=1
+```
 
 ### Using in C++
 


### PR DESCRIPTION
* Feature: Use the builtin profiler to automatically make zones for mod callback functions.
  * This is useful for modders and other users to find out which parts of which mods are responsible for lag spikes, or for making the server start slow.
  * (No 100% coverage. If a part of AsyncRunStep is not taken up by a mod callback, it's either (1) the engine doing things (this can also be caused by a mod, if it gave the engine much work to do), (2) the engine waiting on something (e.g. env lock), or (3) a mod callback not recognized by the builtin profiler. Users should add ZoneScopeds in the engine to get more details.)
* Doc: Basic doc for builtin profiler, and better `/profiler` chatcommand help.
* Fix: `register_functions` (table of callback register function names), and `entity_instrumentation` is no longer outdated.
* Fix: Builtin profiler output is no longer printed to debug.txt or to file in world with translation escapes.
* Fix: Entity callback name generation used `obj_def.label` (normally non-existing field), now it uses the entity name.
* Small code improvements, like use of new `Settings.get_bool` with default.

## To do

This PR is a Ready for Review.

## How to test

* See doc.
