### PR TITLE
Add missing "Y" to string in 3d noise settings

### DIFF
--- a/builtin/common/settings/dlg_change_mapgen_flags.lua
+++ b/builtin/common/settings/dlg_change_mapgen_flags.lua
@@ -69,7 +69,7 @@ local function get_formspec(dialogdata)
 			fgettext("This is also the scale of the largest structures in the $1 direction of the noise.", "X")})
 	if dimension == 3 then
 		add_field(3.6, "te_spready", fgettext("$1 spread", "Y"), t[4], {
-			fgettext("Scales the noise in the $1 axis by this value."),
+			fgettext("Scales the noise in the $1 axis by this value.", "Y"),
 			fgettext("This is also the scale of the largest structures in the $1 direction of the noise.", "Y")})
 	else
 		fields[#fields + 1] = "label[4," .. height - 0.2 .. ";" ..


### PR DESCRIPTION
Fixes #16824
## To do

This PR is Ready for Review.


## How to test

<!-- Example code or instructions -->
1. perform steps listed in #16824
2. observe that it shows the correct thing

<img width="427" height="227" alt="Screenshot From 2026-01-08 16-58-14" src="https://github.com/user-attachments/assets/4e2fe62f-6c5c-4995-91a8-d56d211eff0b" />

