### PR TITLE
Mapgen: Correct border block criteria

### DIFF
--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -339,7 +339,9 @@ void ServerMap::finishBlockMake(BlockMakeData *data,
 
 		/* Border blocks are grabbed during
 		   generation but mustn't be marked generated. */
-		if (bp >= bpmin && bp <= bpmax) {
+		if (bp.X >= bpmin.X && bp.X <= bpmax.X
+				&& bp.Y >= bpmin.Y && bp.Y <= bpmax.Y
+				&& bp.Z >= bpmin.Z && bp.Z <= bpmax.Z) {
 			block->setGenerated(true);
 			// Set timestamp to ensure correct application
 			// of LBMs and other stuff.


### PR DESCRIPTION
* servermap.cpp (ServerMap::finishBlockMake): Don't compare vectors with a total order function.

This addresses a regression from e86d2fea8.

*This patch was provided by repetitivestrain on IRC.*

Fixes #16516

## To do

This PR is Ready for Review.

## How to test

1. Check for light artifacts as mentioned in #16516
