### PR TITLE
Show proper default key name in reset tooltip on keybindings menu

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -620,7 +620,7 @@ local function get_formspec(dialogdata)
 				default = (default ~= "")
 					and core.get_key_description(default)
 
-					-- Indicates that the action does not have a corresponding keybinding.
+					--~ Indicates that the action does not have a corresponding keybinding.
 					or fgettext_ne("Not bound")
 			end
 

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -616,7 +616,7 @@ local function get_formspec(dialogdata)
 
 		if show_reset then
 			local default = comp.setting.type == "key"
-				and core.scancode_to_key_name(comp.setting.default)
+				and core.scancode_to_keyname(comp.setting.default)
 				or comp.setting.default
 
 			local reset_tooltip = default and

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -615,11 +615,13 @@ local function get_formspec(dialogdata)
 		local info_reset_y = used_h / 2 - 0.25
 
 		if show_reset then
-			local default
+			local default = comp.setting.default
 			if comp.setting.type == "key" then
-				default = (comp.setting.default ~= "")
-					and core.get_key_description(comp.setting.default)
-					or "Not bound"
+				default = (default ~= "")
+					and core.get_key_description(default)
+
+					-- Indicates that the action does not have a corresponding keybinding.
+					or fgettext_ne("Not bound")
 			end
 
 			local reset_tooltip = default and

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -616,7 +616,7 @@ local function get_formspec(dialogdata)
 
 		if show_reset then
 			local default = comp.setting.type == "key"
-				and core.scancode_to_keyname(comp.setting.default)
+				and core.get_key_description(comp.setting.default)
 				or comp.setting.default
 
 			local reset_tooltip = default and

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -615,7 +615,7 @@ local function get_formspec(dialogdata)
 		local info_reset_y = used_h / 2 - 0.25
 
 		if show_reset then
-			local default = comp.setting.type == "key" 
+			local default = comp.setting.type == "key"
 				and core.scancode_to_key_name(comp.setting.default)
 				or comp.setting.default
 

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -615,9 +615,12 @@ local function get_formspec(dialogdata)
 		local info_reset_y = used_h / 2 - 0.25
 
 		if show_reset then
-			local default = comp.setting.type == "key"
-				and core.get_key_description(comp.setting.default)
-				or comp.setting.default
+			local default
+			if comp.setting.type == "key" then
+				default = (comp.setting.default ~= "")
+					and core.get_key_description(comp.setting.default)
+					or "Not bound"
+			end
 
 			local reset_tooltip = default and
 					fgettext("Reset setting to default ($1)", tostring(default)) or

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -616,9 +616,9 @@ local function get_formspec(dialogdata)
 
 		if show_reset then
 			local default = comp.setting.type == "key" 
-    				and core.scancode_to_key_name(comp.setting.default)
-    				or comp.setting.default
-    				
+				and core.scancode_to_key_name(comp.setting.default)
+				or comp.setting.default
+
 			local reset_tooltip = default and
 					fgettext("Reset setting to default ($1)", tostring(default)) or
 					fgettext("Reset setting to default")

--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -615,7 +615,10 @@ local function get_formspec(dialogdata)
 		local info_reset_y = used_h / 2 - 0.25
 
 		if show_reset then
-			local default = comp.setting.default
+			local default = comp.setting.type == "key" 
+    				and core.scancode_to_key_name(comp.setting.default)
+    				or comp.setting.default
+    				
 			local reset_tooltip = default and
 					fgettext("Reset setting to default ($1)", tostring(default)) or
 					fgettext("Reset setting to default")

--- a/src/script/lua_api/l_menu_common.cpp
+++ b/src/script/lua_api/l_menu_common.cpp
@@ -54,11 +54,11 @@ int ModApiMenuCommon::l_normalize_keycode(lua_State *L)
 
 int ModApiMenuCommon::l_scancode_to_keyname(lua_State *L)
 {
-    const char *keystr = luaL_checkstring(L, 1);
-    KeyPress kp(keystr);
-    std::string name = kp.name();
-    lua_pushstring(L, name.c_str());
-    return 1;
+	const char *keystr = luaL_checkstring(L, 1);
+	KeyPress kp(keystr);
+	std::string name = kp.name();
+	lua_pushstring(L, name.c_str());
+	return 1;
 }
 
 
