### PR TITLE
Interpolate client position updates for content_caos

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1540,7 +1540,7 @@ void GenericCAO::processMessage(const std::string &data)
 	} else if (cmd == AO_CMD_UPDATE_POSITION) {
 		// Not sent by the server if this object is an attachment.
 		// We might however get here if the server notices the object being detached before the client.
-		m_position = readV3F32(is);
+		v3f newpos = readV3F32(is);
 		m_velocity = readV3F32(is);
 		m_acceleration = readV3F32(is);
 		m_rotation = readV3F32(is);
@@ -1549,6 +1549,13 @@ void GenericCAO::processMessage(const std::string &data)
 		bool do_interpolate = readU8(is);
 		bool is_end_position = readU8(is);
 		float update_interval = readF32(is);
+
+		// interpolate position if it's off less than 1 node
+		// 17.3 ~= sqrt(3) * BS
+		if (do_interpolate && newpos.getDistanceFrom(m_position) < 17.3f)
+			m_position = m_position * 0.9f + newpos * 0.1f;
+		else
+			m_position = newpos;
 
 		if(getParent() != NULL) // Just in case
 			return;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1540,7 +1540,7 @@ void GenericCAO::processMessage(const std::string &data)
 	} else if (cmd == AO_CMD_UPDATE_POSITION) {
 		// Not sent by the server if this object is an attachment.
 		// We might however get here if the server notices the object being detached before the client.
-		v3f newpos = readV3F32(is);
+		m_position = readV3F32(is);
 		m_velocity = readV3F32(is);
 		m_acceleration = readV3F32(is);
 		m_rotation = readV3F32(is);
@@ -1549,13 +1549,6 @@ void GenericCAO::processMessage(const std::string &data)
 		bool do_interpolate = readU8(is);
 		bool is_end_position = readU8(is);
 		float update_interval = readF32(is);
-
-		// interpolate position if it's off less than 1 node
-		// 17.3 ~= sqrt(3) * BS
-		if (do_interpolate && newpos.getDistanceFrom(m_position) < 17.3f)
-			m_position = m_position * 0.9f + newpos * 0.1f;
-		else
-			m_position = newpos;
 
 		if(getParent() != NULL) // Just in case
 			return;

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1098,7 +1098,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 		pos_translator.val_current = m_position;
 		pos_translator.val_target = m_position;
 	} else {
-		rot_translator.translate(dtime);
+		rot_translator.translate(dtime * 0.1f);
 		v3f lastpos = pos_translator.val_current;
 
 		if(m_prop.physical)
@@ -1125,7 +1125,7 @@ void GenericCAO::step(float dtime, ClientEnvironment *env)
 			pos_translator.update(m_position, pos_translator.aim_is_end,
 					pos_translator.anim_time);
 		}
-		pos_translator.translate(dtime);
+		pos_translator.translate(dtime * 0.1f);
 		updateNodePos();
 
 		float moved = lastpos.getDistanceFrom(pos_translator.val_current);


### PR DESCRIPTION
Consider this an experiment.
There are many sources of jitter for active objects.
One category of jitter is client/server position estimates getting out of sync, which then causes jitter when the server sends its next update and the position is jerked back to the server position.

This is an attempt to reduce that impact. When the difference between position is less than 1 node, the client will interpolate instead. That helps with varying server steps and latencies, and does not cause real problems as larger difference are still hard-reset on the client.

The main problem is that client and server will perform (improved Euler) integration (of acceleration, speed -> position) based on different time intervals, and "always" come to slightly different estimates in between server updates. I would consider this crutch, still.

## To do

This PR is a Work in Progress.

TODO: testing, feedback, discussion

## How to test

Join any world with mobs, observe their movements. Have any objects you can attach to (steampunk blimps or hot air balloon, or any test entity), observe how much (or not) the world is jittering around you.
In my tests this reduces jitter a lot, while not impairing collision detection.
