### PR TITLE
Fix debug.getinfo not being unset in CPCSM

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -41,7 +41,7 @@ stds.menu_common = {
 	},
 }
 
-files["builtin/client/register.lua"] = {
+files["builtin/client/init.lua"] = {
 	globals = {
 		debug = {fields={"getinfo"}},
 	}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -47,6 +47,12 @@ files["builtin/client/register.lua"] = {
 	}
 }
 
+files["builtin/sscsm_client/init.lua"] = {
+	globals = {
+		debug = {fields={"getinfo"}},
+	}
+}
+
 files["builtin/common/math.lua"] = {
 	globals = {
 		"math",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -47,12 +47,6 @@ files["builtin/client/init.lua"] = {
 	}
 }
 
-files["builtin/sscsm_client/init.lua"] = {
-	globals = {
-		debug = {fields={"getinfo"}},
-	}
-}
-
 files["builtin/common/math.lua"] = {
 	globals = {
 		"math",

--- a/builtin/client/init.lua
+++ b/builtin/client/init.lua
@@ -13,3 +13,6 @@ dofile(commonpath .. "information_formspecs.lua")
 dofile(clientpath .. "chatcommands.lua")
 dofile(clientpath .. "misc.lua")
 assert(loadfile(commonpath .. "item_s.lua"))({}) -- Just for push/read node functions
+
+-- unset, as promised in initializeSecurityClient()
+debug.getinfo = nil

--- a/builtin/common/register.lua
+++ b/builtin/common/register.lua
@@ -1,4 +1,5 @@
 local builtin_shared = ...
+local debug_getinfo = debug.getinfo
 
 do
 	local default = {mod = "??", name = "??"}
@@ -56,7 +57,7 @@ function builtin_shared.make_registration()
 		core.callback_origins[func] = {
 			-- may be nil or return nil
 			mod = core.get_current_modname and core.get_current_modname() or "??",
-			name = debug.getinfo(1, "n").name or "??"
+			name = debug_getinfo(1, "n").name or "??"
 		}
 	end
 	return t, registerfunc
@@ -69,7 +70,7 @@ function builtin_shared.make_registration_reverse()
 		core.callback_origins[func] = {
 			-- may be nil or return nil
 			mod = core.get_current_modname and core.get_current_modname() or "??",
-			name = debug.getinfo(1, "n").name or "??"
+			name = debug_getinfo(1, "n").name or "??"
 		}
 	end
 	return t, registerfunc

--- a/builtin/common/strict.lua
+++ b/builtin/common/strict.lua
@@ -1,4 +1,4 @@
-local getinfo, rawget, rawset = debug.getinfo, rawget, rawset
+local debug_getinfo, rawget, rawset = debug.getinfo, rawget, rawset
 
 function core.global_exists(name)
 	if type(name) ~= "string" then
@@ -18,7 +18,7 @@ function meta:__newindex(name, value)
 	if declared[name] then
 		return
 	end
-	local info = getinfo(2, "Sl")
+	local info = debug_getinfo(2, "Sl")
 	if info ~= nil then
 		local desc = ("%s:%d"):format(info.short_src, info.currentline)
 		local warn_key = ("%s\0%d\0%s"):format(info.source, info.currentline, name)
@@ -36,7 +36,7 @@ function meta:__index(name)
 	if declared[name] then
 		return
 	end
-	local info = getinfo(2, "Sl")
+	local info = debug_getinfo(2, "Sl")
 	if info == nil then
 		return
 	end

--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -1,5 +1,6 @@
 local builtin_shared = ...
 local S = core.get_translator("__builtin")
+local debug_getinfo = debug.getinfo
 
 --
 -- Make raw registration functions inaccessible to anyone except this file
@@ -548,7 +549,7 @@ function core.registered_on_player_hpchange(player, hp_change, reason)
 		local func = core.registered_on_player_hpchanges.modifiers[i]
 		hp_change, last = func(player, hp_change, reason)
 		if type(hp_change) ~= "number" then
-			local debuginfo = debug.getinfo(func)
+			local debuginfo = debug_getinfo(func)
 			error("The register_on_hp_changes function has to return a number at " ..
 				debuginfo.short_src .. " line " .. debuginfo.linedefined)
 		end
@@ -570,7 +571,7 @@ function core.register_on_player_hpchange(func, modifier)
 	end
 	core.callback_origins[func] = {
 		mod = core.get_current_modname() or "??",
-		name = debug.getinfo(1, "n").name or "??"
+		name = debug_getinfo(1, "n").name or "??"
 	}
 end
 

--- a/builtin/profiler/instrumentation.lua
+++ b/builtin/profiler/instrumentation.lua
@@ -5,6 +5,7 @@
 local format, ipairs, type = string.format, ipairs, type
 local core, get_current_modname = core, core.get_current_modname
 local profiler, sampler = ...
+local debug_getinfo = debug.getinfo
 
 local instrument_builtin = core.settings:get_bool("instrument.builtin", false)
 
@@ -67,7 +68,7 @@ local worldmods_path = regex_escape(core.get_worldpath())
 local user_path = regex_escape(core.get_user_path())
 local builtin_path = regex_escape(core.get_builtin_path())
 local function generate_source_location(def)
-	local info = debug.getinfo(def.func)
+	local info = debug_getinfo(def.func)
 	local modpath = regex_escape(core.get_modpath(def.mod) or "")
 	local source = info.source
 	if modpath ~= "" then

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -309,7 +309,7 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"time"
 	};
 	static const char *debug_whitelist[] = {
-		"getinfo", // used by builtin and unset before mods load <- FIXME: doesn't actually happen
+		"getinfo", // used by builtin and unset before mods load
 		"traceback"
 	};
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -309,7 +309,7 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"time"
 	};
 	static const char *debug_whitelist[] = {
-		"getinfo", // used by builtin and unset before mods load
+		"getinfo", // used by builtin and unset before mods load <- FIXME: doesn't actually happen
 		"traceback"
 	};
 


### PR DESCRIPTION
Fixes a regression from eeb6cab4c4304cba92a77c2e759fcdde9dc0bcd1.

`debug.getinfo` is supposed to be unset in cpcsm:
https://github.com/luanti-org/luanti/blob/5f5ea132516d8a55aca48c5c40e1198b0486afa5/src/script/cpp_api/s_security.cpp#L312

(Commits taken from #15818.)

## To do

This PR is a Ready for Review.

## How to test

* Look if debug.getinfo is available in cpcsm: `.lua return dump(debug.getinfo)` (<https://github.com/Desour/calculator>)
  (should be `nil`)
* Look if debug.getinfo is available in ssm: `/lua return dump(debug.getinfo)` (<https://github.com/Desour/luacmd>)
  (should be `<function>`)
* Enable builtin profiler to check that it still works.