### PR TITLE
Fix comment in client.h

### DIFF
--- a/src/client/client.h
+++ b/src/client/client.h
@@ -523,7 +523,7 @@ private:
 	// The authentication methods we can use to enter sudo mode (=change password)
 	u32 m_sudo_auth_methods;
 
-	// The seed returned by the server in TOCLIENT_INIT is stored here
+	// The seed returned by the server in TOCLIENT_AUTH_ACCEPT is stored here
 	u64 m_map_seed = 0;
 
 	// Auth data


### PR DESCRIPTION
The goal is to correct a comment. TOCLIENT_INIT is deprecated, and the map seed is sent in TOCLIENT_AUTH_ACCEPT instead. No need to test as this is a documentation update.

https://github.com/luanti-org/luanti/blob/421835a30ebe46e4712cb2b0fe3787ae8ef0a674/util/wireshark/minetest.lua#L547

https://github.com/luanti-org/luanti/blob/421835a30ebe46e4712cb2b0fe3787ae8ef0a674/util/wireshark/minetest.lua#L511-L519