### PR TITLE
Android: read-only access to Luanti's data directory using DocumentsProvider

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,17 @@
 				android:resource="@xml/filepaths" />
 		</provider>
 
+		<provider
+            android:name="net.minetest.minetest.LuantiDocumentsProvider"
+            android:authorities="net.minetest.minetest.documents"
+            android:exported="true"
+            android:grantUriPermissions="true"
+            android:permission="android.permission.MANAGE_DOCUMENTS">
+            <intent-filter>
+                <action android:name="android.content.action.DOCUMENTS_PROVIDER" />
+            </intent-filter>
+        </provider>
+
 </application>
 
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
 			android:enabled="true"
 			android:exported="false" />
 
+		<!-- FIXME: we can probably drop this and use the documents provider to share files -->
 		<provider
 			android:name="androidx.core.content.FileProvider"
 			android:authorities="net.minetest.minetest.fileprovider"
@@ -61,7 +62,7 @@
 		</provider>
 
 		<provider
-            android:name="net.minetest.minetest.LuantiDocumentsProvider"
+            android:name=".LuantiDocumentsProvider"
             android:authorities="net.minetest.minetest.documents"
             android:exported="true"
             android:grantUriPermissions="true"

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -7,14 +7,25 @@ import java.io.FileNotFoundException;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
 
+  private static final String EXTERNAL_APP_DATA_DIRECTORY = Utils.getUserDataDirectory(getContext()).getAbsolutePath();
+	
   private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {
     Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES,
-    Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE
-	Root.COLUMN_SUMMARY, Root.COLUMN_DOCUMENT_ID};
+    Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE,
+	Root.COLUMN_DOCUMENT_ID};
 	
   @Override
   public Cursor queryRoots(String[] projection) throws FileNotFoundException {
-    
+	// Let's see what happens if I ignore projection
+    final MatrixCursor result = new MatrixCursor(DEFAULT_ROOT_PROJECTION /*resolveRootProjection(projection)*/);
+	final MatrixCursor.RowBuilder appDataRootRow = result.newRow();
+
+	appDataRootRow.add(Root.COLUMN_ROOT_ID, EXTERNAL_APP_DATA_DIRECTORY);
+	appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
+	appDataRootRow.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH);
+    appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+	appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
+	appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, EXTERNAL_APP_DATA_DIRECTORY);
   }
 
   // helper method

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,5 +1,6 @@
 import static android.provider.DocumentsContract.Document;
 import static android.provider.DocumentsContract.Root;
+import static net.minetest.minetest.R;
 
 import android.database.Cursor;
 import android.database.MatrixCursor;

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,7 +1,9 @@
 import android.database.Cursor;
 import android.database.MatrixCursor;
+import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsProvider;
 import android.provider.DocumentsContract.Root;
+import android.provider.DocumentsContract.Document;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -18,7 +20,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
   private static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[] {
     Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME,
     Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED,
-    Document.COLUMN_FLAGS, Document.COLUMN_SIZE,};
+    Document.COLUMN_FLAGS, Document.COLUMN_SIZE};
 	
   @Override
   public Cursor queryRoots(String[] projection) throws FileNotFoundException {
@@ -29,7 +31,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 	
 	appDataRootRow.add(Root.COLUMN_ROOT_ID, EXTERNAL_APP_DATA_DIRECTORY);
     appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
-	appDataRootRow.add(Root.COLUMN_FLAGS, /*Root.FLAG_SUPPORTS_CREATE |*/ Root.FLAG_SUPPORTS_SEARCH);
+	appDataRootRow.add(Root.COLUMN_FLAGS, /*Root.FLAG_SUPPORTS_CREATE |*/ 0);
     appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
 	appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
 	appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, EXTERNAL_APP_DATA_DIRECTORY);
@@ -50,7 +52,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 		childDocumentRow.add(Document.COLUMN_DISPLAY_NAME, child.getName());
 		if (child.isDirectory()) {
 		  childDocumentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
-		else {
+		} else {
           childDocumentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
 		}
 		childDocumentRow.add(Document.COLUMN_LAST_MODIFIED, child.lastModified());
@@ -60,8 +62,41 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
     return result;
 }
 
