### PR TITLE
Add option to open issues with plain markdown template again

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,60 @@
+---
+name: Bug report (template)
+about: Report a problem or mistake
+title: ''
+labels: Unconfirmed bug
+assignees: ''
+---
+
+<!--
+Please note the following:
+
+1. **Update Luanti to the latest stable or dev version** before submitting a bug report. Make sure the bug is still reproducible on the latest version.
+2. This page is for reporting the bugs of **the engine itself**. For bugs in a particular game, please [search for the game on ContentDB](https://content.luanti.org/packages/?type=game) and submit a bug report to its developers.
+    * For example, issues about Minetest Game are submitted to [its own repository](https://github.com/luanti-org/minetest_game/issues).
+3. Please provide as many relevant details as possible.
+4. If you have used an LLM/AI to format your issue description, disclose this. Try to keep it concise. No walls of text please.
+-->
+
+
+##### Luanti version
+<!--
+Paste the Luanti version below.
+Refer to the "About" tab of the menu or run `luanti --version` on the command line.
+-->
+```
+
+```
+
+##### OS, Hardware & Co.
+<!-- Please fill these out: -->
+
+* Operating system and version:
+  Example: Ubuntu 22.04
+* CPU model:
+  (rarely useful)
+* GPU model:
+  (only necessary for graphics issues)
+* "Active renderer":
+  (required for graphics, windowing, and input issues)
+  You can find this in the "About" tab in the main menu.
+  Example: ES 3.2 / ogles2 / X11
+
+
+##### Summary
+<!--
+Describe your problem here.
+
+Make sure to include the all error messages you see and/or screenshots in case of visual bugs.
+Attaching a copy of your `debug.txt` and `minetest.conf` can be helpful as well.
+-->
+
+##### Steps to reproduce
+<!--
+Explain how the problem has happened.
+
+To the extent possible, the reproduction steps should describe not just what you did (e.g. "I open my world and it crashes")
+but be detailed enough so that anyone with a fresh installation of Luanti could follow these steps to encounter the same problem.
+In case of modding issues it is often useful to include a code snippet.
+This will help us diagnose the problem quicker and more efficiently. Thank you.
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ Please note the following:
 -->
 
 
-##### Luanti version
+### Luanti version
 <!--
 Paste the Luanti version below.
 Refer to the "About" tab of the menu or run `luanti --version` on the command line.
@@ -26,7 +26,7 @@ Refer to the "About" tab of the menu or run `luanti --version` on the command li
 
 ```
 
-##### OS, Hardware & Co.
+### OS, Hardware & Co.
 <!-- Please fill these out: -->
 
 * Operating system and version:
@@ -41,7 +41,7 @@ Refer to the "About" tab of the menu or run `luanti --version` on the command li
   Example: ES 3.2 / ogles2 / X11
 
 
-##### Summary
+### Summary
 <!--
 Describe your problem here.
 
@@ -49,7 +49,7 @@ Make sure to include the all error messages you see and/or screenshots in case o
 Attaching a copy of your `debug.txt` and `minetest.conf` can be helpful as well.
 -->
 
-##### Steps to reproduce
+### Steps to reproduce
 <!--
 Explain how the problem has happened.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,4 +1,4 @@
-name: Bug report (form)
+name: Bug report (form, recommended)
 description: Report a problem or mistake
 labels: ["Unconfirmed bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,4 +1,4 @@
-name: Bug report
+name: Bug report (form)
 description: Report a problem or mistake
 labels: ["Unconfirmed bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request (template)
+about: Suggest an idea for this project
+title: ''
+labels: Feature request
+assignees: ''
+---
+
+<!--
+Please note the following:
+1. Only submit a feature request if the feature does not exist on the latest dev version.
+2. This page is for suggesting changes to **the engine itself**. To suggest changes to games, please [search for the game in the ContentDB](https://content.luanti.org/packages/?type=game) and submit a feature request in their issue trackers.
+3. If you have used an LLM/AI to format your issue description, disclose this. Try to keep it concise. No walls of text please.
+-->
+
+### Problem
+
+A clear and concise description of the problem, i.e. "Why is this needed?"
+Example: I'm always frustrated when [...]
+
+### Solutions
+
+A clear and concise description of what you want to happen.
+
+### Alternatives
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,4 +1,4 @@
-name: Feature request
+name: Feature request (form)
 description: Suggest an idea for this project
 labels: ["Feature request"]
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,4 +1,4 @@
-name: Feature request (form)
+name: Feature request (form, recommended)
 description: Suggest an idea for this project
 labels: ["Feature request"]
 body:


### PR DESCRIPTION
* Since #13222, one can only open issues with the github forms thing, or open a blank one.
  I very much dislike these forms. They are so cumbersome to use imo.
  And when opening a blank one it's hard to remember how exactly the issue sections look like usually.
* This PR adds the option to pick either form or template when opening an issue. (Because maybe there are some who prefer form.)
* The templates are based on what was there before #13222, but I've updated them to be mostly consistent with the new versions.

## To do

This PR is a Ready for Review.

## How to test

* Open an issue here: https://github.com/Desour/gh_issue_tmplt_test/issues
  (Idk if there's an easier way to test than to create a new repo. #11403 (an earlier attempt of using gh forms) also did it like this.)
