### PR TITLE
[no squash] Make static world lighting (light curve & AO) configurable via API

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -529,12 +529,6 @@ fov (Field of view) int 72 45 160
 #    light, it has very little effect on natural night light.
 display_gamma (Light curve gamma) float 1.0 0.33 3.0
 
-#    The strength (darkness) of node ambient-occlusion shading.
-#    Lower is darker, Higher is lighter. The valid range of values for this
-#    setting is 0.25 to 4.0 inclusive. If the value is out of range it will be
-#    set to the nearest valid value.
-ambient_occlusion_gamma (Ambient occlusion gamma) float 1.8 0.25 4.0
-
 [**Screenshots]
 
 #    Path to save screenshots at. Can be an absolute or relative path.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -547,12 +547,6 @@ fov (Field of view) int 72 45 160
 #    light, it has very little effect on natural night light.
 display_gamma (Light curve gamma) float 1.0 0.33 3.0
 
-#    The strength (darkness) of node ambient-occlusion shading.
-#    Lower is darker, Higher is lighter. The valid range of values for this
-#    setting is 0.25 to 4.0 inclusive. If the value is out of range it will be
-#    set to the nearest valid value.
-ambient_occlusion_gamma (Ambient occlusion gamma) float 1.8 0.25 4.0
-
 [**Screenshots]
 
 #    Path to save screenshots at. Can be an absolute or relative path.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9573,6 +9573,9 @@ child will follow movement and rotation of that bone.
           * table containing 16 numbers or an empty table to reset to the default
           * The values should be monotonically increasing and the last value should
             be 255. Otherwise there might be lighting bugs.
+        * `ao_gamma`: Strength of node ambient-occlusion shading. Lower is darker, Higher is lighter.
+          * Recommended range: from 0.25 to 3.0, default: 1.8
+          * A value of 0.0 will disable this shading entirely.
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9535,7 +9535,7 @@ child will follow movement and rotation of that bone.
           The default is a zero vector and disables the override.
           Note: the vector points "outwards" so that `(0, 1, 0)` is equivalent to
           the sun at midday shining straight down.
-      * `exposure` is a table that controls automatic exposure.
+      * `exposure` is a table that controls automatic exposure
         The basic exposure factor equation is `e = 2^exposure_correction / clamp(luminance, 2^luminance_min, 2^luminance_max)`
         * This has no effect on clients who have the "Automatic Exposure" effect disabled.
         * `luminance_min` set the lower luminance boundary to use in the calculation (default: `-3.0`)
@@ -9559,13 +9559,20 @@ child will follow movement and rotation of that bone.
           spreads from the bright objects.
           * Recommended range: from 0.1 to 8.0, default: 1.0
         * The behavior of values outside the recommended range is unspecified.
-      * `volumetric_light`: is a table that controls volumetric light (a.k.a. "godrays")
+      * `volumetric_light` is a table that controls volumetric light (a.k.a. "godrays")
         * This has no effect on clients who have the "Volumetric Lighting" or "Bloom" effects disabled.
         * `strength`: sets the strength of the volumetric light effect from 0 (off, default) to 1 (strongest).
             * `0.2` is a reasonable standard value.
             * Currently, bloom `intensity` and `strength_factor` affect volumetric
               lighting `strength` and vice versa. This behavior is to be changed
               in the future, do not rely on it.
+      * `static` is a table that controls static world lighting
+        * (added in 5.17.0, no client setting requirements)
+        * Note that changing these parameters is an expensive operation for the client.
+        * `light_curve`: LUT that converts light values (0-15) to intensity on screen (0-255)
+          * table containing 16 numbers or an empty table to reset to the default
+          * The values should be monotonically increasing and the last value should
+            be 255. Otherwise there might be lighting bugs.
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9691,7 +9691,7 @@ You **must not** mix names and track numbers to refer to the same animation.
           The default is a zero vector and disables the override.
           Note: the vector points "outwards" so that `(0, 1, 0)` is equivalent to
           the sun at midday shining straight down.
-      * `exposure` is a table that controls automatic exposure.
+      * `exposure` is a table that controls automatic exposure
         The basic exposure factor equation is `e = 2^exposure_correction / clamp(luminance, 2^luminance_min, 2^luminance_max)`
         * This has no effect on clients who have the "Automatic Exposure" effect disabled.
         * `luminance_min` set the lower luminance boundary to use in the calculation (default: `-3.0`)
@@ -9715,13 +9715,23 @@ You **must not** mix names and track numbers to refer to the same animation.
           spreads from the bright objects.
           * Recommended range: from 0.1 to 8.0, default: 1.0
         * The behavior of values outside the recommended range is unspecified.
-      * `volumetric_light`: is a table that controls volumetric light (a.k.a. "godrays")
+      * `volumetric_light` is a table that controls volumetric light (a.k.a. "godrays")
         * This has no effect on clients who have the "Volumetric Lighting" or "Bloom" effects disabled.
         * `strength`: sets the strength of the volumetric light effect from 0 (off, default) to 1 (strongest).
             * `0.2` is a reasonable standard value.
             * Currently, bloom `intensity` and `strength_factor` affect volumetric
               lighting `strength` and vice versa. This behavior is to be changed
               in the future, do not rely on it.
+      * `static` is a table that controls static world lighting
+        * (added in 5.18.0, no client setting requirements)
+        * Note that changing these parameters is an expensive operation for the client.
+        * `light_curve`: LUT that converts light values (0-15) to intensity on screen (0-255)
+          * table containing 16 numbers or an empty table to reset to the default
+          * The values should be monotonically increasing and the last value should
+            be 255. Otherwise there might be lighting bugs.
+        * `ao_gamma`: Strength of node ambient-occlusion shading. Lower is darker, Higher is lighter.
+          * Recommended range: from 0.25 to 3.0, default: 1.8
+          * A value of 0.0 will disable this shading entirely.
 
 * `get_lighting()`: returns the current state of lighting for the player.
     * Result is a table with the same fields as `light_definition` in `set_lighting`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -450,6 +450,7 @@ set(independent_SRCS
 	hud_element.cpp
 	inventory.cpp
 	itemstackmetadata.cpp
+	lighting.cpp
 	log.cpp
 	metadata.cpp
 	modchannels.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -456,6 +456,7 @@ set(independent_SRCS
 	hud_element.cpp
 	inventory.cpp
 	itemstackmetadata.cpp
+	lighting.cpp
 	log.cpp
 	metadata.cpp
 	modchannels.cpp

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -728,6 +728,9 @@ void Client::step(float dtime)
 		};
 	}
 
+	// Intentionally do this *after* processing mesh updates
+	updateStaticLighting(player->getLighting().static_);
+
 	/*
 		Load fetched media
 	*/
