### PR TITLE
Fix invalid duplicate provides tag in AppStream metainfo

### DIFF
--- a/misc/org.luanti.luanti.metainfo.xml
+++ b/misc/org.luanti.luanti.metainfo.xml
@@ -3,6 +3,7 @@
     <id>org.luanti.luanti</id>
     <provides>
         <id>net.minetest.minetest</id>
+        <binary>luanti</binary>
     </provides>
     <replaces>
         <id>net.minetest.minetest</id>
@@ -164,10 +165,6 @@
     <url type="help">https://docs.luanti.org</url>
     <url type="vcs-browser">https://github.com/luanti-org/luanti</url>
     <url type="contribute">https://www.luanti.org/get-involved</url>
-
-    <provides>
-        <binary>luanti</binary>
-    </provides>
 
     <translation type="gettext">luanti</translation>
 


### PR DESCRIPTION
AppStream doesn't seem to like the duplicated `<provides>` elements.

## To do

This PR is Ready for Review.

## How to test

```
$ appstreamcli validate misc/org.luanti.luanti.metainfo.xml 
I: org.luanti.luanti:61: description-first-para-too-short
     Luanti is a block-based sandbox game platform.
E: org.luanti.luanti:168: tag-duplicated provides

✘ Validation failed: errors: 1, infos: 1, pedantic: 3
```
