### PR TITLE
settingtypes.txt: float and int without max but with min

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -40,6 +40,7 @@
 # `type_args` can be:
 #   * int:
 #            - default
+#            - default min
 #            - default min max
 #   * string:
 #            - default (if default is not specified then "" is set)
@@ -47,8 +48,10 @@
 #            - default
 #   * float:
 #            - default
+#            - default min
 #            - default min max
 #   * enum:
+#            Empty string "" is a valid enum value
 #            - default value1,value2,...
 #   * path:
 #            - default (if default is not specified then "" is set)
@@ -866,7 +869,7 @@ formspec_fullscreen_bg_color (Formspec Full-Screen Background Color) string (0,0
 gui_scaling_filter (GUI scaling filter) bool false
 
 #    Delay showing tooltips, stated in milliseconds.
-tooltip_show_delay (Tooltip delay) int 400 0 18446744073709551615
+tooltip_show_delay (Tooltip delay) int 400 0
 
 #    Append item name to tooltip.
 tooltip_append_itemname (Append item name) bool false


### PR DESCRIPTION
# Things done

- Document in settingtypes.txt that int and float types can specify a min value without specifying a max value.
  - examples found in existing code:
    - contentdb_max_concurrent_downloads, time_speed, anticheat_movement_tolerance and more
- remove one occurence of the maximum value of uint64 as max for tooltip_show_delay
  - since leaving max blank is a valid and working solution its not needed to put the max value there
- Document that enum values can be empty string. (usage found in setting "language")


- Goal of the PR

consistency between documenting comment at the beginning of the file and actual usage

- How does the PR work?
- Does it resolve any reported issue?
no
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  - section 2.2
- If not a bug fix, why is this PR needed? What usecases does it solve?
fixing documentation is important to reduce future confusioin
removing the explicit max value enables for future replacement of integer type without breakage

## To do

Ready for Review.
<!-- ^ delete one -->

## How to test

build luanti and try to set the modified settings

i tested it on nixos with

```nix
pkgs.luanti.overrideAttrs (old: {
            src = pkgs.fetchFromGitHub {
              owner = "lomenzel";
              repo = "luanti";
              rev = "65224b9ad6d9234185c095f87980b924c25bfbe8";
              sha256 = "sha256-5khUTsJjPfnZan06VHwtq4nMDIyJa/aXjdVHha1RjWs=";
            };
            version = "lomenzel-patch";
})
```


<!-- Example code or instructions -->