+@Override
+public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
+
+    final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
+    final File document = new File(documentId);
+    
+        final MatrixCursor.RowBuilder documentRow = result.newRow();
+
+		documentRow.add(Document.COLUMN_DOCUMENT_ID, document.getAbsolutePath());
+		documentRow.add(Document.COLUMN_DISPLAY_NAME, document.getName());
+		if (document.isDirectory()) {
+		  documentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
+	    } else {
+          documentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
+		}
+		documentRow.add(Document.COLUMN_LAST_MODIFIED, document.lastModified());
+		documentRow.add(Document.COLUMN_FLAGS, 0);
+		documentRow.add(Document.COLUMN_SIZE, document.length());
+    
+    return result;
+}
+
+@Override
+public ParcelFileDescriptor openDocument(final String documentId, final String mode, CancellationSignal signal) throws UnsupportedOperationException, FileNotFoundException {
+    final File file = new File(documentId);
+
+	if (mode != "r") {
+      throw UnsupportedOperationException("Only r mode (MODE_READ_ONLY) is supported");
+	}
+
+    return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+}
+	
   // Helper methods
-  private String[] resolveRootProjection(String[] projection) {
+  private static String[] resolveRootProjection(String[] projection) {
     if (projection == null) {
 		return DEFAULT_ROOT_PROJECTION;
 	} else {
@@ -69,7 +104,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 	}
   }
 
-  private String[] resolveDocumentProjection(String[] projection) {
+  private static String[] resolveDocumentProjection(String[] projection) {
     if (projection == null) {
 		return DEFAULT_DOCUMENT_PROJECTION;
 	} else {

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,3 +1,5 @@
+package net.minetest.minetest.LuantiDocumentsProvider;
+
 import static android.provider.DocumentsContract.Document;
 import static android.provider.DocumentsContract.Root;
 

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,16 +1,17 @@
+import static android.provider.DocumentsContract.Root;
+import static android.provider.DocumentsContract.Document;
+
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsProvider;
-import android.provider.DocumentsContract.Root;
-import android.provider.DocumentsContract.Document;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
 
-  private static final String EXTERNAL_APP_DATA_DIRECTORY = Utils.getUserDataDirectory(getContext()).getAbsolutePath();
+  private static final String EXTERNAL_APP_DATA_DIRECTORY = Utils.getUserDataDirectory(this).getAbsolutePath();
 	
   private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {
     Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES,
@@ -21,6 +22,11 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
     Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME,
     Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED,
     Document.COLUMN_FLAGS, Document.COLUMN_SIZE};
+
+  @Override
+  public boolean onCreate() {
+	return true
+  }
 	
   @Override
   public Cursor queryRoots(String[] projection) throws FileNotFoundException {
@@ -31,7 +37,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 	
 	appDataRootRow.add(Root.COLUMN_ROOT_ID, EXTERNAL_APP_DATA_DIRECTORY);
     appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
-	appDataRootRow.add(Root.COLUMN_FLAGS, /*Root.FLAG_SUPPORTS_CREATE |*/ 0);
+	appDataRootRow.add(Root.COLUMN_FLAGS, 0);
     appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
 	appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
 	appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, EXTERNAL_APP_DATA_DIRECTORY);
@@ -89,7 +95,7 @@ public ParcelFileDescriptor openDocument(final String documentId, final String m
     final File file = new File(documentId);
 
 	if (mode != "r") {
-      throw UnsupportedOperationException("Only r mode (MODE_READ_ONLY) is supported");
+      throw new UnsupportedOperationException("Only r mode (MODE_READ_ONLY) is supported");
 	}
 
     return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -3,6 +3,7 @@ import android.database.MatrixCursor;
 import android.provider.DocumentsProvider;
 import android.provider.DocumentsContract.Root;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
@@ -13,25 +14,64 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
     Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES,
     Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE,
 	Root.COLUMN_DOCUMENT_ID};
+
+  private static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[] {
+    Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME,
+    Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED,
+    Document.COLUMN_FLAGS, Document.COLUMN_SIZE,};
 	
   @Override
   public Cursor queryRoots(String[] projection) throws FileNotFoundException {
-	// Let's see what happens if I ignore projection
-    final MatrixCursor result = new MatrixCursor(DEFAULT_ROOT_PROJECTION /*resolveRootProjection(projection)*/);
+	
+    final MatrixCursor result = new MatrixCursor(resolveRootProjection(projection));
 	final MatrixCursor.RowBuilder appDataRootRow = result.newRow();
 
+	
 	appDataRootRow.add(Root.COLUMN_ROOT_ID, EXTERNAL_APP_DATA_DIRECTORY);
-	appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
-	appDataRootRow.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_CREATE | Root.FLAG_SUPPORTS_SEARCH);
+    appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
+	appDataRootRow.add(Root.COLUMN_FLAGS, /*Root.FLAG_SUPPORTS_CREATE |*/ Root.FLAG_SUPPORTS_SEARCH);
     appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
 	appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
 	appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, EXTERNAL_APP_DATA_DIRECTORY);
+
+	
+	return result;
   }
 
-  // helper method
+  @Override
+  public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder) throws FileNotFoundException {
+
+    final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
+    final File parent = new File(parentDocumentId);
+    for (File child : parent.listFiles()) {
+        final MatrixCursor.RowBuilder childDocumentRow = result.newRow();
+
+		childDocumentRow.add(Document.COLUMN_DOCUMENT_ID, child.getAbsolutePath());
+		childDocumentRow.add(Document.COLUMN_DISPLAY_NAME, child.getName());
+		if (child.isDirectory()) {
+		  childDocumentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
+		else {
+          childDocumentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
+		}
+		childDocumentRow.add(Document.COLUMN_LAST_MODIFIED, child.lastModified());
+		childDocumentRow.add(Document.COLUMN_FLAGS, 0);
+		childDocumentRow.add(Document.COLUMN_SIZE, child.length());
+    }
+    return result;
+}
+
+  // Helper methods
   private String[] resolveRootProjection(String[] projection) {
     if (projection == null) {
 		return DEFAULT_ROOT_PROJECTION;
+	} else {
+		return projection;
+	}
+  }
+
+  private String[] resolveDocumentProjection(String[] projection) {
+    if (projection == null) {
+		return DEFAULT_DOCUMENT_PROJECTION;
 	} else {
 		return projection;
 	}

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,7 +1,19 @@
+import android.database.Cursor;
+import android.database.MatrixCursor;
 import android.provider.DocumentsProvider;
+
+import java.io.FileNotFoundException;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
 
   @Override
-  public
+  public Cursor queryRoots(String[] projection) throws FileNotFoundException {
+    
+  }
+
+  // helper method
+  private MatrixCursor resolveRootProjection(String[] projection) {
+    if (projection == null) 
+  }
+	
 }

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,121 +1,107 @@
-import static android.provider.DocumentsContract.Root;
 import static android.provider.DocumentsContract.Document;
+import static android.provider.DocumentsContract.Root;
 
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsProvider;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
-
   private static final String EXTERNAL_APP_DATA_DIRECTORY = Utils.getUserDataDirectory(this).getAbsolutePath();
-	
-  private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {
-    Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES,
-    Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE,
-	Root.COLUMN_DOCUMENT_ID};
 
-  private static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[] {
-    Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME,
-    Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED,
-    Document.COLUMN_FLAGS, Document.COLUMN_SIZE};
+  private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES, Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE, Root.COLUMN_DOCUMENT_ID};
+
+  private static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[] {Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME, Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED, Document.COLUMN_FLAGS, Document.COLUMN_SIZE};
 
   @Override
   public boolean onCreate() {
-	return true
+    return true;
   }
-	
+
   @Override
   public Cursor queryRoots(String[] projection) throws FileNotFoundException {
-	
     final MatrixCursor result = new MatrixCursor(resolveRootProjection(projection));
-	final MatrixCursor.RowBuilder appDataRootRow = result.newRow();
+    final MatrixCursor.RowBuilder appDataRootRow = result.newRow();
 
-	
-	appDataRootRow.add(Root.COLUMN_ROOT_ID, EXTERNAL_APP_DATA_DIRECTORY);
+    appDataRootRow.add(Root.COLUMN_ROOT_ID, EXTERNAL_APP_DATA_DIRECTORY);
     appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
-	appDataRootRow.add(Root.COLUMN_FLAGS, 0);
+    appDataRootRow.add(Root.COLUMN_FLAGS, 0);
     appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
-	appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
-	appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, EXTERNAL_APP_DATA_DIRECTORY);
+    appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
+    appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, EXTERNAL_APP_DATA_DIRECTORY);
 
-	
-	return result;
+    return result;
   }
 
   @Override
   public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder) throws FileNotFoundException {
-
     final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
     final File parent = new File(parentDocumentId);
     for (File child : parent.listFiles()) {
-        final MatrixCursor.RowBuilder childDocumentRow = result.newRow();
+      final MatrixCursor.RowBuilder childDocumentRow = result.newRow();
 
-		childDocumentRow.add(Document.COLUMN_DOCUMENT_ID, child.getAbsolutePath());
-		childDocumentRow.add(Document.COLUMN_DISPLAY_NAME, child.getName());
-		if (child.isDirectory()) {
-		  childDocumentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
-		} else {
-          childDocumentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
-		}
-		childDocumentRow.add(Document.COLUMN_LAST_MODIFIED, child.lastModified());
-		childDocumentRow.add(Document.COLUMN_FLAGS, 0);
-		childDocumentRow.add(Document.COLUMN_SIZE, child.length());
+      childDocumentRow.add(Document.COLUMN_DOCUMENT_ID, child.getAbsolutePath());
+      childDocumentRow.add(Document.COLUMN_DISPLAY_NAME, child.getName());
+      if (child.isDirectory()) {
+        childDocumentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
+      } else {
+        childDocumentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
+      }
+      childDocumentRow.add(Document.COLUMN_LAST_MODIFIED, child.lastModified());
+      childDocumentRow.add(Document.COLUMN_FLAGS, 0);
+      childDocumentRow.add(Document.COLUMN_SIZE, child.length());
     }
     return result;
-}
+  }
 
-@Override
-public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
-
+  @Override
+  public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
     final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
     final File document = new File(documentId);
-    
-        final MatrixCursor.RowBuilder documentRow = result.newRow();
 
-		documentRow.add(Document.COLUMN_DOCUMENT_ID, document.getAbsolutePath());
-		documentRow.add(Document.COLUMN_DISPLAY_NAME, document.getName());
-		if (document.isDirectory()) {
-		  documentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
-	    } else {
-          documentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
-		}
-		documentRow.add(Document.COLUMN_LAST_MODIFIED, document.lastModified());
-		documentRow.add(Document.COLUMN_FLAGS, 0);
-		documentRow.add(Document.COLUMN_SIZE, document.length());
-    
+    final MatrixCursor.RowBuilder documentRow = result.newRow();
+
+    documentRow.add(Document.COLUMN_DOCUMENT_ID, document.getAbsolutePath());
+    documentRow.add(Document.COLUMN_DISPLAY_NAME, document.getName());
+    if (document.isDirectory()) {
+      documentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
+    } else {
+      documentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
+    }
+    documentRow.add(Document.COLUMN_LAST_MODIFIED, document.lastModified());
+    documentRow.add(Document.COLUMN_FLAGS, 0);
+    documentRow.add(Document.COLUMN_SIZE, document.length());
+
     return result;
-}
+  }
 
-@Override
-public ParcelFileDescriptor openDocument(final String documentId, final String mode, CancellationSignal signal) throws UnsupportedOperationException, FileNotFoundException {
+  @Override
+  public ParcelFileDescriptor openDocument(final String documentId, final String mode, CancellationSignal signal) throws UnsupportedOperationException, FileNotFoundException {
     final File file = new File(documentId);
 
-	if (mode != "r") {
+    if (mode != "r") {
       throw new UnsupportedOperationException("Only r mode (MODE_READ_ONLY) is supported");
-	}
+    }
 
     return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
-}
-	
+  }
+
   // Helper methods
   private static String[] resolveRootProjection(String[] projection) {
     if (projection == null) {
-		return DEFAULT_ROOT_PROJECTION;
-	} else {
-		return projection;
-	}
+      return DEFAULT_ROOT_PROJECTION;
+    } else {
+      return projection;
+    }
   }
 
   private static String[] resolveDocumentProjection(String[] projection) {
     if (projection == null) {
-		return DEFAULT_DOCUMENT_PROJECTION;
-	} else {
-		return projection;
-	}
+      return DEFAULT_DOCUMENT_PROJECTION;
+    } else {
+      return projection;
+    }
   }
-	
 }

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,4 +1,4 @@
-package net.minetest.minetest.LuantiDocumentsProvider;
+package net.minetest.minetest;
 
 import static android.provider.DocumentsContract.Document;
 import static android.provider.DocumentsContract.Root;

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,16 +1,18 @@
 import static android.provider.DocumentsContract.Document;
 import static android.provider.DocumentsContract.Root;
-import static net.minetest.minetest.R;
 
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsProvider;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 
+import net.minetest.minetest.Utils;
+
 public class LuantiDocumentsProvider extends DocumentsProvider {
-  private static final String EXTERNAL_APP_DATA_DIRECTORY = Utils.getUserDataDirectory(this).getAbsolutePath();
+  private String externalAppDataDirectory;
 
   private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES, Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE, Root.COLUMN_DOCUMENT_ID};
 
@@ -18,6 +20,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 
   @Override
   public boolean onCreate() {
+	externalAppDataDirectory = Utils.getUserDataDirectory(getContext()).getAbsolutePath();
     return true;
   }
 
@@ -26,12 +29,12 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
     final MatrixCursor result = new MatrixCursor(resolveRootProjection(projection));
     final MatrixCursor.RowBuilder appDataRootRow = result.newRow();
 
-    appDataRootRow.add(Root.COLUMN_ROOT_ID, EXTERNAL_APP_DATA_DIRECTORY);
+    appDataRootRow.add(Root.COLUMN_ROOT_ID, externalAppDataDirectory);
     appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
     appDataRootRow.add(Root.COLUMN_FLAGS, 0);
     appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
     appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
-    appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, EXTERNAL_APP_DATA_DIRECTORY);
+    appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, externalAppDataDirectory);
 
     return result;
   }

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -37,7 +37,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
     appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
     appDataRootRow.add(Root.COLUMN_FLAGS, 0);
     appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
-    appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.documents_provider_root_title));
+    appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.label));
     appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, externalAppDataDirectory);
 
     return result;

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -3,6 +3,7 @@ import static android.provider.DocumentsContract.Root;
 
 import android.database.Cursor;
 import android.database.MatrixCursor;
+import android.os.CancellationSignal;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsProvider;
 
@@ -10,6 +11,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 
 import net.minetest.minetest.Utils;
+import net.minetest.minetest.R;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
   private String externalAppDataDirectory;

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,0 +1,7 @@
+import android.provider.DocumentsProvider;
+
+public class LuantiDocumentsProvider extends DocumentsProvider {
+
+  @Override
+  public
+}

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -1,19 +1,29 @@
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.provider.DocumentsProvider;
+import android.provider.DocumentsContract.Root;
 
 import java.io.FileNotFoundException;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
 
+  private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {
+    Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES,
+    Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE
+	Root.COLUMN_SUMMARY, Root.COLUMN_DOCUMENT_ID};
+	
   @Override
   public Cursor queryRoots(String[] projection) throws FileNotFoundException {
     
   }
 
   // helper method
-  private MatrixCursor resolveRootProjection(String[] projection) {
-    if (projection == null) 
+  private String[] resolveRootProjection(String[] projection) {
+    if (projection == null) {
+		return DEFAULT_ROOT_PROJECTION;
+	} else {
+		return projection;
+	}
   }
 	
 }

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Locale;
 import java.util.regex.Pattern;
 
@@ -26,8 +27,6 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 	private static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[] {
 		Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME, Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED, Document.COLUMN_FLAGS, Document.COLUMN_SIZE
 	};
-
-	private static final String ROOT_ID = "1"; // no particular meaning, we only have one root
 
 	private static final Pattern TEXT_FILE_REGEX = Pattern.compile("\\.(lua|txt|md|example|conf|po|tr|json|obj)$");
 
@@ -44,7 +43,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 		final MatrixCursor result = new MatrixCursor(resolveRootProjection(projection));
 		final MatrixCursor.RowBuilder row = result.newRow();
 
-		row.add(Root.COLUMN_ROOT_ID, ROOT_ID);
+		row.add(Root.COLUMN_ROOT_ID, "1"); // no particular meaning, we only have one root
 		row.add(Root.COLUMN_FLAGS, Root.FLAG_LOCAL_ONLY);
 		row.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
 		row.add(Root.COLUMN_TITLE, getContext().getString(R.string.label));
@@ -54,10 +53,10 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 	}
 
 	/* the provider exposes relative paths, so we have these two helpers */
-	private String makeRelative(@NonNull File file)
+	private String makeRelative(@NonNull File file) throws IOException
 	{
 		final String base = dataDirectory;
-		String fileAbs = file.getAbsolutePath();
+		String fileAbs = file.getCanonicalPath();
 		if (fileAbs.equals(base))
 			return ".";
 		if (fileAbs.length() <= base.length() || !fileAbs.startsWith(base + "/"))
@@ -90,7 +89,13 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 
 	private void makeDocumentRow(@NonNull File file, @NonNull MatrixCursor.RowBuilder row)
 	{
-		final String relative = makeRelative(file);
+		final String relative;
+		try {
+			relative = makeRelative(file);
+		} catch (IOException e) {
+			// document providers are not allowed to throw an IOException, so just bail out
+			return;
+		}
 		row.add(Document.COLUMN_DOCUMENT_ID, relative);
 		row.add(Document.COLUMN_DISPLAY_NAME, file.getName());
 		if (file.isDirectory()) {

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -9,107 +9,147 @@ import android.os.CancellationSignal;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsProvider;
 
+import androidx.annotation.NonNull;
+
 import java.io.File;
 import java.io.FileNotFoundException;
-
-import net.minetest.minetest.Utils;
-import net.minetest.minetest.R;
+import java.util.Locale;
+import java.util.regex.Pattern;
 
 public class LuantiDocumentsProvider extends DocumentsProvider {
-  private String externalAppDataDirectory;
+	private String dataDirectory;
 
-  private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES, Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE, Root.COLUMN_DOCUMENT_ID};
+	private static final String[] DEFAULT_ROOT_PROJECTION = new String[] {
+		Root.COLUMN_ROOT_ID, Root.COLUMN_MIME_TYPES, Root.COLUMN_FLAGS, Root.COLUMN_ICON, Root.COLUMN_TITLE, Root.COLUMN_DOCUMENT_ID
+	};
 
-  private static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[] {Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME, Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED, Document.COLUMN_FLAGS, Document.COLUMN_SIZE};
+	private static final String[] DEFAULT_DOCUMENT_PROJECTION = new String[] {
+		Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME, Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED, Document.COLUMN_FLAGS, Document.COLUMN_SIZE
+	};
 
-  @Override
-  public boolean onCreate() {
-	externalAppDataDirectory = Utils.getUserDataDirectory(getContext()).getAbsolutePath();
-    return true;
-  }
+	private static final String ROOT_ID = "1"; // no particular meaning, we only have one root
 
-  @Override
-  public Cursor queryRoots(String[] projection) throws FileNotFoundException {
-    final MatrixCursor result = new MatrixCursor(resolveRootProjection(projection));
-    final MatrixCursor.RowBuilder appDataRootRow = result.newRow();
+	private static final Pattern TEXT_FILE_REGEX = Pattern.compile("\\.(lua|txt|md|example|conf|po|tr|json|obj)$");
 
-    appDataRootRow.add(Root.COLUMN_ROOT_ID, externalAppDataDirectory);
-    appDataRootRow.add(Root.COLUMN_MIME_TYPES, "*/*");
-    appDataRootRow.add(Root.COLUMN_FLAGS, 0);
-    appDataRootRow.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
-    appDataRootRow.add(Root.COLUMN_TITLE, getContext().getString(R.string.label));
-    appDataRootRow.add(Root.COLUMN_DOCUMENT_ID, externalAppDataDirectory);
+	@Override
+	public boolean onCreate()
+	{
+		dataDirectory = Utils.getUserDataDirectory(getContext()).getAbsolutePath();
+		return true;
+	}
 
-    return result;
-  }
+	@Override
+	public Cursor queryRoots(String[] projection)
+	{
+		final MatrixCursor result = new MatrixCursor(resolveRootProjection(projection));
+		final MatrixCursor.RowBuilder row = result.newRow();
 
-  @Override
-  public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder) throws FileNotFoundException {
-    final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
-    final File parent = new File(parentDocumentId);
-    for (File child : parent.listFiles()) {
-      final MatrixCursor.RowBuilder childDocumentRow = result.newRow();
+		row.add(Root.COLUMN_ROOT_ID, ROOT_ID);
+		row.add(Root.COLUMN_FLAGS, Root.FLAG_LOCAL_ONLY);
+		row.add(Root.COLUMN_ICON, R.mipmap.ic_launcher);
+		row.add(Root.COLUMN_TITLE, getContext().getString(R.string.label));
+		row.add(Root.COLUMN_DOCUMENT_ID, ".");
 
-      childDocumentRow.add(Document.COLUMN_DOCUMENT_ID, child.getAbsolutePath());
-      childDocumentRow.add(Document.COLUMN_DISPLAY_NAME, child.getName());
-      if (child.isDirectory()) {
-        childDocumentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
-      } else {
-        childDocumentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
-      }
-      childDocumentRow.add(Document.COLUMN_LAST_MODIFIED, child.lastModified());
-      childDocumentRow.add(Document.COLUMN_FLAGS, 0);
-      childDocumentRow.add(Document.COLUMN_SIZE, child.length());
-    }
-    return result;
-  }
+		return result;
+	}
 
-  @Override
-  public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
-    final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
-    final File document = new File(documentId);
+	/* the provider exposes relative paths, so we have these two helpers */
+	private String makeRelative(@NonNull File file)
+	{
+		final String base = dataDirectory;
+		String fileAbs = file.getAbsolutePath();
+		if (fileAbs.equals(base))
+			return ".";
+		if (fileAbs.length() <= base.length() || !fileAbs.startsWith(base + "/"))
+			throw new IllegalArgumentException("path is not relative to base");
+		return fileAbs.substring(base.length() + 1);
+	}
 
-    final MatrixCursor.RowBuilder documentRow = result.newRow();
+	private File fromRelative(@NonNull String s)
+	{
+		final String base = dataDirectory;
+		if (s.contains("../"))
+			throw new IllegalArgumentException("no parent folder allowed");
+		return new File(base + "/" + s);
+	}
 
-    documentRow.add(Document.COLUMN_DOCUMENT_ID, document.getAbsolutePath());
-    documentRow.add(Document.COLUMN_DISPLAY_NAME, document.getName());
-    if (document.isDirectory()) {
-      documentRow.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
-    } else {
-      documentRow.add(Document.COLUMN_MIME_TYPE, "*/*");
-    }
-    documentRow.add(Document.COLUMN_LAST_MODIFIED, document.lastModified());
-    documentRow.add(Document.COLUMN_FLAGS, 0);
-    documentRow.add(Document.COLUMN_SIZE, document.length());
+	private String guessMimeType(@NonNull String filename)
+	{
+		filename = filename.toLowerCase(Locale.ROOT);
+		// Perform some basic guessing. This might help other apps handle the files correctly.
+		if (TEXT_FILE_REGEX.matcher(filename).find() || filename.equals("world.mt"))
+			return "text/plain";
+		if (filename.endsWith(".png"))
+			return "image/png";
+		if (filename.endsWith(".jpg") || filename.endsWith(".jpeg"))
+			return "image/jpeg";
+		if (filename.endsWith(".ogg"))
+			return "audio/ogg";
+		return "application/octet-stream";
+	}
 
-    return result;
-  }
+	private void makeDocumentRow(@NonNull File file, @NonNull MatrixCursor.RowBuilder row)
+	{
+		final String relative = makeRelative(file);
+		row.add(Document.COLUMN_DOCUMENT_ID, relative);
+		row.add(Document.COLUMN_DISPLAY_NAME, file.getName());
+		if (file.isDirectory()) {
+			row.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
+		} else {
+			row.add(Document.COLUMN_MIME_TYPE, guessMimeType(file.getName()));
+		}
+		row.add(Document.COLUMN_LAST_MODIFIED, file.lastModified());
+		row.add(Document.COLUMN_FLAGS, 0);
+		row.add(Document.COLUMN_SIZE, file.length());
+	}
 
-  @Override
-  public ParcelFileDescriptor openDocument(final String documentId, final String mode, CancellationSignal signal) throws UnsupportedOperationException, FileNotFoundException {
-    final File file = new File(documentId);
+	@Override
+	public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder)
+	{
+		final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
+		final File parent = fromRelative(parentDocumentId);
+		final File[] files = parent.listFiles();
+		if (files == null)
+			return result;
+		for (File child : files) {
+			if (child.getName().equals(".nomedia"))
+				continue;
+			makeDocumentRow(child, result.newRow());
+		}
+		return result;
+	}
 
-    if (mode != "r") {
-      throw new UnsupportedOperationException("Only r mode (MODE_READ_ONLY) is supported");
-    }
+	@Override
+	public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException
+	{
+		final MatrixCursor result = new MatrixCursor(resolveDocumentProjection(projection));
+		final File file = fromRelative(documentId);
+		if (!file.exists())
+			throw new FileNotFoundException("File not found");
+		makeDocumentRow(file, result.newRow());
+		return result;
+	}
 
-    return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
-  }
+	@Override
+	public ParcelFileDescriptor openDocument(final String documentId, final String mode, CancellationSignal signal)
+		throws UnsupportedOperationException, FileNotFoundException
+	{
+		if (!mode.equals("r"))
+			throw new UnsupportedOperationException("Only reading supported");
+		final File file = fromRelative(documentId);
+		if (!file.exists())
+			throw new FileNotFoundException("File not found");
+		return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY);
+	}
 
-  // Helper methods
-  private static String[] resolveRootProjection(String[] projection) {
-    if (projection == null) {
-      return DEFAULT_ROOT_PROJECTION;
-    } else {
-      return projection;
-    }
-  }
+	// Helper methods
+	private static String[] resolveRootProjection(String[] projection)
+	{
+		return projection == null ? DEFAULT_ROOT_PROJECTION : projection;
+	}
 
-  private static String[] resolveDocumentProjection(String[] projection) {
-    if (projection == null) {
-      return DEFAULT_DOCUMENT_PROJECTION;
-    } else {
-      return projection;
-    }
-  }
+	private static String[] resolveDocumentProjection(String[] projection)
+	{
+		return projection == null ? DEFAULT_DOCUMENT_PROJECTION : projection;
+	}
 }

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -8,6 +8,7 @@ import android.database.MatrixCursor;
 import android.os.CancellationSignal;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsProvider;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -33,8 +34,13 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 	@Override
 	public boolean onCreate()
 	{
-		dataDirectory = Utils.getUserDataDirectory(getContext()).getAbsolutePath();
-		return true;
+		try {
+			dataDirectory = Utils.getUserDataDirectory(getContext()).getCanonicalPath();
+		} catch (IOException e) {
+			Log.w("LuantiDocumentsProvider", e);
+			return false;
+		}
+		return new File(dataDirectory).isDirectory();
 	}
 
 	@Override
@@ -93,8 +99,8 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 		try {
 			relative = makeRelative(file);
 		} catch (IOException e) {
-			// document providers are not allowed to throw an IOException, so just bail out
-			return;
+			Log.w("LuantiDocumentsProvider", "can't make relative: " + file.getAbsolutePath(), e);
+			return; // document providers are not allowed to throw an IOException, so just bail out
 		}
 		row.add(Document.COLUMN_DOCUMENT_ID, relative);
 		row.add(Document.COLUMN_DISPLAY_NAME, file.getName());

--- a/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
+++ b/android/app/src/main/java/net/minetest/minetest/LuantiDocumentsProvider.java
@@ -29,7 +29,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 		Document.COLUMN_DOCUMENT_ID, Document.COLUMN_DISPLAY_NAME, Document.COLUMN_MIME_TYPE, Document.COLUMN_LAST_MODIFIED, Document.COLUMN_FLAGS, Document.COLUMN_SIZE
 	};
 
-	private static final Pattern TEXT_FILE_REGEX = Pattern.compile("\\.(lua|txt|md|example|conf|po|tr|json|obj)$");
+	private static final Pattern TEXT_FILE_REGEX = Pattern.compile("\\.(lua|txt|md|example|conf|po|tr|json)$");
 
 	@Override
 	public boolean onCreate()
@@ -82,6 +82,7 @@ public class LuantiDocumentsProvider extends DocumentsProvider {
 	{
 		filename = filename.toLowerCase(Locale.ROOT);
 		// Perform some basic guessing. This might help other apps handle the files correctly.
+		// See Client::loadMedia() for media file types.
 		if (TEXT_FILE_REGEX.matcher(filename).find() || filename.equals("world.mt"))
 			return "text/plain";
 		if (filename.endsWith(".png"))

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,5 +9,4 @@
 	<string name="game_notification_title">Luanti is running</string>
 	<string name="ime_dialog_done">Done</string>
 	<string name="no_web_browser">No web browser found</string>
-	<string name="documents_provider_root_title">Game Files</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
 	<string name="game_notification_title">Luanti is running</string>
 	<string name="ime_dialog_done">Done</string>
 	<string name="no_web_browser">No web browser found</string>
+	<string name="documents_provider_root_title">Game Files</string>
 </resources>

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -849,6 +849,8 @@ bool Client::loadMedia(const std::string &data, const std::string &filename,
 {
 	std::string name;
 
+	// Consider updating LuantiDocumentsProvider.java if new file types are added
+
 	const char *image_ext[] = {
 		".png", ".jpg", ".tga",
 		NULL


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
Make it possible for Android 11+ users to share or back-up their game data using Android's Storage Access Framework (SAF).
- How does the PR work?
 By implementing Android's ``DocumentsProvider`` interface.

Only implements ``queryRoots``, ``queryChildDocuments``, ``queryDocument`` and ``openDocument``. All those methods were added in API level 19 (Android 4.4).

I've decided not to support creating documents right now because I will also have to support moving, renaming and deleting documents and it will take some time while I want any access to the external app data directory to be added as soon as possible.

~~An interesting fact: Opening and creating were added since DocumentsProvider was first added to API level 19, but moving, renaming and deleting were only added since API level 24 (Android 7.0). However users using Android 4.4 to Android 10 will be able to access the external app data directory anyway so no file stuck problems.~~ wrong.

- Does it resolve any reported issue?
Partially solves #16077 (Opening files only)
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Seems not
- If not a bug fix, why is this PR needed? What usecases does it solve?
Let Android 11+ users share or back-up their game data, although they still can't import it on Android but they can import it on Luanti on Linux, for example
- If you have used an LLM/AI to help with code or assets, you must disclose this.
No LLM/AI was used

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

## How to test

1. Install
2. Using any apps that trigger ``Intent.ACTION_OPEN``, like HTML file input on a web browser.
3. You should see Luanti icon and the text "Game Files" and be able to pick file(s) from Luanti's private data directory.
4. The file(s) should be opened properly.

Update: I changed the root title from "Game Files" to just Luanti in the two latest commits.

Tested on my Samsung Galaxy A14 (Android 15) and works.

I signed the arm64-armv8a and armeabi-v7a action build of commit 109de1b with debug keystore, you can download them here:

https://github.com/oong819/misc-stuff/blob/main/app-arm64-v8a-debug-signed-oong819-%20109de1b.apk

https://github.com/oong819/misc-stuff/blob/main/app-armeabi-v7a-debug-signed-oong819-109de1b.apk

Screenshots:
<img width="1080" height="2408" alt="Screenshot_20260418_225613_Files showing Game Files row with Luanti icon has been added to SAF file picker" src="https://github.com/user-attachments/assets/4a8e72b7-42c1-4533-9fe8-7abf2db0132e" />
<img width="1080" height="2408" alt="Screenshot_20260418_225618_Files showing inside Luanti external app data directory accessed with SAF file picker" src="https://github.com/user-attachments/assets/b7cf791d-9b7d-4ced-b0ad-ed2cbf46fc32" />

Also if you access it before Luanti unzipped anything, it'll just be empty and do not crash, if anyone wondering.