### PR TITLE
Add missing IsWritable checks

### DIFF
--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -375,7 +375,7 @@ bool CGUIEditBox::processKey(const SEvent &event)
 			}
 			break;
 		case KEY_INSERT:
-			if (!isEnabled())
+			if (!isEnabled() || !IsWritable)
 				break;
 
 			OverwriteMode = !OverwriteMode;
@@ -865,7 +865,7 @@ void CGUIEditBox::draw()
 		}
 
 		// draw cursor
-		if (isEnabled()) {
+		if (isEnabled() && IsWritable) {
 			if (WordWrap || MultiLine) {
 				cursorLine = getLineFromPos(CursorPos);
 				txtLine = &BrokenText[cursorLine];
@@ -1312,7 +1312,7 @@ void CGUIEditBox::inputChar(wchar_t c)
 
 void CGUIEditBox::inputString(const core::stringw &str)
 {
-	if (!isEnabled())
+	if (!isEnabled() || !IsWritable)
 		return;
 
 	core::stringw s;


### PR DESCRIPTION
Fixes https://irc.luanti.org/luanti/2025-09-21#i_6285409

## How to test
* Enter the pause menu
* Click on the version test. Check that the cursor no longer appears.
* Check that version text can no longer be entered with keypresses.
* Check that version text can no longer be entered with Ctrl-V.
* Check that Ctrl-C and Ctrl-X only copies the selected portion of the version text.
* Check that the above keybindings and text input work as usual in writable edit boxes.