@@ -842,6 +845,38 @@ void Client::step(float dtime)
 		m_localdb->endSave();
 		m_localdb->beginSave();
 	}
+}
+
+bool Client::updateStaticLighting(const StaticLighting &future)
+{
+	auto &current = m_committed_static_light;
+
+	if (current == future)
+		return false;
+	current = future;
+	infostream << "Static lighting params changed" << std::endl;
+
+	float gamma = g_settings->getFloat("display_gamma");
+	if (current.light_curve_set) {
+		set_light_table(current.light_curve, gamma);
+	} else {
+		set_light_curve(gamma);
+	}
+
+	// First get rid of all meshes that we have generated or are about to generate
+	m_mesh_update_manager->clearAllQueues();
+
+	// Then re-generate every block mesh
+	// (yes, this isn't a smooth operation at all. the static lighting should
+	// change very rarely at all.)
+	ClientMap &map = m_env.getClientMap();
+	std::vector<v3s16> to_update;
+	map.getBlocksWithMeshes(to_update);
+	for (v3s16 p : to_update) {
+		m_mesh_update_manager->updateBlock(&map, p, false, false, false);
+	}
+
+	return true;
 }
 
 bool Client::loadMedia(const std::string &data, const std::string &filename,
@@ -1920,19 +1955,16 @@ void Client::afterContentReceived()
 	// content from previous sessions.
 	guiScalingCacheClear();
 
-	// Rebuild inherited images and recreate textures
 	infostream<<"- Rebuilding images and textures"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Loading textures..."),
 			guienv, m_tsrc, 0, 66);
 	m_tsrc->rebuildImagesAndTextures();
 
-	// Rebuild shaders
 	infostream<<"- Rebuilding shaders"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Rebuilding shaders..."),
 			guienv, m_tsrc, 0, 68);
 	m_shsrc->rebuildShaders();
 
-	// Update node aliases
 	infostream<<"- Updating node aliases"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Initializing nodes..."),
 			guienv, m_tsrc, 0, 70);
@@ -1945,14 +1977,15 @@ void Client::afterContentReceived()
 	m_nodedef->setNodeRegistrationStatus(true);
 	m_nodedef->runNodeResolveCallbacks();
 
-	// Update node textures and assign shaders to each tile
-	infostream<<"- Updating node textures"<<std::endl;
+	infostream<<"- Updating node visuals"<<std::endl;
 	TextureUpdateArgs tu_args;
 	tu_args.last_time_ms = porting::getTimeMs();
 	tu_args.text_base = wstrgettext("Initializing nodes");
 	NodeVisuals::fillNodeVisuals(m_nodedef, this, &tu_args);
 
-	// Start mesh update thread after setting up content definitions
+	// cf. updateStaticLighting()
+	set_light_curve(g_settings->getFloat("display_gamma"));
+
 	infostream<<"- Starting mesh update thread"<<std::endl;
 	m_mesh_update_manager->start();
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -699,6 +699,9 @@ void Client::step(float dtime)
 		};
 	}
 
+	// Intentionally do this *after* processing mesh updates
+	updateStaticLighting(player->getLighting().static_);
+
 	/*
 		Load fetched media
 	*/
@@ -813,6 +816,38 @@ void Client::step(float dtime)
 		m_localdb->endSave();
 		m_localdb->beginSave();
 	}
+}
+
+bool Client::updateStaticLighting(const StaticLighting &future)
+{
+	auto &current = m_committed_static_light;
+
+	if (current == future)
+		return false;
+	current = future;
+	infostream << "Static lighting params changed" << std::endl;
+
+	float gamma = g_settings->getFloat("display_gamma");
+	if (current.light_curve_set) {
+		set_light_table(current.light_curve, gamma);
+	} else {
+		set_light_curve(gamma);
+	}
+
+	// First get rid of all meshes that we have generated or are about to generate
+	m_mesh_update_manager->clearAllQueues();
+
+	// Then re-generate every block mesh
+	// (yes, this isn't a smooth operation at all. the static lighting should
+	// change very rarely at all.)
+	ClientMap &map = m_env.getClientMap();
+	std::vector<v3s16> to_update;
+	map.getBlocksWithMeshes(to_update);
+	for (v3s16 p : to_update) {
+		m_mesh_update_manager->updateBlock(&map, p, false, false, false);
+	}
+
+	return true;
 }
 
 bool Client::loadMedia(const std::string &data, const std::string &filename,
@@ -1895,19 +1930,16 @@ void Client::afterContentReceived()
 	// content from previous sessions.
 	guiScalingCacheClear();
 
-	// Rebuild inherited images and recreate textures
 	infostream<<"- Rebuilding images and textures"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Loading textures..."),
 			guienv, m_tsrc, 0, 66);
 	m_tsrc->rebuildImagesAndTextures();
 
-	// Rebuild shaders
 	infostream<<"- Rebuilding shaders"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Rebuilding shaders..."),
 			guienv, m_tsrc, 0, 68);
 	m_shsrc->rebuildShaders();
 
-	// Update node aliases
 	infostream<<"- Updating node aliases"<<std::endl;
 	m_rendering_engine->draw_load_screen(wstrgettext("Initializing nodes..."),
 			guienv, m_tsrc, 0, 70);
@@ -1920,8 +1952,7 @@ void Client::afterContentReceived()
 	m_nodedef->setNodeRegistrationStatus(true);
 	m_nodedef->runNodeResolveCallbacks();
 
-	// Update node textures and assign shaders to each tile
-	infostream<<"- Updating node textures"<<std::endl;
+	infostream<<"- Updating node visuals"<<std::endl;
 	TextureUpdateArgs tu_args;
 	tu_args.last_time_ms = porting::getTimeMs();
 	tu_args.text_base = wstrgettext("Initializing nodes");
@@ -1931,7 +1962,9 @@ void Client::afterContentReceived()
 	// minimap_color, and palette - the two values we care for in SSCSM, get populated
 	m_sscsm_controller->runEvent(this, std::make_unique<SSCSMEventAfterContentReceived>());
 
-	// Start mesh update thread after setting up content definitions
+	// cf. updateStaticLighting()
+	set_light_curve(g_settings->getFloat("display_gamma"));
+
 	infostream<<"- Starting mesh update thread"<<std::endl;
 	m_mesh_update_manager->start();
 

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -9,6 +9,7 @@
 #include "gameparams.h" // ELoginRegister
 #include "inventorymanager.h"
 #include "irrlichttypes.h"
+#include "lighting.h"
 #include "network/address.h"
 #include "network/networkprotocol.h" // multiple enums
 #include "network/peerhandler.h"
@@ -435,9 +436,14 @@ public:
 
 	const std::string &getFormspecPrepend() const;
 