@@ -69,6 +69,7 @@ void ModApiMenuCommon::Initialize(lua_State *L, int top)
 	API_FCT(driver_supports_shadows);
 	API_FCT(irrlicht_device_supports_touch);
 	API_FCT(normalize_keycode);
+	API_FCT(scancode_to_keyname);
 }
 
 

--- a/src/script/lua_api/l_menu_common.cpp
+++ b/src/script/lua_api/l_menu_common.cpp
@@ -52,7 +52,7 @@ int ModApiMenuCommon::l_normalize_keycode(lua_State *L)
 }
 
 
-int ModApiMenuCommon::l_scancode_to_keyname(lua_State *L)
+int ModApiMenuCommon::l_get_key_description(lua_State *L)
 {
 	const char *keystr = luaL_checkstring(L, 1);
 	KeyPress kp(keystr);
@@ -69,7 +69,7 @@ void ModApiMenuCommon::Initialize(lua_State *L, int top)
 	API_FCT(driver_supports_shadows);
 	API_FCT(irrlicht_device_supports_touch);
 	API_FCT(normalize_keycode);
-	API_FCT(scancode_to_keyname);
+	API_FCT(get_key_description);
 }
 
 

--- a/src/script/lua_api/l_menu_common.cpp
+++ b/src/script/lua_api/l_menu_common.cpp
@@ -52,6 +52,16 @@ int ModApiMenuCommon::l_normalize_keycode(lua_State *L)
 }
 
 
+int ModApiMenuCommon::l_scancode_to_keyname(lua_State *L)
+{
+    const char *keystr = luaL_checkstring(L, 1);
+    KeyPress kp(keystr);
+    std::string name = kp.name();
+    lua_pushstring(L, name.c_str());
+    return 1;
+}
+
+
 void ModApiMenuCommon::Initialize(lua_State *L, int top)
 {
 	API_FCT(gettext);

--- a/src/script/lua_api/l_menu_common.h
+++ b/src/script/lua_api/l_menu_common.h
@@ -15,7 +15,7 @@ private:
 	static int l_driver_supports_shadows(lua_State *L);
 	static int l_irrlicht_device_supports_touch(lua_State *L);
 	static int l_normalize_keycode(lua_State *L);
-	static int l_scancode_to_keyname(lua_State *L);
+	static int l_get_key_description(lua_State *L);
 
 public:
 	static void Initialize(lua_State *L, int top);

--- a/src/script/lua_api/l_menu_common.h
+++ b/src/script/lua_api/l_menu_common.h
@@ -15,6 +15,7 @@ private:
 	static int l_driver_supports_shadows(lua_State *L);
 	static int l_irrlicht_device_supports_touch(lua_State *L);
 	static int l_normalize_keycode(lua_State *L);
+	static int l_scancode_to_keyname(lua_State *L);
 
 public:
 	static void Initialize(lua_State *L, int top);


### PR DESCRIPTION
Fixes #16515

This PR fixes an issue in the keybindings menu where the reset button shows a cryptic tooltip such as "Reset setting to default (SYSTEM_SCANCODE_##)".

This also adds a new core function for the main menu `core.get_key_description()` to take a scancode and convert it to the human-readable name that is already available in KeyPress.

## To do

This PR is Ready for Review.

## How to test

<!-- Example code or instructions -->

1. navigate to the keybindings menu inside settings
2. set a keybinding
3. hover over the reset button and observe that it shows a human-readable key name
<img width="551" height="232" alt="Screenshot From 2025-12-24 10-42-59" src="https://github.com/user-attachments/assets/551c9c2d-4cd1-453f-8334-6aef396275b4" />

