### PR TITLE
Enable strip_color_codes by default

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -1078,7 +1078,7 @@ csm_restriction_noderange (Client-side node lookup range restriction) int 0 0 42
 
 #    Remove color codes from incoming chat messages
 #    Use this to stop players from being able to use color in their messages
-strip_color_codes (Strip color codes) bool false
+strip_color_codes (Strip color codes) bool true
 
 #    Set the maximum length of a chat message (in characters) sent by clients.
 chat_message_max_size (Chat message max length) int 500 10 65535

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -422,7 +422,7 @@ void set_default_settings()
 #endif
 
 	// Server
-	settings->setDefault("strip_color_codes", "false");
+	settings->setDefault("strip_color_codes", "true");
 #ifndef NDEBUG
 	settings->setDefault("random_mod_load_order", "true");
 #else


### PR DESCRIPTION
previously: #11849

The ways to enter color codes are very limited and it should be an intentional decision by server owners to allow this.

## To do

This PR is Ready for Review.