-	inline MeshGrid getMeshGrid()
+	inline MeshGrid getMeshGrid() const
 	{
 		return m_mesh_grid;
+	}
+
+	inline const StaticLighting &getCommittedStaticLighting() const
+	{
+		return m_committed_static_light;
 	}
 
 	bool inhibit_inventory_revert = false;
@@ -467,8 +473,6 @@ private:
 
 	void ReceiveAll();
 
-	void sendPlayerPos();
-
 	void deleteAuthData();
 	// helper method shared with clientpackethandler
 	static AuthMechanism choseAuthMech(const u32 mechs);
@@ -478,6 +482,9 @@ private:
 	void sendDeletedBlocks(std::vector<v3s16> &blocks);
 	void sendGotBlocks(const std::vector<v3s16> &blocks);
 	void sendRemovedSounds(const std::vector<s32> &soundList);
+	void sendPlayerPos();
+
+	bool updateStaticLighting(const StaticLighting &future);
 
 	bool canSendChatMessage() const;
 
@@ -496,7 +503,6 @@ private:
 	MtEventManager *m_event;
 	RenderingEngine *m_rendering_engine;
 	ItemVisualsManager *m_item_visuals_manager;
-
 
 	std::unique_ptr<MeshUpdateManager> m_mesh_update_manager;
 	ClientEnvironment m_env;
@@ -534,6 +540,12 @@ private:
 
 	// The seed returned by the server in TOCLIENT_AUTH_ACCEPT is stored here
 	u64 m_map_seed = 0;
+
+	// The number of blocks the client will combine for mesh generation.
+	MeshGrid m_mesh_grid;
+
+	// The static lighting currently in use
+	StaticLighting m_committed_static_light;
 
 	// Auth data
 	std::string m_playername;
@@ -607,7 +619,4 @@ private:
 	u32 m_csm_restriction_noderange = 8;
 
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
-
-	// The number of blocks the client will combine for mesh generation.
-	MeshGrid m_mesh_grid;
 };

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -9,6 +9,7 @@
 #include "gameparams.h" // ELoginRegister
 #include "inventorymanager.h"
 #include "irrlichttypes.h"
+#include "lighting.h"
 #include "network/address.h"
 #include "network/networkprotocol.h" // multiple enums
 #include "network/peerhandler.h"
@@ -442,9 +443,14 @@ public:
 
 	const std::string &getFormspecPrepend() const;
 
-	inline MeshGrid getMeshGrid()
+	inline MeshGrid getMeshGrid() const
 	{
 		return m_mesh_grid;
+	}
+
+	inline const StaticLighting &getCommittedStaticLighting() const
+	{
+		return m_committed_static_light;
 	}
 
 	bool inhibit_inventory_revert = false;
@@ -474,8 +480,6 @@ private:
 
 	void ReceiveAll();
 
-	void sendPlayerPos();
-
 	void deleteAuthData();
 	// helper method shared with clientpackethandler
 	static AuthMechanism choseAuthMech(const u32 mechs);
@@ -485,6 +489,9 @@ private:
 	void sendDeletedBlocks(std::vector<v3s16> &blocks);
 	void sendGotBlocks(const std::vector<v3s16> &blocks);
 	void sendRemovedSounds(const std::vector<s32> &soundList);
+	void sendPlayerPos();
+
+	bool updateStaticLighting(const StaticLighting &future);
 
 	bool canSendChatMessage() const;
 
@@ -503,7 +510,6 @@ private:
 	MtEventManager *m_event;
 	RenderingEngine *m_rendering_engine;
 	ItemVisualsManager *m_item_visuals_manager;
-
 
 	std::unique_ptr<MeshUpdateManager> m_mesh_update_manager;
 	ClientEnvironment m_env;
@@ -541,6 +547,12 @@ private:
 
 	// The seed returned by the server in TOCLIENT_AUTH_ACCEPT is stored here
 	u64 m_map_seed = 0;
+
+	// The number of blocks the client will combine for mesh generation.
+	MeshGrid m_mesh_grid;
+
+	// The static lighting currently in use
+	StaticLighting m_committed_static_light;
 
 	// Auth data
 	std::string m_playername;
@@ -614,7 +626,4 @@ private:
 	u32 m_csm_restriction_noderange = 8;
 
 	std::unique_ptr<ModChannelMgr> m_modchannel_mgr;
-
-	// The number of blocks the client will combine for mesh generation.
-	MeshGrid m_mesh_grid;
 };

--- a/src/client/clientmap.h
+++ b/src/client/clientmap.h
@@ -99,6 +99,9 @@ public:
 	/// @brief Calculate statistics about the map and keep the blocks alive
 	void touchMapBlocks();
 
+	/// @brief returns a distance-sorted list of all block mesh positions
+	void getBlocksWithMeshes(std::vector<v3s16> &out);
+
 	void updateDrawListShadow(v3f shadow_light_pos, v3f shadow_light_dir, float radius, float length);
 	void clearDrawListShadow();
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -492,8 +492,6 @@ void Game::run()
 
 	draw_times.reset();
 
-	set_light_curve(g_settings->getFloat("display_gamma"));
-
 	m_touch_simulate_aux1 = g_settings->getBool("fast_move")
 			&& client->checkPrivilege("fast");
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -490,8 +490,6 @@ void Game::run()
 
 	draw_times.reset();
 
-	set_light_curve(g_settings->getFloat("display_gamma"));
-
 	m_touch_simulate_aux1 = g_settings->getBool("fast_move")
 			&& client->checkPrivilege("fast");
 

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -146,6 +146,8 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 {
 	const NodeDefManager *ndef = data->m_nodedef;
 
+	assert(data->m_smooth_lighting);
+
 	u16 ambient_occlusion = 0;
 	u16 light_count = 0;
 	u8 light_source_max = 0;
@@ -162,12 +164,12 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		if (n.getContent() == CONTENT_IGNORE)
 			return true;
 		const ContentFeatures &f = ndef->get(n);
-		if (f.light_source > light_source_max)
-			light_source_max = f.light_source;
+		light_source_max = std::max(light_source_max, f.light_source);
 		// Check f.solidness because fast-style leaves look better this way
 		if (f.param_type == CPT_LIGHT && f.visuals->solidness != 2) {
-			u8 light_level_day = n.getLight(LIGHTBANK_DAY, f.getLightingFlags());
-			u8 light_level_night = n.getLight(LIGHTBANK_NIGHT, f.getLightingFlags());
+			const auto lf = f.getLightingFlags();
+			u8 light_level_day = n.getLight(LIGHTBANK_DAY, lf);
+			u8 light_level_night = n.getLight(LIGHTBANK_NIGHT, lf);
 			if (light_level_day == LIGHT_SUN)
 				direct_sunlight = true;
 			light_day += decode_light(light_level_day);
@@ -221,25 +223,20 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	}
 
 	if (ambient_occlusion > 4) {
-		static thread_local const float ao_gamma = rangelim(
-			g_settings->getFloat("ambient_occlusion_gamma"), 0.25, 4.0);
-
-		// Table of gamma space multiply factors.
-		static thread_local const float light_amount[3] = {
-			powf(0.75, 1.0 / ao_gamma),
-			powf(0.5,  1.0 / ao_gamma),
-			powf(0.25, 1.0 / ao_gamma)
-		};
-
-		//calculate table index for gamma space multiplier
-		ambient_occlusion -= 5;
+		float light_amount; // gamma space multiplier
+		if (ambient_occlusion == 5)
+			light_amount = std::pow(0.75f, data->m_ao_gamma_inv);
+		else if (ambient_occlusion == 6)
+			light_amount = std::pow(0.5f, data->m_ao_gamma_inv);
+		else // >= 7
+			light_amount = std::pow(0.25f, data->m_ao_gamma_inv);
 
 		if (!skip_ambient_occlusion_day)
 			light_day = rangelim(core::round32(
-					light_day * light_amount[ambient_occlusion]), 0, 255);
+					light_day * light_amount), 0, 255);
 		if (!skip_ambient_occlusion_night)
 			light_night = rangelim(core::round32(
-					light_night * light_amount[ambient_occlusion]), 0, 255);
+					light_night * light_amount), 0, 255);
 	}
 
 	return light_day | (light_night << 8);

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -146,6 +146,8 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 {
 	const NodeDefManager *ndef = data->m_nodedef;
 
+	assert(data->m_smooth_lighting);
+
 	u16 ambient_occlusion = 0;
 	u16 light_count = 0;
 	u8 light_source_max = 0;
@@ -162,12 +164,13 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		if (n.getContent() == CONTENT_IGNORE)
 			return true;
 		const ContentFeatures &f = ndef->get(n);
-		if (f.light_source > light_source_max)
-			light_source_max = f.light_source;
+
+		light_source_max = std::max(light_source_max, f.light_source);
 		// Check solidness because fast-style leaves look better this way
 		if (f.param_type == CPT_LIGHT && NDT_solidness[f.drawtype] != 2) {
-			u8 light_level_day = n.getLight(LIGHTBANK_DAY, f.getLightingFlags());
-			u8 light_level_night = n.getLight(LIGHTBANK_NIGHT, f.getLightingFlags());
+			const auto lf = f.getLightingFlags();
+			u8 light_level_day = n.getLight(LIGHTBANK_DAY, lf);
+			u8 light_level_night = n.getLight(LIGHTBANK_NIGHT, lf);
 			if (light_level_day == LIGHT_SUN)
 				direct_sunlight = true;
 			light_day += decode_light(light_level_day);
@@ -221,25 +224,20 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 	}
 
 	if (ambient_occlusion > 4) {
-		static thread_local const float ao_gamma = rangelim(
-			g_settings->getFloat("ambient_occlusion_gamma"), 0.25, 4.0);
-
-		// Table of gamma space multiply factors.
-		static thread_local const float light_amount[3] = {
-			powf(0.75, 1.0 / ao_gamma),
-			powf(0.5,  1.0 / ao_gamma),
-			powf(0.25, 1.0 / ao_gamma)
-		};
-
-		//calculate table index for gamma space multiplier
-		ambient_occlusion -= 5;
+		float light_amount; // gamma space multiplier
+		if (ambient_occlusion == 5)
+			light_amount = std::pow(0.75f, data->m_ao_gamma_inv);
+		else if (ambient_occlusion == 6)
+			light_amount = std::pow(0.5f, data->m_ao_gamma_inv);
+		else // >= 7
+			light_amount = std::pow(0.25f, data->m_ao_gamma_inv);
 
 		if (!skip_ambient_occlusion_day)
 			light_day = rangelim(core::round32(
-					light_day * light_amount[ambient_occlusion]), 0, 255);
+					light_day * light_amount), 0, 255);
 		if (!skip_ambient_occlusion_night)
 			light_night = rangelim(core::round32(
-					light_night * light_amount[ambient_occlusion]), 0, 255);
+					light_night * light_amount), 0, 255);
 	}
 
 	return light_day | (light_night << 8);

--- a/src/client/mapblock_mesh.h
+++ b/src/client/mapblock_mesh.h
@@ -45,6 +45,7 @@ struct MeshMakeData
 
 	// relative to blockpos
 	v3s16 m_crack_pos_relative = v3s16(-1337,-1337,-1337);
+	float m_ao_gamma_inv = 0.0f;
 	bool m_generate_minimap = false;
 	bool m_smooth_lighting = false;
 	bool m_enable_water_reflections = false;

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -236,6 +236,12 @@ void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 	}
 
 	data->setCrack(q->crack_level, q->crack_pos);
+
+	// Changes to static lighting will cause a re-mesh of the entire map, so
+	// this doesn't need an update mechanism.
+	float ao_gamma = m_client->getCommittedStaticLighting().ao_gamma;
+	data->m_ao_gamma_inv = ao_gamma == 0.0f ? 0.0f : (1.0f / ao_gamma);
+
 	data->m_generate_minimap = !!m_client->getMinimap();
 	data->m_smooth_lighting = m_cache_smooth_lighting;
 	data->m_enable_water_reflections = m_cache_enable_water_reflections;

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -237,6 +237,12 @@ void MeshUpdateQueue::fillDataFromMapBlocks(QueuedMeshUpdate *q)
 	}
 
 	data->setCrack(q->crack_level, q->crack_pos);
+
+	// Changes to static lighting will cause a re-mesh of the entire map, so
+	// this doesn't need an update mechanism.
+	float ao_gamma = m_client->getCommittedStaticLighting().ao_gamma;
+	data->m_ao_gamma_inv = ao_gamma == 0.0f ? 0.0f : (1.0f / ao_gamma);
+
 	data->m_generate_minimap = !!m_client->getMinimap();
 	data->m_smooth_lighting = m_cache_smooth_lighting;
 	data->m_enable_water_reflections = m_cache_enable_water_reflections;

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -302,7 +302,6 @@ void set_default_settings()
 	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
 	settings->setDefault("show_entity_selectionbox", "false");
-	settings->setDefault("ambient_occlusion_gamma", "1.8");
 	settings->setDefault("arm_inertia", "true");
 	settings->setDefault("hurt_flash_enabled", "true");
 	settings->setDefault("show_nametag_backgrounds", "true");

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -304,7 +304,6 @@ void set_default_settings()
 	settings->setDefault("hud_hotbar_max_width", "1.0");
 	settings->setDefault("enable_local_map_saving", "false");
 	settings->setDefault("show_entity_selectionbox", "false");
