### PR TITLE
In-Game server should use dedicated_server_step

### DIFF
--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -2567,20 +2567,14 @@ inline void Game::step(f32 dtime)
 	ZoneScoped;
 
 	if (server) {
-		float fps_max = !device->isWindowFocused() && simple_singleplayer_mode ?
-				g_settings->getFloat("fps_max_unfocused") :
-				g_settings->getFloat("fps_max");
-		fps_max = std::max(fps_max, 1.0f);
-		/*
-		 * Unless you have a barebones game, running the server at more than 60Hz
-		 * is hardly realistic and you're at the point of diminishing returns.
-		 * fps_max is also not necessarily anywhere near the FPS actually achieved
-		 * (also due to vsync).
-		 */
-		fps_max = std::min(fps_max, 60.0f);
+		float server_step;
+		if(!device->isWindowFocused() && simple_singleplayer_mode)
+			server_step = 1.0f / std::max(g_settings->getFloat("fps_max_unfocused"), 1.0f);
+		else
+			server_step = g_settings->getFloat("dedicated_server_step");
 
 		server->setStepSettings(Server::StepSettings{
-				1.0f / fps_max,
+				server_step,
 				m_is_paused
 			});
 

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -440,7 +440,7 @@ void set_default_settings()
 	settings->setDefault("strict_protocol_version_checking", "false");
 	settings->setDefault("protocol_version_min", "1");
 	settings->setDefault("player_transfer_distance", "0");
-	settings->setDefault("max_simultaneous_block_sends_per_client", "40");
+	settings->setDefault("max_simultaneous_block_sends_per_client", "160");
 
 	settings->setDefault("motd", "");
 	settings->setDefault("max_users", "15");
@@ -496,9 +496,9 @@ void set_default_settings()
 	settings->setDefault("debug_log_level", "action");
 	settings->setDefault("debug_log_size_max", "50");
 	settings->setDefault("chat_log_level", "error");
-	settings->setDefault("emergequeue_limit_total", "1024");
-	settings->setDefault("emergequeue_limit_diskonly", "128");
-	settings->setDefault("emergequeue_limit_generate", "128");
+	settings->setDefault("emergequeue_limit_total", "4096");
+	settings->setDefault("emergequeue_limit_diskonly", "512");
+	settings->setDefault("emergequeue_limit_generate", "512");
 	settings->setDefault("num_emerge_threads", "1");
 	settings->setDefault("secure.enable_security", "true");
 	settings->setDefault("secure.trusted_mods", "");
@@ -560,9 +560,9 @@ void set_default_settings()
 	settings->setDefault("screen_w", "0");
 	settings->setDefault("screen_h", "0");
 	settings->setDefault("performance_tradeoffs", "true");
-	settings->setDefault("max_simultaneous_block_sends_per_client", "10");
-	settings->setDefault("emergequeue_limit_diskonly", "16");
-	settings->setDefault("emergequeue_limit_generate", "16");
+	settings->setDefault("max_simultaneous_block_sends_per_client", "40");
+	settings->setDefault("emergequeue_limit_diskonly", "64");
+	settings->setDefault("emergequeue_limit_generate", "64");
 	settings->setDefault("max_block_generate_distance", "5");
 	settings->setDefault("sqlite_synchronous", "1");
 	settings->setDefault("server_map_save_interval", "15");


### PR DESCRIPTION
Based on IRC discussion and some testing... For your consideration.
With this change, an in-game server will `dedicated_server_step` seconds as its step length, just like a separate standalone server would.
This also adjusts the emerge queues accordingly. Before we tried to use 60hz (i.e. 0.0166...), now with the default of 0.09 the default server step is 5.4x longer. To be conservative I only adjust the queue sizes by 4x.

## Discussion

I assume this will spark a lot of discussion. I just wanted to put a stake in the ground around which we can discuss. I am certainly not emotionally attached to this change.

## Alternatives

1. Do nothing. Physics between standalone and in-game server will be subtly different.
2. Introduce a new setting `ingame_server_step` (or similar) instead.

## To do

This PR is Ready for Review.

## How to test

Load any world in singleplayer mode (or hosted server via the UI). The server step is now identical to what a standalone server would do.
