### PR TITLE
SDL3: pass X position of text cursor to `SDL_SetTextInputArea`

### DIFF
--- a/irr/include/CGUIEditBox.h
+++ b/irr/include/CGUIEditBox.h
@@ -138,6 +138,8 @@ public:
 	//! Returns whether the element takes input from the IME
 	bool acceptsIME() override { return isEnabled() && IsWritable; };
 
+	u32 getTextInputCursorPosition() override { return CursorVisualX - HScrollPos; };
+
 	//! set true if this EditBox is writable
 	void setWritable(bool writable) { IsWritable = writable; }
 
@@ -199,6 +201,7 @@ protected:
 	core::stringw CursorChar; // IGUIFont::draw needs stringw instead of wchar_t
 	//! Text insertion position. Is `Text.size()` when appending (rightmost position).
 	s32 CursorPos;
+	s32 CursorVisualX; // X offset of the cursor from the left edge of the box.
 	s32 HScrollPos, VScrollPos; // scroll position in characters
 	u32 Max;
 	u32 VScrollBarWidth = 0;

--- a/irr/include/IGUIElement.h
+++ b/irr/include/IGUIElement.h
@@ -687,6 +687,13 @@ public:
 		return false;
 	}
 
+	//! Returns the X coordinate of the relative cursor position for text input.
+	//! This is only relevant if acceptsIME() returns true.
+	virtual u32 getTextInputCursorPosition()
+	{
+		return 0;
+	}
+
 protected:
 	// not virtual because needed in constructor
 	void addChildToEnd(IGUIElement *child)

--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -757,7 +757,6 @@ void CGUIEditBox::draw()
 	IGUIFont *font = getActiveFont();
 
 	s32 cursorLine = 0;
-	s32 charcursorpos = 0;
 
 	if (font) {
 		if (LastBreakFont != font) {
@@ -878,13 +877,13 @@ void CGUIEditBox::draw()
 				startPos = BrokenTextPositions[cursorLine];
 			}
 			s = txtLine->subString(0, CursorPos - startPos);
-			charcursorpos = font->getDimension(s.c_str()).Width +
+			CursorVisualX = font->getDimension(s.c_str()).Width +
 							font->getKerning(CursorChar[0],
 							CursorPos - startPos > 0 ? (*txtLine)[CursorPos - startPos - 1] : 0).X;
 
 			if (focus && (CursorBlinkTime == 0 || (os::Timer::getTime() - BlinkStartTime) % (2 * CursorBlinkTime) < CursorBlinkTime)) {
 				setTextRect(cursorLine);
-				CurrentTextRect.UpperLeftCorner.X += charcursorpos;
+				CurrentTextRect.UpperLeftCorner.X += CursorVisualX;
 
 				if (OverwriteMode) {
 					core::stringw character = Text.subString(CursorPos, 1);

--- a/irr/src/CIrrDeviceSDL.cpp
+++ b/irr/src/CIrrDeviceSDL.cpp
@@ -361,7 +361,7 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents()
 		// sent as text input events instead of the result) when
 		// SDL_StartTextInput() is called on the same input box.
 		core::rect<s32> pos = elem->getAbsolutePosition();
-		if (!SDL_TextInputActive(Window) || lastElemPos != pos) {
+		if (_IRR_USE_SDL3_ || !SDL_TextInputActive(Window) || lastElemPos != pos) {
 			lastElemPos = pos;
 			SDL_Rect rect;
 			rect.x = pos.UpperLeftCorner.X;
@@ -369,11 +369,15 @@ void CIrrDeviceSDL::resetReceiveTextInputEvents()
 			rect.w = pos.getWidth();
 			rect.h = pos.getHeight();
 #ifdef _IRR_USE_SDL3_
-			SDL_SetTextInputArea(Window, &rect, 10);
+			auto cursor = elem->getTextInputCursorPosition();
+			SDL_SetTextInputArea(Window, &rect, cursor);
 #else
 			SDL_SetTextInputRect(&rect);
 #endif
-			SDL_StartTextInput(Window);
+			// SDL2 requires SDL_SetTextInputArea() to be called before SDL_StartTextInput
+			// SDL3 does not have this requirement
+			if (!_IRR_USE_SDL3_ || !SDL_TextInputActive(Window))
+				SDL_StartTextInput(Window);
 		}
 	} else {
 		SDL_StopTextInput(Window);


### PR DESCRIPTION
This PR passes the (relative) X position of the cursor to [`SDL_SetTextInputArea`](https://wiki.libsdl.org/SDL3/SDL_SetTextInputArea). This allows (for example) IMEs to place the candidate list in a way that "follows" the cursor.

- How does the PR work?
  This PR extracts the X position of the cursor to a variable that is exposed with the `getTextInputCursorPosition()` method.
- Does it resolve any reported issue?
  No.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  No.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  This is a minor UI improvement.

## To do

This PR is a Work in Progress.

- [x] `CGUIEditBox`
- [ ] `GUIChatConsole`

## How to test
Enter text with an IME and observe that the candidate list "moves" along with the cursor.