-	settings->setDefault("ambient_occlusion_gamma", "1.8");
 	settings->setDefault("arm_inertia", "true");
 	settings->setDefault("hurt_flash_enabled", "true");
 	settings->setDefault("show_nametag_backgrounds", "true");

--- a/src/light.cpp
+++ b/src/light.cpp
@@ -65,14 +65,24 @@ void set_light_curve(float gamma)
 
 	for (size_t i = 1; i < LIGHT_SUN; i++) {
 		float brightness = params.get((float)i / LIGHT_SUN);
-		// Strictly speaking, rangelim is not necessary here - if the implementation
-		// is conforming. But we don't want problems in any case.
-		light_LUT[i] = rangelim((s32)(255.0f * brightness), 0, 255);
+		light_LUT[i] = std::clamp<s32>(255.0f * brightness, 0, 255);
 
 		// Ensure light brightens with each level
 		if (light_LUT[i] <= light_LUT[i - 1]) {
 			light_LUT[i] = std::min<u8>(254, light_LUT[i - 1]) + 1;
 		}
+	}
+}
+
+void set_light_table(u8 *data, float gamma)
+{
+	gamma = rangelim(gamma, 0.33f, 3.0f);
+
+	// No restrictons on values here, API users were warned to set sane values
+	for (size_t i = 0; i <= LIGHT_SUN; i++) {
+		float brightness = (float)data[i] / 255.0f;
+		brightness = std::pow(brightness, 1.0f / gamma);
+		light_LUT[i] = std::clamp<s32>(255.0f * brightness, 0, 255);
 	}
 }
 

--- a/src/light.h
+++ b/src/light.h
@@ -53,6 +53,9 @@ float decode_light_f(float light_f);
 // Update light value table using the specified gamma
 void set_light_curve(float gamma);
 
+// Update light value table with a custom LUT
+void set_light_table(u8 data[LIGHT_SUN+1], float gamma);
+
 #endif
 
 // 0 <= daylight_factor <= 1000

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -1,0 +1,16 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 sfan5
+
+#include "lighting.h"
+
+#include <cstring>
+
+bool StaticLighting::operator==(const StaticLighting &other) const
+{
+	if (light_curve_set != other.light_curve_set)
+		return false;
+	if (light_curve_set && memcmp(light_curve, other.light_curve, sizeof(light_curve)) != 0)
+		return false;
+	return true;
+}

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -8,7 +8,8 @@
 
 bool StaticLighting::operator==(const StaticLighting &other) const
 {
-	if (light_curve_set != other.light_curve_set)
+	if (light_curve_set != other.light_curve_set ||
+		ao_gamma != other.ao_gamma)
 		return false;
 	if (light_curve_set && memcmp(light_curve, other.light_curve, sizeof(light_curve)) != 0)
 		return false;

--- a/src/lighting.cpp
+++ b/src/lighting.cpp
@@ -1,0 +1,17 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2025 sfan5
+
+#include "lighting.h"
+
+#include <cstring>
+
+bool StaticLighting::operator==(const StaticLighting &other) const
+{
+	if (light_curve_set != other.light_curve_set ||
+		ao_gamma != other.ao_gamma)
+		return false;
+	if (light_curve_set && memcmp(light_curve, other.light_curve, sizeof(light_curve)) != 0)
+		return false;
+	return true;
+}

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -3,6 +3,7 @@
 // Copyright (C) 2021 x2048, Dmitry Kostenko <codeforsmile@gmail.com>
 
 #pragma once
+#include "irrlichttypes.h"
 #include "SColor.h"
 #include "irr_v3d.h"
 
@@ -40,7 +41,31 @@ struct AutoExposure
 	{}
 };
 
-/** Describes ambient light settings for a player
+/*
+ * Describes the "static" lighting parameters for a player.
+ *
+ * The difference is that these are baked into the map block meshes and require
+ * more work to update.
+ */
+struct StaticLighting
+{
+	static constexpr int LIGHT_CURVE_SIZE = 16;
+
+	// Light curve: used to decode map light (0-15) into intensity (0-255)
+	bool light_curve_set = false;
+	u8 light_curve[LIGHT_CURVE_SIZE];
+
+	// Ambient occlusion gamma
+	float ao_gamma = 1.8f;
+
+	bool operator==(const StaticLighting &other) const;
+	bool operator!=(const StaticLighting &other) const {
+		return !(*this == other);
+	}
+};
+
+/*
+ * Describes ambient light settings for a player
  */
 struct Lighting
 {
@@ -53,4 +78,6 @@ struct Lighting
 	float bloom_strength_factor {1.0f};
 	float bloom_radius {1.0f};
 	v3f shadow_direction;
+
+	StaticLighting static_;
 };

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -3,6 +3,7 @@
 // Copyright (C) 2021 x2048, Dmitry Kostenko <codeforsmile@gmail.com>
 
 #pragma once
+#include "irrlichttypes.h"
 #include "SColor.h"
 #include "irr_v3d.h"
 
@@ -40,7 +41,27 @@ struct AutoExposure
 	{}
 };
 
-/** Describes ambient light settings for a player
+/*
+ * Describes the "static" lighting parameters for a player.
+ *
+ * The difference is that these are baked into the map block meshes and require
+ * more work to update.
+ */
+struct StaticLighting
+{
+	static constexpr int LIGHT_CURVE_SIZE = 16;
+
+	bool light_curve_set = false;
+	u8 light_curve[LIGHT_CURVE_SIZE];
+
+	bool operator==(const StaticLighting &other) const;
+	bool operator!=(const StaticLighting &other) const {
+		return !(*this == other);
+	}
+};
+
+/*
+ * Describes ambient light settings for a player
  */
 struct Lighting
 {
@@ -53,4 +74,6 @@ struct Lighting
 	float bloom_strength_factor {1.0f};
 	float bloom_radius {1.0f};
 	v3f shadow_direction;
+
+	StaticLighting static_;
 };

--- a/src/lighting.h
+++ b/src/lighting.h
@@ -51,8 +51,12 @@ struct StaticLighting
 {
 	static constexpr int LIGHT_CURVE_SIZE = 16;
 
+	// Light curve: used to decode map light (0-15) into intensity (0-255)
 	bool light_curve_set = false;
 	u8 light_curve[LIGHT_CURVE_SIZE];
+
+	// Ambient occlusion gamma
+	float ao_gamma = 1.8f;
 
 	bool operator==(const StaticLighting &other) const;
 	bool operator!=(const StaticLighting &other) const {

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1923,5 +1923,6 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 		*pkt >> s.light_curve_set;
 		if (s.light_curve_set)
 			pkt->readRawString(reinterpret_cast<char*>(s.light_curve), sizeof(s.light_curve));
+		*pkt >> s.ao_gamma;
 	} while (0);
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1883,6 +1883,7 @@ void Client::handleCommand_MinimapModes(NetworkPacket *pkt)
 void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 {
 	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
+	auto &s = lighting.static_;
 
 	*pkt >> lighting.shadow_intensity;
 	do {
@@ -1916,5 +1917,11 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 			break;
 		// >= 5.16.0-dev
 		*pkt >> lighting.shadow_direction;
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.17.0-dev
+		*pkt >> s.light_curve_set;
+		if (s.light_curve_set)
+			pkt->readRawString(reinterpret_cast<char*>(s.light_curve), sizeof(s.light_curve));
 	} while (0);
 }

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1883,6 +1883,7 @@ void Client::handleCommand_MinimapModes(NetworkPacket *pkt)
 void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 {
 	Lighting& lighting = m_env.getLocalPlayer()->getLighting();
+	auto &s = lighting.static_;
 
 	*pkt >> lighting.shadow_intensity;
 	do {
@@ -1916,5 +1917,12 @@ void Client::handleCommand_SetLighting(NetworkPacket *pkt)
 			break;
 		// >= 5.16.0-dev
 		*pkt >> lighting.shadow_direction;
+		if (!pkt->hasRemainingBytes())
+			break;
+		// >= 5.18.0-dev
+		*pkt >> s.light_curve_set;
+		if (s.light_curve_set)
+			pkt->readRawString(reinterpret_cast<char*>(s.light_curve), sizeof(s.light_curve));
+		*pkt >> s.ao_gamma;
 	} while (0);
 }

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2746,6 +2746,7 @@ int ObjectRef::l_set_lighting(lua_State *L)
 			s.light_curve_set = any;
 		}
 		lua_pop(L, 1); // light_curve
+		getfloatfield(L, -1, "ao_gamma", s.ao_gamma);
 	}
 	lua_pop(L, 1); // static
 
@@ -2816,6 +2817,8 @@ int ObjectRef::l_get_lighting(lua_State *L)
 		}
 	}
 	lua_setfield(L, -2, "light_curve");
+	lua_pushnumber(L, s.ao_gamma);
+	lua_setfield(L, -2, "ao_gamma");
 	lua_setfield(L, -2, "static");
 
 	return 1;

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2680,52 +2680,74 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	Lighting lighting;
+	if (lua_isnoneornil(L, 2)) {
+		// reset to default
+		getServer(L)->setLighting(player, {});
+		return 0;
+	}
+	luaL_checktype(L, 2, LUA_TTABLE);
 
-	if (!lua_isnoneornil(L, 2)) {
-		luaL_checktype(L, 2, LUA_TTABLE);
-		lighting = player->getLighting();
-		lua_getfield(L, 2, "shadows");
-		if (lua_istable(L, -1)) {
-			getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
-			lua_getfield(L, -1, "tint");
-			read_color(L, -1, &lighting.shadow_tint);
-			lua_pop(L, 1); // tint
-			lua_getfield(L, -1, "direction");
-			if (!lua_isnil(L, -1))
-				lighting.shadow_direction = check_v3f(L, -1);
-			lua_pop(L, 1); // direction
+	Lighting lighting = player->getLighting();
+
+	lua_getfield(L, 2, "shadows");
+	if (lua_istable(L, -1)) {
+		getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
+		lua_getfield(L, -1, "tint");
+		read_color(L, -1, &lighting.shadow_tint);
+		lua_pop(L, 1); // tint
+		lua_getfield(L, -1, "direction");
+		if (!lua_isnil(L, -1))
+			lighting.shadow_direction = check_v3f(L, -1);
+		lua_pop(L, 1); // direction
+	}
+	lua_pop(L, 1); // shadows
+
+	getfloatfield(L, -1, "saturation", lighting.saturation);
+
+	lua_getfield(L, 2, "exposure");
+	if (lua_istable(L, -1)) {
+		lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
+		lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
+		lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
+		lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
+		lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
+		lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
+	}
+	lua_pop(L, 1); // exposure
+
+	lua_getfield(L, 2, "volumetric_light");
+	if (lua_istable(L, -1)) {
+		getfloatfield(L, -1, "strength", lighting.volumetric_light_strength);
+		lighting.volumetric_light_strength = rangelim(lighting.volumetric_light_strength, 0.0f, 1.0f);
+	}
+	lua_pop(L, 1); // volumetric_light
+
+	lua_getfield(L, 2, "bloom");
+	if (lua_istable(L, -1)) {
+		lighting.bloom_intensity       = getfloatfield_default(L, -1, "intensity",       lighting.bloom_intensity);
+		lighting.bloom_strength_factor = getfloatfield_default(L, -1, "strength_factor", lighting.bloom_strength_factor);
+		lighting.bloom_radius          = getfloatfield_default(L, -1, "radius",          lighting.bloom_radius);
+	}
+	lua_pop(L, 1); // bloom
+
+	lua_getfield(L, 2, "static");
+	if (lua_istable(L, -1)) {
+		auto &s = lighting.static_;
+		lua_getfield(L, -1, "light_curve");
+		if (!lua_isnil(L, -1)) {
+			bool any = false;
+			for (int i = 0; i < StaticLighting::LIGHT_CURVE_SIZE; i++) {
+				lua_rawgeti(L, -1, i + 1);
+				any |= !lua_isnoneornil(L, -1);
+				s.light_curve[i] = lua_tointeger(L, -1);
+				lua_pop(L, 1);
+			}
+			// empty table <=> unset
+			s.light_curve_set = any;
 		}
-		lua_pop(L, 1); // shadows
-
-		getfloatfield(L, -1, "saturation", lighting.saturation);
-
-		lua_getfield(L, 2, "exposure");
-		if (lua_istable(L, -1)) {
-			lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
-			lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
-			lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
-			lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
-			lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
-			lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
-		}
-		lua_pop(L, 1); // exposure
-
-		lua_getfield(L, 2, "volumetric_light");
-		if (lua_istable(L, -1)) {
-			getfloatfield(L, -1, "strength", lighting.volumetric_light_strength);
-			lighting.volumetric_light_strength = rangelim(lighting.volumetric_light_strength, 0.0f, 1.0f);
-		}
-		lua_pop(L, 1); // volumetric_light
-
-		lua_getfield(L, 2, "bloom");
-		if (lua_istable(L, -1)) {
-			lighting.bloom_intensity       = getfloatfield_default(L, -1, "intensity",       lighting.bloom_intensity);
-			lighting.bloom_strength_factor = getfloatfield_default(L, -1, "strength_factor", lighting.bloom_strength_factor);
-			lighting.bloom_radius          = getfloatfield_default(L, -1, "radius",          lighting.bloom_radius);
-		}
-		lua_pop(L, 1); // bloom
-}
+		lua_pop(L, 1); // light_curve
+	}
+	lua_pop(L, 1); // static
 
 	getServer(L)->setLighting(player, lighting);
 	return 0;
@@ -2753,6 +2775,7 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_setfield(L, -2, "shadows");
 	lua_pushnumber(L, lighting.saturation);
 	lua_setfield(L, -2, "saturation");
+
 	lua_newtable(L); // "exposure"
 	lua_pushnumber(L, lighting.exposure.luminance_min);
 	lua_setfield(L, -2, "luminance_min");
@@ -2767,10 +2790,12 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.exposure.center_weight_power);
 	lua_setfield(L, -2, "center_weight_power");
 	lua_setfield(L, -2, "exposure");
+
 	lua_newtable(L); // "volumetric_light"
 	lua_pushnumber(L, lighting.volumetric_light_strength);
 	lua_setfield(L, -2, "strength");
 	lua_setfield(L, -2, "volumetric_light");
+
 	lua_newtable(L); // "bloom"
 	lua_pushnumber(L, lighting.bloom_intensity);
 	lua_setfield(L, -2, "intensity");
@@ -2779,6 +2804,20 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.bloom_radius);
 	lua_setfield(L, -2, "radius");
 	lua_setfield(L, -2, "bloom");
+
+	const auto &s = lighting.static_;
+	lua_newtable(L); // "static"
+	lua_newtable(L);
+	if (s.light_curve_set) {
+		int i = 0;
+		for (u8 n : s.light_curve) {
+			lua_pushinteger(L, n);
+			lua_rawseti(L, -2, ++i);
+		}
+	}
+	lua_setfield(L, -2, "light_curve");
+	lua_setfield(L, -2, "static");
+
 	return 1;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -2828,52 +2828,75 @@ int ObjectRef::l_set_lighting(lua_State *L)
 	if (player == nullptr)
 		return 0;
 
-	Lighting lighting;
+	if (lua_isnoneornil(L, 2)) {
+		// reset to default
+		getServer(L)->setLighting(player, {});
+		return 0;
+	}
+	luaL_checktype(L, 2, LUA_TTABLE);
 
-	if (!lua_isnoneornil(L, 2)) {
-		luaL_checktype(L, 2, LUA_TTABLE);
-		lighting = player->getLighting();
-		lua_getfield(L, 2, "shadows");
-		if (lua_istable(L, -1)) {
-			getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
-			lua_getfield(L, -1, "tint");
-			read_color(L, -1, &lighting.shadow_tint);
-			lua_pop(L, 1); // tint
-			lua_getfield(L, -1, "direction");
-			if (!lua_isnil(L, -1))
-				lighting.shadow_direction = check_v3f(L, -1);
-			lua_pop(L, 1); // direction
+	Lighting lighting = player->getLighting();
+
+	lua_getfield(L, 2, "shadows");
+	if (lua_istable(L, -1)) {
+		getfloatfield(L, -1, "intensity", lighting.shadow_intensity);
+		lua_getfield(L, -1, "tint");
+		read_color(L, -1, &lighting.shadow_tint);
+		lua_pop(L, 1); // tint
+		lua_getfield(L, -1, "direction");
+		if (!lua_isnil(L, -1))
+			lighting.shadow_direction = check_v3f(L, -1);
+		lua_pop(L, 1); // direction
+	}
+	lua_pop(L, 1); // shadows
+
+	getfloatfield(L, -1, "saturation", lighting.saturation);
+
+	lua_getfield(L, 2, "exposure");
+	if (lua_istable(L, -1)) {
+		lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
+		lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
+		lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
+		lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
+		lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
+		lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
+	}
+	lua_pop(L, 1); // exposure
+
+	lua_getfield(L, 2, "volumetric_light");
+	if (lua_istable(L, -1)) {
+		getfloatfield(L, -1, "strength", lighting.volumetric_light_strength);
+		lighting.volumetric_light_strength = rangelim(lighting.volumetric_light_strength, 0.0f, 1.0f);
+	}
+	lua_pop(L, 1); // volumetric_light
+
+	lua_getfield(L, 2, "bloom");
+	if (lua_istable(L, -1)) {
+		lighting.bloom_intensity       = getfloatfield_default(L, -1, "intensity",       lighting.bloom_intensity);
+		lighting.bloom_strength_factor = getfloatfield_default(L, -1, "strength_factor", lighting.bloom_strength_factor);
+		lighting.bloom_radius          = getfloatfield_default(L, -1, "radius",          lighting.bloom_radius);
+	}
+	lua_pop(L, 1); // bloom
+
+	lua_getfield(L, 2, "static");
+	if (lua_istable(L, -1)) {
+		auto &s = lighting.static_;
+		lua_getfield(L, -1, "light_curve");
+		if (!lua_isnil(L, -1)) {
+			bool any = false;
+			for (int i = 0; i < StaticLighting::LIGHT_CURVE_SIZE; i++) {
+				lua_rawgeti(L, -1, i + 1);
+				any |= !lua_isnoneornil(L, -1);
+				s.light_curve[i] = lua_tointeger(L, -1);
+				lua_pop(L, 1);
+			}
+			// empty table <=> unset
+			s.light_curve_set = any;
 		}
-		lua_pop(L, 1); // shadows
-
-		getfloatfield(L, -1, "saturation", lighting.saturation);
-
-		lua_getfield(L, 2, "exposure");
-		if (lua_istable(L, -1)) {
-			lighting.exposure.luminance_min       = getfloatfield_default(L, -1, "luminance_min",       lighting.exposure.luminance_min);
-			lighting.exposure.luminance_max       = getfloatfield_default(L, -1, "luminance_max",       lighting.exposure.luminance_max);
-			lighting.exposure.exposure_correction = getfloatfield_default(L, -1, "exposure_correction",      lighting.exposure.exposure_correction);
-			lighting.exposure.speed_dark_bright   = getfloatfield_default(L, -1, "speed_dark_bright",   lighting.exposure.speed_dark_bright);
-			lighting.exposure.speed_bright_dark   = getfloatfield_default(L, -1, "speed_bright_dark",   lighting.exposure.speed_bright_dark);
-			lighting.exposure.center_weight_power = getfloatfield_default(L, -1, "center_weight_power", lighting.exposure.center_weight_power);
-		}
-		lua_pop(L, 1); // exposure
-
-		lua_getfield(L, 2, "volumetric_light");
-		if (lua_istable(L, -1)) {
-			getfloatfield(L, -1, "strength", lighting.volumetric_light_strength);
-			lighting.volumetric_light_strength = rangelim(lighting.volumetric_light_strength, 0.0f, 1.0f);
-		}
-		lua_pop(L, 1); // volumetric_light
-
-		lua_getfield(L, 2, "bloom");
-		if (lua_istable(L, -1)) {
-			lighting.bloom_intensity       = getfloatfield_default(L, -1, "intensity",       lighting.bloom_intensity);
-			lighting.bloom_strength_factor = getfloatfield_default(L, -1, "strength_factor", lighting.bloom_strength_factor);
-			lighting.bloom_radius          = getfloatfield_default(L, -1, "radius",          lighting.bloom_radius);
-		}
-		lua_pop(L, 1); // bloom
-}
+		lua_pop(L, 1); // light_curve
+		getfloatfield(L, -1, "ao_gamma", s.ao_gamma);
+	}
+	lua_pop(L, 1); // static
 
 	getServer(L)->setLighting(player, lighting);
 	return 0;
@@ -2901,6 +2924,7 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_setfield(L, -2, "shadows");
 	lua_pushnumber(L, lighting.saturation);
 	lua_setfield(L, -2, "saturation");
+
 	lua_newtable(L); // "exposure"
 	lua_pushnumber(L, lighting.exposure.luminance_min);
 	lua_setfield(L, -2, "luminance_min");
@@ -2915,10 +2939,12 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.exposure.center_weight_power);
 	lua_setfield(L, -2, "center_weight_power");
 	lua_setfield(L, -2, "exposure");
+
 	lua_newtable(L); // "volumetric_light"
 	lua_pushnumber(L, lighting.volumetric_light_strength);
 	lua_setfield(L, -2, "strength");
 	lua_setfield(L, -2, "volumetric_light");
+
 	lua_newtable(L); // "bloom"
 	lua_pushnumber(L, lighting.bloom_intensity);
 	lua_setfield(L, -2, "intensity");
@@ -2927,6 +2953,22 @@ int ObjectRef::l_get_lighting(lua_State *L)
 	lua_pushnumber(L, lighting.bloom_radius);
 	lua_setfield(L, -2, "radius");
 	lua_setfield(L, -2, "bloom");
+
+	const auto &s = lighting.static_;
+	lua_newtable(L); // "static"
+	lua_newtable(L);
+	if (s.light_curve_set) {
+		int i = 0;
+		for (u8 n : s.light_curve) {
+			lua_pushinteger(L, n);
+			lua_rawseti(L, -2, ++i);
+		}
+	}
+	lua_setfield(L, -2, "light_curve");
+	lua_pushnumber(L, s.ao_gamma);
+	lua_setfield(L, -2, "ao_gamma");
+	lua_setfield(L, -2, "static");
+
 	return 1;
 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2036,11 +2036,9 @@ void Server::SendOverrideDayNightRatio(session_t peer_id, bool do_override,
 
 void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 {
-	NetworkPacket pkt(TOCLIENT_SET_LIGHTING,
-			4, peer_id);
+	NetworkPacket pkt(TOCLIENT_SET_LIGHTING, 70, peer_id);
 
-	pkt << lighting.shadow_intensity;
-	pkt << lighting.saturation;
+	pkt << lighting.shadow_intensity << lighting.saturation;
 
 	pkt << lighting.exposure.luminance_min
 			<< lighting.exposure.luminance_max
@@ -2054,6 +2052,11 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 			lighting.bloom_radius;
 
 	pkt << lighting.shadow_direction;
+
+	const auto &s = lighting.static_;
+	pkt << s.light_curve_set;
+	if (s.light_curve_set)
+		pkt.putRawString(reinterpret_cast<const char*>(s.light_curve), sizeof(s.light_curve));
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2057,6 +2057,7 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 	pkt << s.light_curve_set;
 	if (s.light_curve_set)
 		pkt.putRawString(reinterpret_cast<const char*>(s.light_curve), sizeof(s.light_curve));
+	pkt << s.ao_gamma;
 
 	Send(&pkt);
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2042,11 +2042,9 @@ void Server::SendOverrideDayNightRatio(session_t peer_id, bool do_override,
 
 void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 {
-	NetworkPacket pkt(TOCLIENT_SET_LIGHTING,
-			4, peer_id);
+	NetworkPacket pkt(TOCLIENT_SET_LIGHTING, 70, peer_id);
 
-	pkt << lighting.shadow_intensity;
-	pkt << lighting.saturation;
+	pkt << lighting.shadow_intensity << lighting.saturation;
 
 	pkt << lighting.exposure.luminance_min
 			<< lighting.exposure.luminance_max
@@ -2060,6 +2058,12 @@ void Server::SendSetLighting(session_t peer_id, const Lighting &lighting)
 			lighting.bloom_radius;
 
 	pkt << lighting.shadow_direction;
+
+	const auto &s = lighting.static_;
+	pkt << s.light_curve_set;
+	if (s.light_curve_set)
+		pkt.putRawString(reinterpret_cast<const char*>(s.light_curve), sizeof(s.light_curve));
+	pkt << s.ao_gamma;
 
 	Send(&pkt);
 }


### PR DESCRIPTION
closes #14900

Demo video of switching between the normal and Minetest 0.3 light curve:
https://0x0.st/KW6c.mkv.mp4

## To do

This PR is Ready for Review.

- [x] AO gamma

## How to test

randomized light curve every 5s:
```lua
local xtimer = 0
core.register_globalstep(function(dtime)
	xtimer = xtimer + dtime
	if xtimer >= 5.2 then
		xtimer = 0
		local c = {math.random(0,128+64)}
		c[16] = math.random(128-64,255)
		for i = 2, 15 do
			local frac = i / 16
			c[i] = math.floor(c[1] * (1 - frac) + c[16] * frac)
		end
		local g = math.random(0,1000) / 1000 * 2.75 + 0.25
		core.chat_send_all(table.concat(c, ",") .. " | " .. tostring(g))
		for _, player in ipairs(minetest.get_connected_players()) do
			player:set_lighting({
				static = {
					light_curve = c,
					ao_gamma = g,
				}
			})
		end
	end
end)
```

fullbright toggle:
```lua
core.register_chatcommand("fb", {
	func = function(name, param)
		local player = core.get_player_by_name(name)
		if player == nil then return false end
		local c = {}
		if player:get_lighting().static.light_curve[1] ~= 254 then
			c = {254,254,254,254,254,254,254,254,254,254,254,254,254,254,254,255}
		end
		player:set_lighting({
			static = { light_curve = c }
		})
		return true
	end
})
```