### PR TITLE
[no sq] Minor NixOS-related changes

### DIFF
--- a/irr/src/CIrrDeviceSDL.h
+++ b/irr/src/CIrrDeviceSDL.h
@@ -17,11 +17,6 @@
 #endif
 
 #include <SDL.h>
-// DirectFB is removed in SDL3, thou distribution as Alpine currently ships SDL2
-// with enabled DirectFB, but requiring another fix at a top of SDL2.
-// We don't need DirectFB in Irrlicht/Minetest, so simply disable it here to prevent issues.
-#undef SDL_VIDEO_DRIVER_DIRECTFB
-#include <SDL_syswm.h>
 
 #include <memory>
 #include <unordered_map>

--- a/shell.nix
+++ b/shell.nix
@@ -13,12 +13,14 @@ pkgs.mkShell {
     pkgs.libjpeg
     pkgs.libpng
     pkgs.libGL
+    pkgs.luajit
     pkgs.SDL2
     pkgs.openal
     pkgs.curl
     pkgs.libvorbis
     pkgs.libogg
     pkgs.gettext
+    pkgs.gmp
     pkgs.freetype
     pkgs.sqlite
   ];


### PR DESCRIPTION
* Commit 1: should be self-explanatory; both dependencies tend to be (at least) nice to have when building Luanti
* Commit 2: `SDL_syswm.h` appears to be unused and can still cause X11-related headers to be included (i.e. required) even in Wayland (I suppose this is also related to how SDL is built for the distro though?)

## How to test

:shrug: