### PR TITLE
Break down `collisionMoveSimple` for easier understanding

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -71,7 +71,7 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
-class KineticObject;
+struct KineticObject;
 
 	struct MovingBox
 	{
@@ -94,9 +94,8 @@ private:
 	bool shouldStepUp(MovingBox const &movingbox, Collision collision, f32 stepheight);
 };
 
-class KineticObject
+struct KineticObject
 {
-public:
 	aabb3f collisionbox;
 	v3f pos;
 	v3f velocity;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -647,7 +647,7 @@ void KineticObject::moveToCollision(
 		Collision collision, v3f avg_speed, f32 dtime, bool step_up)
 {
 	// Move to the point of collision and reduce dtime by collision.dtime
-	if (collision.dtime < 0) {
+	if (collision.dtime < 0.f) {
 		// Handle negative collision.dtime
 		// This largely means an "instant" collision, e.g., with the
 		// floor. We use aspeed and collision.dtime to be consistent

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 // Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
+#include <cassert>
 #include "collision.h"
 #include <cmath>
 #include "irr_aabb3d.h"
+#include <limits>
 #include "mapblock.h"
 #include "map.h"
 #include "nodedef.h"
@@ -19,9 +21,6 @@
 #include "util/timetaker.h"
 #include "profiler.h"
 #include "object_properties.h"
-
-#include <cassert>
-#include <limits>
 #include <vector>
 
 #ifdef __FAST_MATH__
@@ -32,8 +31,6 @@
 bool g_collision_problems_encountered = false;
 
 namespace {
-
-f32 constexpr g_mystery_constant{0.0f};
 
 struct NearbyCollisionInfo {
 	// node
@@ -606,7 +603,7 @@ bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
 			   (movingbox.box.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
 			   (!wouldCollideWithCeiling(cinfo, stepbox,
 					   cbox.MaxEdge.Y - movingbox.box.MinEdge.Y,
-					   g_mystery_constant));
+					   0.0f));
 	} else {
 		return false;
 	}
@@ -766,10 +763,10 @@ void KineticObject::stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
 			X-Z-area.
 		*/
 
-		if (cbox.MaxEdge.X - g_mystery_constant > box.MinEdge.X &&
-				cbox.MinEdge.X + g_mystery_constant < box.MaxEdge.X &&
-				cbox.MaxEdge.Z - g_mystery_constant > box.MinEdge.Z &&
-				cbox.MinEdge.Z + g_mystery_constant < box.MaxEdge.Z) {
+		if (cbox.MaxEdge.X > box.MinEdge.X &&
+				cbox.MinEdge.X < box.MaxEdge.X &&
+				cbox.MaxEdge.Z > box.MinEdge.Z &&
+				cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
 				this->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
 				box = this->collisionbox;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -663,7 +663,7 @@ void KineticObject::moveToCollision(
 				this->pos.Z += avg_speed.Z * collision.dtime;
 			}
 		}
-	} else if (collision.dtime > 0) {
+	} else if (collision.dtime > 0.f) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
 		v3f const subinterval_avg_speed =

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -100,6 +100,8 @@ struct KineticObject
 
 	void moveUnobstructed(f32 dtime);
 
+	void moveUnobstructed(f32 dtime, v3f speed);
+
 	void moveToCollision(
 			Collision collision, v3f avg_speed, f32 dtime, bool step_up);
 
@@ -591,8 +593,13 @@ v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 
 void KineticObject::moveUnobstructed(f32 dtime)
 {
+	this->moveUnobstructed(dtime, this->getProjectedAvgSpeed(dtime));
+}
+
+void KineticObject::moveUnobstructed(f32 dtime, v3f speed)
+{
 	// No collision with any collision box.
-	this->pos += this->getProjectedAvgSpeed(dtime) * dtime;
+	this->pos += speed * dtime;
 	// Final speed:
 	this->velocity += this->accel * dtime;
 	// Limit speed for avoiding hangs
@@ -659,7 +666,7 @@ Collision MovementContext::findNearestCollision(const MovingBox &movingbox)
 void KineticObject::moveToCollision(
 		Collision collision, v3f avg_speed, f32 dtime, bool step_up)
 {
-	// Move to the point of collision and reduce dtime by collision.dtime
+	// Move to the point of collision
 	if (collision.dtime < 0.f) {
 		// Handle negative collision.dtime
 		// This largely means an "instant" collision, e.g., with the
@@ -679,13 +686,12 @@ void KineticObject::moveToCollision(
 	} else if (collision.dtime > 0.f) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
-		const v3f subinterval_avg_speed =
+
+		// We can't use getProjectedAvgSpeed here, because we don't truncate
+		// the velocity before movement.
+		const v3f subinterval_avg_velocity =
 				this->velocity + this->accel * 0.5f * collision.dtime;
-		this->pos += subinterval_avg_speed * collision.dtime;
-		// Speed at (approximated) collision:
-		this->velocity += this->accel * collision.dtime;
-		// Limit speed for avoiding hangs
-		this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
+		this->moveUnobstructed(collision.dtime, subinterval_avg_velocity);
 	}
 }
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -73,8 +73,10 @@ struct NearbyCollisionInfo {
 
 struct Collision
 {
-	// This is the delta between the current dtime and the time at
-	// which the collision is predicted to occur.
+	/**
+	 * This is the delta between the current dtime and the time at
+	 * which the collision is predicted to occur.
+	 */
 	f32 dtime{std::numeric_limits<f32>::infinity()};
 	int boxindex{-1};
 	CollisionAxis axis{COLLISION_AXIS_NONE};

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -108,6 +108,12 @@ struct KineticObject
 	CollisionMoveResult collideWith(Collision collision,
 			NearbyCollisionInfo &nearest_info, bool step_up,
 			StepUpMode step_up_mode);
+
+	void collideX(f32 bounce);
+
+	void collideZ(f32 bounce);
+
+	bool collideY(f32 bounce);
 };
 
 class MovementContext
@@ -712,26 +718,11 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (collision.axis == COLLISION_AXIS_X) {
-		if (bounce < -1e-4 && fabsf(this->velocity.X) > BS * 3) {
-			this->velocity.X *= bounce;
-		} else {
-			this->velocity.X = 0.f;
-			// avoid colliding in the next iterations
-			this->accel.X = 0.f;
-		}
+		this->collideX(bounce);
 	} else if (collision.axis == COLLISION_AXIS_Z) {
-		if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {
-			this->velocity.Z *= bounce;
-		} else {
-			this->velocity.Z = 0.f;
-			// avoid colliding in the next iterations
-			this->accel.Z = 0.f;
-		}
+		this->collideZ(bounce);
 	} else { // collision.axis == COLLISION_AXIS_Y)
-		if (bounce < -1e-4 && fabsf(this->velocity.Y) > BS * 3) {
-			this->velocity.Y *= bounce;
-		} else {
-			if (this->velocity.Y < 0.0f) {
+		if (this->collideY(bounce)) {
 				// FIXME: This code is necessary until
 				// `axisAlignedCollision` takes acceleration
 				// into consideration for the time calculation.
@@ -739,10 +730,6 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 				// especially at high step (dtime) intervals.
 				result.touching_ground    = true;
 				result.standing_on_object = nearest_info.isObject();
-			}
-			this->velocity.Y = 0.f;
-			// avoid colliding in the next iterations
-			this->accel.Y = 0.f;
 		}
 	}
 
@@ -758,6 +745,44 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		result.collisions.push_back(info);
 	}
 
+	return result;
+}
+
+void KineticObject::collideX(f32 bounce)
+{
+	if (bounce < -1e-4 && fabsf(this->velocity.X) > BS * 3) {
+		this->velocity.X *= bounce;
+	} else {
+		this->velocity.X = 0.f;
+		// avoid colliding in the next interations
+		this->accel.X = 0.f;
+	}
+}
+
+void KineticObject::collideZ(f32 bounce)
+{
+	if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {
+		this->velocity.Z *= bounce;
+	} else {
+		this->velocity.Z = 0.f;
+		// avoid colliding in the next iterations
+		this->accel.Z = 0.f;
+	}
+}
+
+bool KineticObject::collideY(f32 bounce)
+{
+	bool result{false};
+	if (bounce < -1e-4 && fabsf(this->velocity.Y) > BS * 3) {
+		this->velocity.Y *= bounce;
+	} else {
+		if (this->velocity.Y < 0.0f) {
+			result = true;
+		}
+		this->velocity.Y = 0.f;
+		// avoid colliding in the next iterations
+		this->accel.Y = 0.f;
+	}
 	return result;
 }
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -106,6 +106,8 @@ struct KineticObject
 
 	v3f getProjectedAvgSpeed(f32 dtime) const;
 
+	void moveUnobstructed(f32 dtime);
+
 	void moveToCollision(
 			Collision collision, v3f avg_speed, f32 dtime, bool step_up);
 
@@ -559,13 +561,7 @@ CollisionMoveResult MovementContext::simulateFor(
 		Collision const collision = this->findNearestCollision(movingbox);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
-			// No collision with any collision box.
-			collider->pos += avg_speed_estimate * this->remaining_dtime;
-			// Final speed:
-			collider->velocity += collider->accel * this->remaining_dtime;
-			// Limit speed for avoiding hangs
-			collider->velocity =
-					truncate(rangelimv(collider->velocity, -5000.0f, 5000.0f), 10000.0f);
+			collider->moveUnobstructed(this->remaining_dtime);
 			break;
 		}
 
@@ -597,6 +593,16 @@ v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 	v3f const avg = this->velocity + this->accel * 0.5f * dtime;
 	// Limit speed for avoiding hangs
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
+}
+
+void KineticObject::moveUnobstructed(f32 dtime)
+{
+	// No collision with any collision box.
+	this->pos += this->getProjectedAvgSpeed(dtime) * dtime;
+	// Final speed:
+	this->velocity += this->accel * dtime;
+	// Limit speed for avoiding hangs
+	this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
 }
 
 bool MovementContext::shouldStepUp(

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -105,10 +105,6 @@ struct KineticObject
 	void moveToCollision(
 			Collision collision, v3f avg_speed, f32 dtime, bool step_up);
 
-	CollisionMoveResult collideWith(Collision collision,
-			NearbyCollisionInfo &nearest_info, bool step_up,
-			StepUpMode step_up_mode);
-
 	void collideX(f32 bounce);
 
 	void collideZ(f32 bounce);
@@ -139,6 +135,9 @@ private:
 			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
 
 	bool shouldStepUp(const MovingBox &movingbox, Collision collision, f32 stepheight);
+
+	CollisionMoveResult collideWith(KineticObject *collider, CollisionAxis axis,
+			NearbyCollisionInfo &nearest_info, bool step_up, StepUpMode step_up_mode);
 
 	void stepUpStairs(KineticObject *collider, CollisionMoveResult &result);
 };
@@ -577,7 +576,8 @@ CollisionMoveResult MovementContext::simulateFor(
 				collision, avg_speed_estimate, this->remaining_dtime, step_up);
 		this->remaining_dtime -= collision.dtime;
 
-		result = collider->collideWith(collision, nearest_info, step_up, step_up_mode);
+		result = this->collideWith(
+				collider, collision.axis, nearest_info, step_up, step_up_mode);
 
 		if (this->remaining_dtime < BS * 1e-10f) {
 			break;
@@ -701,28 +701,28 @@ void KineticObject::moveToCollision(
 	}
 }
 
-CollisionMoveResult KineticObject::collideWith(Collision collision,
+CollisionMoveResult MovementContext::collideWith(KineticObject *collider, CollisionAxis axis,
 		NearbyCollisionInfo &nearest_info, bool step_up, StepUpMode step_up_mode)
 {
 	CollisionMoveResult result;
 
-	v3f old_speed_f = this->velocity;
+	v3f old_speed_f = collider->velocity;
 
 	// Get bounce multiplier
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
 
 	// Set the speed component that caused the collision to zero
 	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
-			(step_up_mode == StepUpMode::FLOATY && this->velocity.Y <= 0.0f) ||
-			(step_up_mode == StepUpMode::RIGID && this->velocity.Y == 0.0f))) {
+			(step_up_mode == StepUpMode::FLOATY && collider->velocity.Y <= 0.0f) ||
+			(step_up_mode == StepUpMode::RIGID && collider->velocity.Y == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
-	} else if (collision.axis == COLLISION_AXIS_X) {
-		this->collideX(bounce);
-	} else if (collision.axis == COLLISION_AXIS_Z) {
-		this->collideZ(bounce);
-	} else { // collision.axis == COLLISION_AXIS_Y)
-		if (this->collideY(bounce)) {
+	} else if (axis == COLLISION_AXIS_X) {
+		collider->collideX(bounce);
+	} else if (axis == COLLISION_AXIS_Z) {
+		collider->collideZ(bounce);
+	} else { // axis == COLLISION_AXIS_Y)
+		if (collider->collideY(bounce)) {
 				// FIXME: This code is necessary until
 				// `axisAlignedCollision` takes acceleration
 				// into consideration for the time calculation.
@@ -735,13 +735,13 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 
 	if (!nearest_info.is_unloaded && !step_up) {
 		CollisionInfo info;
-		info.axis      = collision.axis;
+		info.axis      = axis;
 		info.type      = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
 		info.node_p    = nearest_info.position;
 		info.object    = nearest_info.obj;
-		info.new_pos   = this->pos;
+		info.new_pos   = collider->pos;
 		info.old_speed = old_speed_f;
-		info.new_speed = this->velocity;
+		info.new_speed = collider->velocity;
 		result.collisions.push_back(info);
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -33,7 +33,7 @@ bool g_collision_problems_encountered = false;
 namespace {
 
 template <typename T>
-core::aabbox3d<T> translate(core::aabbox3d<T> const &bbox, core::vector3d<T> const &v)
+core::aabbox3d<T> translate(const core::aabbox3d<T> &bbox, const core::vector3d<T> &v)
 {
 	core::aabbox3d<T> result{bbox};
 	result.MinEdge += v;
@@ -116,7 +116,7 @@ public:
 
 	void jerkUpwards(float dy);
 
-	const aabb3f& getCollisionbox() const
+	const aabb3f &getCollisionbox() const
 	{
 		return this->collisionbox;
 	}
@@ -446,7 +446,7 @@ static void add_object_boxes(Environment *env,
 		LocalPlayer *lplayer = c_env->getLocalPlayer();
 		auto *obj = (ClientActiveObject*) lplayer->getCAO();
 		if (!self || (self != obj && self != obj->getParent())) {
-			aabb3f const lplayer_collisionbox =
+			const aabb3f lplayer_collisionbox =
 					translate(lplayer->getCollisionbox(), lplayer->getPosition());
 			cinfo.emplace_back(obj, 0, lplayer_collisionbox);
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -394,7 +394,7 @@ static bool add_area_node_boxes(const v3s16 min, const v3s16 max, IGameDef *game
 			n.getCollisionBoxes(nodedef, &nodeboxes, neighbors);
 
 			v3f posf = intToFloat(p, BS);
-			for (auto box : nodeboxes) {
+			for (const auto &box : nodeboxes) {
 				cinfo.emplace_back(false, n_bouncy_value, p, translate(box, posf));
 			}
 		} else {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -71,10 +71,21 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
+class KineticObject;
+
+	struct MovingBox
+	{
+		aabb3f box;
+		v3f velocity;
+	};
+
 struct MovementContext
 {
 	std::vector<NearbyCollisionInfo> cinfo;
 	f32 remaining_dtime;
+
+	CollisionMoveResult simulateFor(
+			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
 };
 
 class KineticObject
@@ -85,17 +96,7 @@ public:
 	v3f velocity;
 	v3f accel;
 
-	CollisionMoveResult simulateFor(
-			MovementContext ctx, f32 stepheight, StepUpMode step_up_mode);
-
 	v3f getProjectedAvgSpeed(f32 dtime) const;
-
-private:
-	struct MovingBox
-	{
-		aabb3f box;
-		v3f velocity;
-	};
 
 	void moveToCollision(
 			Collision collision, v3f avg_speed, f32 dtime, bool step_up);
@@ -488,7 +489,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	}
 
 	MovementContext ctx{cinfo, dtime};
-	CollisionMoveResult result = collider.simulateFor(ctx, stepheight, step_up_mode);
+	CollisionMoveResult result = ctx.simulateFor(&collider, stepheight, step_up_mode);
 
 	*pos_f = collider.pos;
 	*speed_f = collider.velocity;
@@ -513,8 +514,8 @@ bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-CollisionMoveResult KineticObject::simulateFor(
-		MovementContext ctx, f32 stepheight, StepUpMode step_up_mode)
+CollisionMoveResult MovementContext::simulateFor(
+		KineticObject *collider, f32 stepheight, StepUpMode step_up_mode)
 {
 	CollisionMoveResult result;
 
@@ -527,43 +528,45 @@ CollisionMoveResult KineticObject::simulateFor(
 			break;
 		}
 
-		v3f const avg_speed_estimate{this->getProjectedAvgSpeed(ctx.remaining_dtime)};
+		v3f const avg_speed_estimate{collider->getProjectedAvgSpeed(this->remaining_dtime)};
 
-		MovingBox movingbox{this->collisionbox, avg_speed_estimate};
-		movingbox.box.MinEdge += this->pos;
-		movingbox.box.MaxEdge += this->pos;
+		MovingBox movingbox{collider->collisionbox, avg_speed_estimate};
+		movingbox.box.MinEdge += collider->pos;
+		movingbox.box.MaxEdge += collider->pos;
 
 		Collision const collision =
-				findNearestCollision(movingbox, ctx.cinfo, ctx.remaining_dtime);
+				collider->findNearestCollision(movingbox, this->cinfo, this->remaining_dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
-			this->pos += avg_speed_estimate * ctx.remaining_dtime;
+			collider->pos += avg_speed_estimate * this->remaining_dtime;
 			// Final speed:
-			this->velocity += this->accel * ctx.remaining_dtime;
+			collider->velocity += collider->accel * this->remaining_dtime;
 			// Limit speed for avoiding hangs
-			this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
+			collider->velocity =
+					truncate(rangelimv(collider->velocity, -5000.0f, 5000.0f), 10000.0f);
 			break;
 		}
 
 		assert(std::isfinite(collision.dtime));
 		// Otherwise, a collision occurred.
-		NearbyCollisionInfo &nearest_info = ctx.cinfo[collision.boxindex];
+		NearbyCollisionInfo &nearest_info = this->cinfo[collision.boxindex];
 
-		bool const step_up =
-				shouldStepUp(movingbox, ctx.remaining_dtime, collision, stepheight, ctx.cinfo);
+		bool const step_up = collider->shouldStepUp(
+				movingbox, this->remaining_dtime, collision, stepheight, this->cinfo);
 
-		this->moveToCollision(collision, avg_speed_estimate, ctx.remaining_dtime, step_up);
-		ctx.remaining_dtime -= collision.dtime;
+		collider->moveToCollision(
+				collision, avg_speed_estimate, this->remaining_dtime, step_up);
+		this->remaining_dtime -= collision.dtime;
 
-		result = this->collideWith(collision, nearest_info, step_up, step_up_mode);
+		result = collider->collideWith(collision, nearest_info, step_up, step_up_mode);
 
-		if (ctx.remaining_dtime < BS * 1e-10f) {
+		if (this->remaining_dtime < BS * 1e-10f) {
 			break;
 		}
 	}
 
-	this->stepUpStairs(ctx.cinfo, result);
+	collider->stepUpStairs(this->cinfo, result);
 	result.collides = !result.collisions.empty();
 
 	return result;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -526,7 +526,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 
 	for (int loopcount = 0;; loopcount++) {
 		if (loopcount >= 100) {
-			warningstream << "collisionMoveSimple: Loop count exceeded, "
+			warningstream << "KineticObject::simulateFor: Loop count exceeded, "
 							 "aborting to avoid infinite loop"
 						  << std::endl;
 			g_collision_problems_encountered = true;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -32,6 +32,15 @@ bool g_collision_problems_encountered = false;
 
 namespace {
 
+template <typename T>
+core::aabbox3d<T> translate(core::aabbox3d<T> const &bbox, core::vector3d<T> const &v)
+{
+	core::aabbox3d<T> result{bbox};
+	result.MinEdge += v;
+	result.MaxEdge += v;
+	return result;
+}
+
 struct NearbyCollisionInfo {
 	// node
 	NearbyCollisionInfo(bool is_ul, int bouncy, v3s16 pos, const aabb3f &box) :
@@ -77,6 +86,11 @@ struct KineticObject
 	v3f pos;
 	v3f velocity;
 	v3f accel;
+
+	aabb3f getAbsCollisionbox() const
+	{
+		return translate(this->collisionbox, this->pos);
+	}
 
 	v3f getProjectedAvgSpeed(f32 dtime) const;
 
@@ -137,15 +151,6 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 		rangelim(vec.Y, low, high),
 		rangelim(vec.Z, low, high)
 	);
-}
-
-template <typename T>
-core::aabbox3d<T> translate(core::aabbox3d<T> const &bbox, core::vector3d<T> const &v)
-{
-	core::aabbox3d<T> result{bbox};
-	result.MinEdge += v;
-	result.MaxEdge += v;
-	return result;
 }
 }
 
@@ -533,8 +538,7 @@ CollisionMoveResult MovementContext::simulateFor(
 
 		v3f const avg_speed_estimate{collider->getProjectedAvgSpeed(this->remaining_dtime)};
 
-		MovingBox movingbox{
-			translate(collider->collisionbox, collider->pos), avg_speed_estimate};
+		MovingBox movingbox{collider->getAbsCollisionbox(), avg_speed_estimate};
 		Collision const collision = this->findNearestCollision(movingbox);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
@@ -743,7 +747,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 	/*
 		Final touches: Check if standing on ground, step up stairs.
 	*/
-	aabb3f box = translate(collider->collisionbox, collider->pos);
+	aabb3f box = collider->getAbsCollisionbox();
 	for (auto const &box_info : this->cinfo) {
 		aabb3f const &cbox = box_info.box;
 
@@ -759,7 +763,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 				cbox.MaxEdge.Z > box.MinEdge.Z && cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
 				collider->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
-				box = translate(collider->collisionbox, collider->pos);
+				box = collider->getAbsCollisionbox();
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
 				// This is code is technically only required if `box_info.is_step_up == true`.

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -82,12 +82,13 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
-struct KineticObject
+class KineticObject
 {
-	aabb3f collisionbox;
-	v3f pos;
-	v3f velocity;
-	v3f accel;
+public:
+	KineticObject(aabb3f cbox, v3f pos, v3f velocity, v3f accel)
+		: collisionbox{cbox}, pos{pos}, velocity{velocity}, accel{accel}
+	{
+	}
 
 	aabb3f getAbsCollisionbox() const
 	{
@@ -114,6 +115,27 @@ struct KineticObject
 	void stopInPlace();
 
 	void jerkUpwards(float dy);
+
+	const aabb3f& getCollisionbox() const
+	{
+		return this->collisionbox;
+	}
+
+	v3f getPosition() const
+	{
+		return this->pos;
+	}
+
+	v3f getVelocity() const
+	{
+		return this->velocity;
+	}
+
+private:
+	aabb3f collisionbox;
+	v3f pos;
+	v3f velocity;
+	v3f accel;
 };
 
 class MovementContext
@@ -494,8 +516,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	CollisionMoveResult result{ctx.collideMove(env, gamedef, stepheight, dtime, &collider,
 			self, collide_with_objects, step_up_mode)};
 
-	*pos_f = collider.pos;
-	*speed_f = collider.velocity;
+	*pos_f = collider.getPosition();
+	*speed_f = collider.getVelocity();
 
 	return result;
 }
@@ -522,8 +544,9 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 
 	// Collect object boxes in movement range
 	if (collide_with_objects) {
-		add_object_boxes(env, collider->collisionbox, this->remaining_dtime, collider->pos,
-				collider->getProjectedAvgSpeed(this->remaining_dtime), self, this->cinfo);
+		add_object_boxes(env, collider->getCollisionbox(), this->remaining_dtime,
+				collider->getPosition(), collider->getProjectedAvgSpeed(this->remaining_dtime),
+				self, this->cinfo);
 	}
 
 	return this->simulateFor(collider, stepheight);
@@ -712,15 +735,16 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 {
 	CollisionMoveResult result;
 
-	v3f old_speed_f = collider->velocity;
+	v3f old_speed_f = collider->getVelocity();
 
 	// Get bounce multiplier
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
 
+	const f32 y_velocity{collider->getVelocity().Y};
 	// Set the speed component that caused the collision to zero
 	if (step_up && (this->step_up_mode == StepUpMode::LEGACY ||
-			(this->step_up_mode == StepUpMode::FLOATY && collider->velocity.Y <= 0.0f) ||
-			(this->step_up_mode == StepUpMode::RIGID && collider->velocity.Y == 0.0f))) {
+			(this->step_up_mode == StepUpMode::FLOATY && y_velocity <= 0.0f) ||
+			(this->step_up_mode == StepUpMode::RIGID && y_velocity == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (axis == COLLISION_AXIS_X) {
@@ -745,9 +769,9 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 		info.type      = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
 		info.node_p    = nearest_info.position;
 		info.object    = nearest_info.obj;
-		info.new_pos   = collider->pos;
+		info.new_pos   = collider->getPosition();
 		info.old_speed = old_speed_f;
-		info.new_speed = collider->velocity;
+		info.new_speed = collider->getVelocity();
 		result.collisions.push_back(info);
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -83,6 +83,9 @@ struct KineticObject
 
 	void moveToCollision(f32 &dtime, Collision collision, bool step_up);
 
+	CollisionMoveResult collideWith(Collision collision,
+			NearbyCollisionInfo &nearest_info, bool step_up,
+			StepUpMode step_up_mode);
 };
 
 // Helper functions:
@@ -123,10 +126,6 @@ static bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed,
 static Collision find_nearest_collision(
 		std::vector<NearbyCollisionInfo> const &cinfo,
 		aabb3f const &movingbox, v3f aspeed_f, f32 dtime);
-
-static CollisionMoveResult collide(KineticObject &collider, Collision collision,
-		NearbyCollisionInfo &nearest_info, bool step_up,
-		StepUpMode step_up_mode);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -512,8 +511,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 		collider.moveToCollision(dtime, collision, step_up);
 
-		result = collide(
-				collider, collision, nearest_info, step_up, step_up_mode);
+		result = collider.collideWith(
+				collision, nearest_info, step_up, step_up_mode);
 
 		if (dtime < BS * 1e-10f)
 			break;
@@ -675,13 +674,13 @@ void KineticObject::moveToCollision(
 	}
 }
 
-CollisionMoveResult collide(KineticObject &collider, Collision collision,
+CollisionMoveResult KineticObject::collideWith(Collision collision,
 		NearbyCollisionInfo &nearest_info, bool step_up,
 		StepUpMode step_up_mode)
 {
 	CollisionMoveResult result;
 
-	v3f old_speed_f = *collider.speed;
+	v3f old_speed_f = *this->speed;
 
 	// Get bounce multiplier
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
@@ -689,24 +688,24 @@ CollisionMoveResult collide(KineticObject &collider, Collision collision,
 	// Set the speed component that caused the collision to zero
 	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
 						   (step_up_mode == StepUpMode::FLOATY &&
-								   collider.speed->Y <= 0.0f) ||
+								   this->speed->Y <= 0.0f) ||
 						   (step_up_mode == StepUpMode::RIGID &&
-								   collider.speed->Y == 0.0f))) {
+								   this->speed->Y == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (collision.axis == COLLISION_AXIS_X) {
-		if (bounce < -1e-4 && fabsf(collider.speed->X) > BS * 3) {
-			collider.speed->X *= bounce;
+		if (bounce < -1e-4 && fabsf(this->speed->X) > BS * 3) {
+			this->speed->X *= bounce;
 		} else {
-			collider.speed->X = 0;
+			this->speed->X = 0;
 			// avoid colliding in the next iterations
-			collider.accel->X = 0;
+			this->accel->X = 0;
 		}
 	} else if (collision.axis == COLLISION_AXIS_Y) {
-		if (bounce < -1e-4 && fabsf(collider.speed->Y) > BS * 3) {
-			collider.speed->Y *= bounce;
+		if (bounce < -1e-4 && fabsf(this->speed->Y) > BS * 3) {
+			this->speed->Y *= bounce;
 		} else {
-			if (collider.speed->Y < 0.0f) {
+			if (this->speed->Y < 0.0f) {
 				// FIXME: This code is necessary until
 				// `axisAlignedCollision` takes acceleration
 				// into consideration for the time calculation.
@@ -715,17 +714,17 @@ CollisionMoveResult collide(KineticObject &collider, Collision collision,
 				result.touching_ground    = true;
 				result.standing_on_object = nearest_info.isObject();
 			}
-			collider.speed->Y = 0;
+			this->speed->Y = 0;
 			// avoid colliding in the next iterations
-			collider.accel->Y = 0;
+			this->accel->Y = 0;
 		}
 	} else { /* collision.axis == COLLISION_AXIS_Z */
-		if (bounce < -1e-4 && fabsf(collider.speed->Z) > BS * 3) {
-			collider.speed->Z *= bounce;
+		if (bounce < -1e-4 && fabsf(this->speed->Z) > BS * 3) {
+			this->speed->Z *= bounce;
 		} else {
-			collider.speed->Z = 0;
+			this->speed->Z = 0;
 			// avoid colliding in the next iterations
-			collider.accel->Z = 0;
+			this->accel->Z = 0;
 		}
 	}
 
@@ -735,9 +734,9 @@ CollisionMoveResult collide(KineticObject &collider, Collision collision,
 		info.type = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
 		info.node_p    = nearest_info.position;
 		info.object    = nearest_info.obj;
-		info.new_pos   = *collider.pos;
+		info.new_pos   = *this->pos;
 		info.old_speed = old_speed_f;
-		info.new_speed = *collider.speed;
+		info.new_speed = *this->speed;
 		result.collisions.push_back(info);
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -89,8 +89,9 @@ public:
 	v3f *avg_speed;
 	v3f *accel;
 
-	collisionMoveResult simulateFor(std::vector<NearbyCollisionInfo> &cinfo,
-			f32 stepheight, StepUpMode step_up_mode, f32 dtime);
+	collisionMoveResult simulateFor(f32 dtime,
+			std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
+			StepUpMode step_up_mode);
 
 private:
 	void moveToCollision(Collision collision, f32 &dtime, bool step_up);
@@ -487,7 +488,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	}
 
 	CollisionMoveResult result =
-			collider.simulateFor(cinfo, stepheight, step_up_mode, dtime);
+			collider.simulateFor(dtime, cinfo, stepheight, step_up_mode);
 
 	/*
 		Final touches: Check if standing on ground, step up stairs.
@@ -549,9 +550,9 @@ bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-collisionMoveResult KineticObject::simulateFor(
+collisionMoveResult KineticObject::simulateFor(f32 dtime,
 		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
-		StepUpMode step_up_mode, f32 dtime)
+		StepUpMode step_up_mode)
 {
 	collisionMoveResult result;
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -539,7 +539,8 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		movingbox.box.MinEdge += this->pos;
 		movingbox.box.MaxEdge += this->pos;
 
-		Collision collision = find_nearest_collision(movingbox, cinfo, dtime);
+		Collision const collision =
+				find_nearest_collision(movingbox, cinfo, dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
@@ -556,7 +557,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 
-		bool step_up =
+		bool const step_up =
 				should_step_up(movingbox, dtime, collision, stepheight, cinfo);
 
 		this->moveToCollision(collision, avg_speed_estimate, dtime, step_up);

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -77,7 +77,7 @@ struct KineticObject
 	v3f *pos;
 	v3f *speed;
 	v3f *avg_speed;
-	v3f accel;
+	v3f *accel;
 };
 
 // Helper functions:
@@ -113,6 +113,10 @@ static Collision find_nearest_collision(
 
 static void move_object_to_collision(KineticObject &collider, f32 &dtime,
 		Collision collision, bool step_up);
+
+static void collide(KineticObject &collider, Collision collision,
+		NearbyCollisionInfo &nearest_info, bool step_up,
+		StepUpMode step_up_mode, CollisionMoveResult &result);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -530,49 +534,13 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 						d));
 		}
 
-		// Get bounce multiplier
-		float bounce = -(float)nearest_info.bouncy / 100.0f;
-
-		KineticObject collider{pos_f, speed_f, &aspeed_f, accel_f};
+		KineticObject collider{pos_f, speed_f, &aspeed_f, &accel_f};
 		move_object_to_collision(collider, dtime, collision, step_up);
 
 		v3f old_speed_f = *speed_f;
 
-		// Set the speed component that caused the collision to zero
-		if (step_up && (step_up_mode == StepUpMode::LEGACY ||
-				(step_up_mode == StepUpMode::FLOATY && speed_f->Y <= 0.0f) ||
-				(step_up_mode == StepUpMode::RIGID && speed_f->Y == 0.0f))) {
-			// Special case: Handle stairs
-			nearest_info.is_step_up = true;
-		} else if (collision.axis == COLLISION_AXIS_X) {
-			if (bounce < -1e-4 && fabsf(speed_f->X) > BS * 3) {
-				speed_f->X *= bounce;
-			} else {
-				speed_f->X = 0;
-				accel_f.X = 0; // avoid colliding in the next iterations
-			}
-		} else if (collision.axis == COLLISION_AXIS_Y) {
-			if (bounce < -1e-4 && fabsf(speed_f->Y) > BS * 3) {
-				speed_f->Y *= bounce;
-			} else {
-				if (speed_f->Y < 0.0f) {
-					// FIXME: This code is necessary until `axisAlignedCollision` takes acceleration
-					// into consideration for the time calculation. Otherwise, the colliding faces
-					// never line up, especially at high step (dtime) intervals.
-					result.touching_ground = true;
-					result.standing_on_object = nearest_info.isObject();
-				}
-				speed_f->Y = 0;
-				accel_f.Y = 0; // avoid colliding in the next iterations
-			}
-		} else { /* collision.axis == COLLISION_AXIS_Z */
-			if (bounce < -1e-4 && fabsf(speed_f->Z) > BS * 3) {
-				speed_f->Z *= bounce;
-			} else {
-				speed_f->Z = 0;
-				accel_f.Z = 0; // avoid colliding in the next iterations
-			}
-		}
+		collide(collider, collision, nearest_info, step_up, step_up_mode,
+				result);
 
 		if (!nearest_info.is_unloaded && !step_up) {
 			CollisionInfo info;
@@ -688,18 +656,69 @@ void move_object_to_collision(KineticObject &collider, f32 &dtime,
 	} else if (collision.dtime > 0) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
-		*collider.avg_speed = *collider.speed +
-				      collider.accel * 0.5f * collision.dtime;
+		*collider.avg_speed =
+				*collider.speed + *collider.accel * 0.5f * collision.dtime;
 		*collider.pos += *collider.avg_speed * collision.dtime;
 		// Speed at (approximated) collision:
-		*collider.speed += collider.accel * collision.dtime;
+		*collider.speed += *collider.accel * collision.dtime;
 		// Limit speed for avoiding hangs
 		*collider.speed = truncate(
-				rangelimv(*collider.speed, -5000.0f, 5000.0f),
-				10000.0f);
+				rangelimv(*collider.speed, -5000.0f, 5000.0f), 10000.0f);
 		dtime -= collision.dtime;
 	}
 }
+
+void collide(KineticObject &collider, Collision collision,
+		NearbyCollisionInfo &nearest_info, bool step_up,
+		StepUpMode step_up_mode, CollisionMoveResult &result)
+{
+	// Get bounce multiplier
+	float bounce = -(float) nearest_info.bouncy / 100.0f;
+
+	// Set the speed component that caused the collision to zero
+	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
+						   (step_up_mode == StepUpMode::FLOATY &&
+								   collider.speed->Y <= 0.0f) ||
+						   (step_up_mode == StepUpMode::RIGID &&
+								   collider.speed->Y == 0.0f))) {
+		// Special case: Handle stairs
+		nearest_info.is_step_up = true;
+	} else if (collision.axis == COLLISION_AXIS_X) {
+		if (bounce < -1e-4 && fabsf(collider.speed->X) > BS * 3) {
+			collider.speed->X *= bounce;
+		} else {
+			collider.speed->X = 0;
+			// avoid colliding in the next iterations
+			collider.accel->X = 0;
+		}
+	} else if (collision.axis == COLLISION_AXIS_Y) {
+		if (bounce < -1e-4 && fabsf(collider.speed->Y) > BS * 3) {
+			collider.speed->Y *= bounce;
+		} else {
+			if (collider.speed->Y < 0.0f) {
+				// FIXME: This code is necessary until
+				// `axisAlignedCollision` takes acceleration
+				// into consideration for the time calculation.
+				// Otherwise, the colliding faces never line up,
+				// especially at high step (dtime) intervals.
+				result.touching_ground    = true;
+				result.standing_on_object = nearest_info.isObject();
+			}
+			collider.speed->Y = 0;
+			// avoid colliding in the next iterations
+			collider.accel->Y = 0;
+		}
+	} else { /* collision.axis == COLLISION_AXIS_Z */
+		if (bounce < -1e-4 && fabsf(collider.speed->Z) > BS * 3) {
+			collider.speed->Z *= bounce;
+		} else {
+			collider.speed->Z = 0;
+			// avoid colliding in the next iterations
+			collider.accel->Z = 0;
+		}
+	}
+}
+
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,
 		const aabb3f &box_0, const v3f &pos_f, ActiveObject *self,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -702,7 +702,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		} else {
 			this->velocity.X = 0.f;
 			// avoid colliding in the next iterations
-			this->accel.X = 0;
+			this->accel.X = 0.f;
 		}
 	} else if (collision.axis == COLLISION_AXIS_Y) {
 		if (bounce < -1e-4 && fabsf(this->velocity.Y) > BS * 3) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -74,7 +74,7 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
-struct KineticBox
+struct MovingBox
 {
 	aabb3f box;
 	v3f avg_speed;
@@ -138,11 +138,11 @@ static bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
 		IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo);
 
-static bool should_step_up(KineticBox const &movingbox, f32 dtime,
+static bool should_step_up(MovingBox const &movingbox, f32 dtime,
 		Collision collision, f32 stepheight,
 		std::vector<NearbyCollisionInfo> const &cinfo);
 
-static Collision find_nearest_collision(KineticBox const &movingbox,
+static Collision find_nearest_collision(MovingBox const &movingbox,
 		std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime);
 
 // Helper function:
@@ -532,7 +532,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 
 		v3f const avg_speed_estimate{this->getProjectedAvgSpeed(dtime)};
 
-		KineticBox movingbox{this->collisionbox, avg_speed_estimate};
+		MovingBox movingbox{this->collisionbox, avg_speed_estimate};
 		movingbox.box.MinEdge += *this->pos;
 		movingbox.box.MaxEdge += *this->pos;
 
@@ -580,7 +580,7 @@ v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
 
-bool should_step_up(KineticBox const &movingbox, f32 dtime, Collision collision,
+bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
 		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo)
 {
 	if (collision.axis != COLLISION_AXIS_Y) {
@@ -608,7 +608,7 @@ bool should_step_up(KineticBox const &movingbox, f32 dtime, Collision collision,
 	}
 }
 
-Collision find_nearest_collision(KineticBox const &movingbox,
+Collision find_nearest_collision(MovingBox const &movingbox,
 		std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime)
 {
 	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -112,15 +112,6 @@ public:
 
 	bool collideY(f32 bounce);
 
-	void stopInPlace();
-
-	void jerkUpwards(float dy);
-
-	const aabb3f &getCollisionbox() const
-	{
-		return collisionbox;
-	}
-
 	v3f getPosition() const
 	{
 		return pos;
@@ -136,8 +127,12 @@ private:
 	v3f pos;
 	v3f velocity;
 	v3f accel;
+
+	friend class MovementContext;
 };
 
+// This class is a friend of KineticObject. It is responsible for upholding all
+// invariants of KineticObject at all times.
 class MovementContext
 {
 public:
@@ -542,15 +537,14 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
 	const core::aabbox3d<s16> range{collider->getMovementRange(remaining_dtime)};
 	if (!add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, cinfo)) {
-		collider->stopInPlace();
+		collider->velocity = v3f();
 		return CollisionMoveResult{};
 	}
 
 	// Collect object boxes in movement range
 	if (collide_with_objects) {
-		add_object_boxes(env, collider->getCollisionbox(), remaining_dtime,
-				collider->getPosition(), collider->getProjectedAvgSpeed(remaining_dtime),
-				self, cinfo);
+		add_object_boxes(env, collider->collisionbox, remaining_dtime, collider->pos,
+				collider->getProjectedAvgSpeed(remaining_dtime), self, cinfo);
 	}
 
 	return simulateFor(collider);
@@ -574,11 +568,6 @@ core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
 	v3s16 min = floatToInt(minpos + collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
 	v3s16 max = floatToInt(maxpos + collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
 	return core::aabbox3d<s16>{min, max};
-}
-
-void KineticObject::stopInPlace()
-{
-	velocity = v3f();
 }
 
 CollisionMoveResult MovementContext::simulateFor(KineticObject *collider)
@@ -772,9 +761,9 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 		info.type      = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
 		info.node_p    = nearest_info.position;
 		info.object    = nearest_info.obj;
-		info.new_pos   = collider->getPosition();
+		info.new_pos   = collider->pos;
 		info.old_speed = old_speed_f;
-		info.new_speed = collider->getVelocity();
+		info.new_speed = collider->velocity;
 		result.collisions.push_back(info);
 	}
 
@@ -839,7 +828,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 		if (cbox.MaxEdge.X > box.MinEdge.X && cbox.MinEdge.X < box.MaxEdge.X &&
 				cbox.MaxEdge.Z > box.MinEdge.Z && cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
-				collider->jerkUpwards(cbox.MaxEdge.Y - box.MinEdge.Y);
+				collider->pos.Y += (cbox.MaxEdge.Y - box.MinEdge.Y);
 				box = collider->getAbsCollisionbox();
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
@@ -851,11 +840,6 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 			}
 		}
 	}
-}
-
-void KineticObject::jerkUpwards(f32 dy)
-{
-	pos.Y += dy;
 }
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -125,12 +125,12 @@ private:
 		v3f velocity;
 	};
 
-	Collision findNearestCollision(MovingBox const &movingbox);
+	Collision findNearestCollision(const MovingBox &movingbox);
 
 	CollisionMoveResult simulateFor(
 			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
 
-	bool shouldStepUp(MovingBox const &movingbox, Collision collision, f32 stepheight);
+	bool shouldStepUp(const MovingBox &movingbox, Collision collision, f32 stepheight);
 
 	void stepUpStairs(KineticObject *collider, CollisionMoveResult &result);
 };
@@ -504,7 +504,7 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 	// are not available for collision detection.
 	// This also intentionally occurs in the case of the object being positioned
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-	core::aabbox3d<s16> const range{collider->getMovementRange(this->remaining_dtime)};
+	const core::aabbox3d<s16> range{collider->getMovementRange(this->remaining_dtime)};
 	if (!add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, this->cinfo)) {
 		collider->velocity = v3f();
 		return CollisionMoveResult{};
@@ -512,7 +512,8 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 
 	// Collect object boxes in movement range
 	if (collide_with_objects) {
-		add_object_boxes(env, collider->collisionbox, this->remaining_dtime, collider->pos, collider->getProjectedAvgSpeed(this->remaining_dtime), self, this->cinfo);
+		add_object_boxes(env, collider->collisionbox, this->remaining_dtime, collider->pos,
+				collider->getProjectedAvgSpeed(this->remaining_dtime), self, this->cinfo);
 	}
 
 	return this->simulateFor(collider, stepheight, step_up_mode);
@@ -548,10 +549,10 @@ CollisionMoveResult MovementContext::simulateFor(
 			break;
 		}
 
-		v3f const avg_speed_estimate{collider->getProjectedAvgSpeed(this->remaining_dtime)};
+		const v3f avg_speed_estimate{collider->getProjectedAvgSpeed(this->remaining_dtime)};
 
 		MovingBox movingbox{collider->getAbsCollisionbox(), avg_speed_estimate};
-		Collision const collision = this->findNearestCollision(movingbox);
+		const Collision collision = this->findNearestCollision(movingbox);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			collider->moveUnobstructed(this->remaining_dtime);
@@ -562,7 +563,7 @@ CollisionMoveResult MovementContext::simulateFor(
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = this->cinfo[collision.boxindex];
 
-		bool const step_up = this->shouldStepUp(movingbox, collision, stepheight);
+		const bool step_up = this->shouldStepUp(movingbox, collision, stepheight);
 
 		collider->moveToCollision(
 				collision, avg_speed_estimate, this->remaining_dtime, step_up);
@@ -583,7 +584,7 @@ CollisionMoveResult MovementContext::simulateFor(
 
 v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 {
-	v3f const avg = this->velocity + this->accel * 0.5f * dtime;
+	const v3f avg = this->velocity + this->accel * 0.5f * dtime;
 	// Limit speed for avoiding hangs
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
@@ -599,7 +600,7 @@ void KineticObject::moveUnobstructed(f32 dtime)
 }
 
 bool MovementContext::shouldStepUp(
-		MovingBox const &movingbox, Collision collision, f32 stepheight)
+		const MovingBox &movingbox, Collision collision, f32 stepheight)
 {
 	if (collision.axis != COLLISION_AXIS_Y) {
 		// movingbox except moved to the horizontal position it would be after
@@ -615,7 +616,7 @@ bool MovementContext::shouldStepUp(
 		stepbox.MaxEdge.X += movingbox.velocity.X * extra_dtime;
 		stepbox.MaxEdge.Z += movingbox.velocity.Z * extra_dtime;
 		// Check for stairs.
-		aabb3f const &cbox = this->cinfo[collision.boxindex].box;
+		const aabb3f &cbox = this->cinfo[collision.boxindex].box;
 		return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
 			   (movingbox.box.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
 			   (!wouldCollideWithCeiling(
@@ -625,7 +626,7 @@ bool MovementContext::shouldStepUp(
 	}
 }
 
-Collision MovementContext::findNearestCollision(MovingBox const &movingbox)
+Collision MovementContext::findNearestCollision(const MovingBox &movingbox)
 {
 	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;
 	f32 nearest_dtime              = this->remaining_dtime;
@@ -633,7 +634,7 @@ Collision MovementContext::findNearestCollision(MovingBox const &movingbox)
 
 	// Go through every nodebox, find nearest collision
 	for (u32 boxindex = 0; boxindex < this->cinfo.size(); boxindex++) {
-		NearbyCollisionInfo const &box_info = this->cinfo[boxindex];
+		const NearbyCollisionInfo &box_info = this->cinfo[boxindex];
 		// Ignore if already stepped up this nodebox.
 		if (box_info.is_step_up) {
 			continue;
@@ -678,7 +679,7 @@ void KineticObject::moveToCollision(
 	} else if (collision.dtime > 0.f) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
-		v3f const subinterval_avg_speed =
+		const v3f subinterval_avg_speed =
 				this->velocity + this->accel * 0.5f * collision.dtime;
 		this->pos += subinterval_avg_speed * collision.dtime;
 		// Speed at (approximated) collision:
@@ -760,8 +761,8 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 		Final touches: Check if standing on ground, step up stairs.
 	*/
 	aabb3f box = collider->getAbsCollisionbox();
-	for (auto const &box_info : this->cinfo) {
-		aabb3f const &cbox = box_info.box;
+	for (const auto &box_info : this->cinfo) {
+		const aabb3f &cbox = box_info.box;
 
 		/*
 			See if the object is touching ground.

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -88,7 +88,7 @@ public:
 	v3f *speed;
 	v3f *accel;
 
-	collisionMoveResult simulateFor(f32 dtime,
+	CollisionMoveResult simulateFor(f32 dtime,
 			std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
 			StepUpMode step_up_mode);
 
@@ -101,6 +101,10 @@ private:
 	CollisionMoveResult collideWith(Collision collision,
 			NearbyCollisionInfo &nearest_info, bool step_up,
 			StepUpMode step_up_mode);
+
+	void stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
+			CollisionMoveResult &result);
+
 };
 
 // Helper functions:
@@ -487,42 +491,6 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	CollisionMoveResult result =
 			collider.simulateFor(dtime, cinfo, stepheight, step_up_mode);
 
-	/*
-		Final touches: Check if standing on ground, step up stairs.
-	*/
-	aabb3f box = box_0;
-	box.MinEdge += *pos_f;
-	box.MaxEdge += *pos_f;
-	for (const auto &box_info : cinfo) {
-		const aabb3f &cbox = box_info.box;
-
-		/*
-			See if the object is touching ground.
-
-			Object touches ground if object's minimum Y is near node's
-			maximum Y and object's X-Z-area overlaps with the node's
-			X-Z-area.
-		*/
-
-		if (cbox.MaxEdge.X - g_mystery_constant > box.MinEdge.X && cbox.MinEdge.X + g_mystery_constant < box.MaxEdge.X &&
-				cbox.MaxEdge.Z - g_mystery_constant > box.MinEdge.Z &&
-				cbox.MinEdge.Z + g_mystery_constant < box.MaxEdge.Z) {
-			if (box_info.is_step_up) {
-				pos_f->Y += cbox.MaxEdge.Y - box.MinEdge.Y;
-				box = box_0;
-				box.MinEdge += *pos_f;
-				box.MaxEdge += *pos_f;
-			}
-			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
-				// This code is technically only required if `box_info.is_step_up == true`.
-				// However, players rely on this check/condition to climb stairs faster. See PR #10587.
-				result.touching_ground = true;
-				result.standing_on_object = box_info.isObject();
-			}
-		}
-	}
-
-	result.collides = !result.collisions.empty();
 	return result;
 }
 
@@ -547,11 +515,11 @@ bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-collisionMoveResult KineticObject::simulateFor(f32 dtime,
+CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
 		StepUpMode step_up_mode)
 {
-	collisionMoveResult result;
+	CollisionMoveResult result;
 
 	for (int loopcount = 0;; loopcount++) {
 		if (loopcount >= 100) {
@@ -598,6 +566,9 @@ collisionMoveResult KineticObject::simulateFor(f32 dtime,
 			break;
 		}
 	}
+
+	this->stepUpStairs(cinfo, result);
+	result.collides = !result.collisions.empty();
 
 	return result;
 }
@@ -769,6 +740,47 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 	}
 
 	return result;
+}
+
+void KineticObject::stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
+		CollisionMoveResult &result)
+{
+	/*
+		Final touches: Check if standing on ground, step up stairs.
+	*/
+	aabb3f box = this->collisionbox;
+	box.MinEdge += *this->pos;
+	box.MaxEdge += *this->pos;
+	for (auto const &box_info : cinfo) {
+		aabb3f const &cbox = box_info.box;
+
+		/*
+			See if the object is touching ground.
+
+			Object touches ground if object's minimum Y is near node's
+			maximum Y and object's X-Z-area overlaps with the node's
+			X-Z-area.
+		*/
+
+		if (cbox.MaxEdge.X - g_mystery_constant > box.MinEdge.X &&
+				cbox.MinEdge.X + g_mystery_constant < box.MaxEdge.X &&
+				cbox.MaxEdge.Z - g_mystery_constant > box.MinEdge.Z &&
+				cbox.MinEdge.Z + g_mystery_constant < box.MaxEdge.Z) {
+			if (box_info.is_step_up) {
+				this->pos->Y += cbox.MaxEdge.Y - box.MinEdge.Y;
+				box = this->collisionbox;
+				box.MinEdge += *this->pos;
+				box.MaxEdge += *this->pos;
+			}
+			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
+				// This is code is technically only required if
+				// `box_info.is_step_up == true`. However, players rely on this
+				// check/condition to climb stairs faster. See PR #10587.
+				result.touching_ground    = true;
+				result.standing_on_object = box_info.isObject();
+			}
+		}
+	}
 }
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -138,6 +138,15 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 		rangelim(vec.Z, low, high)
 	);
 }
+
+template <typename T>
+core::aabbox3d<T> translate(core::aabbox3d<T> const &bbox, core::vector3d<T> const &v)
+{
+	core::aabbox3d<T> result{bbox};
+	result.MinEdge += v;
+	result.MaxEdge += v;
+	return result;
+}
 }
 
 static bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
@@ -345,9 +354,7 @@ static bool add_area_node_boxes(const v3s16 min, const v3s16 max, IGameDef *game
 
 			v3f posf = intToFloat(p, BS);
 			for (auto box : nodeboxes) {
-				box.MinEdge += posf;
-				box.MaxEdge += posf;
-				cinfo.emplace_back(false, n_bouncy_value, p, box);
+				cinfo.emplace_back(false, n_bouncy_value, p, translate(box, posf));
 			}
 		} else {
 			// Collide with loaded CONTENT_IGNORE nodes
@@ -395,10 +402,8 @@ static void add_object_boxes(Environment *env,
 		LocalPlayer *lplayer = c_env->getLocalPlayer();
 		auto *obj = (ClientActiveObject*) lplayer->getCAO();
 		if (!self || (self != obj && self != obj->getParent())) {
-			aabb3f lplayer_collisionbox = lplayer->getCollisionbox();
-			v3f lplayer_pos = lplayer->getPosition();
-			lplayer_collisionbox.MinEdge += lplayer_pos;
-			lplayer_collisionbox.MaxEdge += lplayer_pos;
+			aabb3f const lplayer_collisionbox =
+					translate(lplayer->getCollisionbox(), lplayer->getPosition());
 			cinfo.emplace_back(obj, 0, lplayer_collisionbox);
 		}
 	}
@@ -528,10 +533,8 @@ CollisionMoveResult MovementContext::simulateFor(
 
 		v3f const avg_speed_estimate{collider->getProjectedAvgSpeed(this->remaining_dtime)};
 
-		MovingBox movingbox{collider->collisionbox, avg_speed_estimate};
-		movingbox.box.MinEdge += collider->pos;
-		movingbox.box.MaxEdge += collider->pos;
-
+		MovingBox movingbox{
+			translate(collider->collisionbox, collider->pos), avg_speed_estimate};
 		Collision const collision = this->findNearestCollision(movingbox);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
@@ -740,9 +743,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 	/*
 		Final touches: Check if standing on ground, step up stairs.
 	*/
-	aabb3f box = collider->collisionbox;
-	box.MinEdge += collider->pos;
-	box.MaxEdge += collider->pos;
+	aabb3f box = translate(collider->collisionbox, collider->pos);
 	for (auto const &box_info : this->cinfo) {
 		aabb3f const &cbox = box_info.box;
 
@@ -758,9 +759,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 				cbox.MaxEdge.Z > box.MinEdge.Z && cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
 				collider->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
-				box = collider->collisionbox;
-				box.MinEdge += collider->pos;
-				box.MaxEdge += collider->pos;
+				box = translate(collider->collisionbox, collider->pos);
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
 				// This is code is technically only required if `box_info.is_step_up == true`.

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -71,12 +71,6 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
-struct MovingBox
-{
-	aabb3f box;
-	v3f velocity;
-};
-
 class KineticObject
 {
 public:
@@ -91,6 +85,12 @@ public:
 	v3f getProjectedAvgSpeed(f32 dtime) const;
 
 private:
+	struct MovingBox
+	{
+		aabb3f box;
+		v3f velocity;
+	};
+
 	void moveToCollision(
 			Collision collision, v3f avg_speed, f32 dtime, bool step_up);
 
@@ -101,7 +101,12 @@ private:
 	void stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
 			CollisionMoveResult &result);
 
-};
+	static bool shouldStepUp(MovingBox const &movingbox, f32 dtime, Collision collision,
+		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo);
+
+	static Collision findNearestCollision(MovingBox const &movingbox,
+			std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime);
+	};
 
 // Helper functions:
 // Truncate floating point numbers to specified number of decimal places
@@ -132,12 +137,6 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 
 static bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
 		IGameDef *gamedef, Environment *env, std::vector<NearbyCollisionInfo> &cinfo);
-
-static bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
-		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo);
-
-static Collision find_nearest_collision(
-		MovingBox const &movingbox, std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -528,7 +527,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		movingbox.box.MinEdge += this->pos;
 		movingbox.box.MaxEdge += this->pos;
 
-		Collision const collision = find_nearest_collision(movingbox, cinfo, dtime);
+		Collision const collision = findNearestCollision(movingbox, cinfo, dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
@@ -544,7 +543,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 
-		bool const step_up = should_step_up(movingbox, dtime, collision, stepheight, cinfo);
+		bool const step_up = shouldStepUp(movingbox, dtime, collision, stepheight, cinfo);
 
 		this->moveToCollision(collision, avg_speed_estimate, dtime, step_up);
 		dtime -= collision.dtime;
@@ -569,8 +568,8 @@ v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
 
-bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision, f32 stepheight,
-		std::vector<NearbyCollisionInfo> const &cinfo)
+bool KineticObject::shouldStepUp(MovingBox const &movingbox, f32 dtime, Collision collision,
+		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo)
 {
 	if (collision.axis != COLLISION_AXIS_Y) {
 		// movingbox except moved to the horizontal position it would be after
@@ -595,7 +594,7 @@ bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision, 
 	}
 }
 
-Collision find_nearest_collision(
+Collision KineticObject::findNearestCollision(
 		MovingBox const &movingbox, std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime)
 {
 	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -87,7 +87,7 @@ struct KineticObject
 	v3f *avg_speed;
 	v3f *accel;
 
-	void moveToCollision(f32 &dtime, Collision collision, bool step_up);
+	void moveToCollision(Collision collision, f32 &dtime, bool step_up);
 
 	CollisionMoveResult collideWith(Collision collision,
 			NearbyCollisionInfo &nearest_info, bool step_up,
@@ -511,7 +511,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 		bool step_up = should_step_up(movingbox, dtime, collision, stepheight, cinfo);
 
-		collider.moveToCollision(dtime, collision, step_up);
+		collider.moveToCollision(collision, dtime, step_up);
 
 		result = collider.collideWith(
 				collision, nearest_info, step_up, step_up_mode);
@@ -643,7 +643,7 @@ Collision find_nearest_collision(KineticBox const &movingbox,
 }
 
 void KineticObject::moveToCollision(
-		f32 &dtime, Collision collision, bool step_up)
+		Collision collision, f32 &dtime, bool step_up)
 {
 	// Move to the point of collision and reduce dtime by collision.dtime
 	if (collision.dtime < 0) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -111,6 +111,8 @@ struct KineticObject
 
 	bool collideY(f32 bounce);
 
+	void stopInPlace();
+
 	void jerkUpwards(float dy);
 };
 
@@ -514,7 +516,7 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
 	const core::aabbox3d<s16> range{collider->getMovementRange(this->remaining_dtime)};
 	if (!add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, this->cinfo)) {
-		collider->velocity = v3f();
+		collider->stopInPlace();
 		return CollisionMoveResult{};
 	}
 
@@ -541,6 +543,11 @@ core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
 	v3s16 min = floatToInt(minpos_f + this->collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
 	v3s16 max = floatToInt(maxpos_f + this->collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
 	return core::aabbox3d<s16>{min, max};
+}
+
+void KineticObject::stopInPlace()
+{
+	this->velocity = v3f();
 }
 
 CollisionMoveResult MovementContext::simulateFor(KineticObject *collider, f32 stepheight)

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -94,7 +94,7 @@ public:
 			StepUpMode step_up_mode);
 
 private:
-	void moveToCollision(Collision collision, f32 &dtime, bool step_up);
+	void moveToCollision(Collision collision, f32 dtime, bool step_up);
 
 	CollisionMoveResult collideWith(Collision collision,
 			NearbyCollisionInfo &nearest_info, bool step_up,
@@ -590,6 +590,7 @@ collisionMoveResult KineticObject::simulateFor(f32 dtime,
 				should_step_up(movingbox, dtime, collision, stepheight, cinfo);
 
 		this->moveToCollision(collision, dtime, step_up);
+		dtime -= collision.dtime;
 
 		result = this->collideWith(
 				collision, nearest_info, step_up, step_up_mode);
@@ -668,7 +669,7 @@ Collision find_nearest_collision(KineticBox const &movingbox,
 }
 
 void KineticObject::moveToCollision(
-		Collision collision, f32 &dtime, bool step_up)
+		Collision collision, f32 dtime, bool step_up)
 {
 	// Move to the point of collision and reduce dtime by collision.dtime
 	if (collision.dtime < 0) {
@@ -697,7 +698,6 @@ void KineticObject::moveToCollision(
 		// Limit speed for avoiding hangs
 		*this->speed =
 				truncate(rangelimv(*this->speed, -5000.0f, 5000.0f), 10000.0f);
-		dtime -= collision.dtime;
 	}
 }
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -82,6 +82,7 @@ struct KineticBox
 
 struct KineticObject
 {
+	aabb3f collisionbox;
 	v3f *pos;
 	v3f *speed;
 	v3f *avg_speed;
@@ -121,11 +122,11 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 }
 }
 
-static bool locate_cboxes_in_movement_range(KineticObject collider,
-		aabb3f box_0, f32 dtime, IGameDef *gamedef, Environment *env,
+static bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
+		IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo);
 
-collisionMoveResult simulate_for(KineticObject &collider, aabb3f const &box_0,
+collisionMoveResult simulate_for(KineticObject &collider,
 		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
 		StepUpMode step_up_mode, f32 dtime);
 
@@ -467,14 +468,14 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	thread_local std::vector<NearbyCollisionInfo> cinfo;
 	cinfo.clear();
 
-	KineticObject collider{pos_f, speed_f, &aspeed_f, &accel_f};
+	KineticObject collider{box_0, pos_f, speed_f, &aspeed_f, &accel_f};
 
 	// Do not move if world has not loaded yet, since custom node boxes
 	// are not available for collision detection.
 	// This also intentionally occurs in the case of the object being positioned
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
 	if (!locate_cboxes_in_movement_range(
-				collider, box_0, dtime, gamedef, env, cinfo)) {
+				collider, dtime, gamedef, env, cinfo)) {
 		*speed_f = v3f(0, 0, 0);
 		return CollisionMoveResult{};
 	}
@@ -484,8 +485,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		add_object_boxes(env, box_0, dtime, *pos_f, aspeed_f, self, cinfo);
 	}
 
-	CollisionMoveResult result = simulate_for(
-			collider, box_0, cinfo, stepheight, step_up_mode, dtime);
+	CollisionMoveResult result =
+			simulate_for(collider, cinfo, stepheight, step_up_mode, dtime);
 
 	/*
 		Final touches: Check if standing on ground, step up stairs.
@@ -526,8 +527,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	return result;
 }
 
-bool locate_cboxes_in_movement_range(KineticObject collider, aabb3f box_0,
-		f32 dtime, IGameDef *gamedef, Environment *env,
+bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
+		IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo)
 {
 	// Movement if no collisions
@@ -539,13 +540,15 @@ bool locate_cboxes_in_movement_range(KineticObject collider, aabb3f box_0,
 	v3f maxpos_f(MYMAX(collider.pos->X, newpos_f.X),
 			MYMAX(collider.pos->Y, newpos_f.Y),
 			MYMAX(collider.pos->Z, newpos_f.Z));
-	v3s16 min = floatToInt(minpos_f + box_0.MinEdge, BS) - v3s16(1, 1, 1);
-	v3s16 max = floatToInt(maxpos_f + box_0.MaxEdge, BS) + v3s16(1, 1, 1);
+	v3s16 min = floatToInt(minpos_f + collider.collisionbox.MinEdge, BS) -
+				v3s16(1, 1, 1);
+	v3s16 max = floatToInt(maxpos_f + collider.collisionbox.MaxEdge, BS) +
+				v3s16(1, 1, 1);
 
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-collisionMoveResult simulate_for(KineticObject &collider, aabb3f const &box_0,
+collisionMoveResult simulate_for(KineticObject &collider,
 		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
 		StepUpMode step_up_mode, f32 dtime)
 {
@@ -560,7 +563,7 @@ collisionMoveResult simulate_for(KineticObject &collider, aabb3f const &box_0,
 			break;
 		}
 
-		KineticBox movingbox{box_0, *collider.avg_speed};
+		KineticBox movingbox{collider.collisionbox, *collider.avg_speed};
 		movingbox.box.MinEdge += *collider.pos;
 		movingbox.box.MaxEdge += *collider.pos;
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -106,11 +106,16 @@ public:
 	void moveToCollision(
 			Collision collision, v3f avg_speed, f32 dtime, bool step_up);
 
-	void collideX(f32 bounce);
-
-	void collideZ(f32 bounce);
-
-	bool collideY(f32 bounce);
+	template <float v3f::*AX> void collide(f32 bounce)
+	{
+		if (bounce < -1e-4 && fabsf(velocity.*AX) > BS * 3) {
+			velocity.*AX *= bounce;
+		} else {
+			velocity.*AX = 0.f;
+			// avoid colliding in the next iterations
+			accel.*AX = 0.f;
+		}
+	}
 
 	v3f getPosition() const
 	{
@@ -740,11 +745,12 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (axis == COLLISION_AXIS_X) {
-		collider->collideX(bounce);
+		collider->collide<&v3f::X>(bounce);
 	} else if (axis == COLLISION_AXIS_Z) {
-		collider->collideZ(bounce);
+		collider->collide<&v3f::Z>(bounce);
 	} else { // axis == COLLISION_AXIS_Y)
-		if (collider->collideY(bounce)) {
+		if ((bounce >= -1e-4 || fabsf(collider->velocity.Y) <= BS * 3) &&
+				collider->velocity.Y < 0.0f) {
 			// FIXME: This code is necessary until
 			// `axisAlignedCollision` takes acceleration
 			// into consideration for the time calculation.
@@ -753,6 +759,7 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 			result.touching_ground    = true;
 			result.standing_on_object = nearest_info.isObject();
 		}
+		collider->collide<&v3f::Y>(bounce);
 	}
 
 	if (!nearest_info.is_unloaded && !step_up) {
@@ -767,44 +774,6 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 		result.collisions.push_back(info);
 	}
 
-	return result;
-}
-
-void KineticObject::collideX(f32 bounce)
-{
-	if (bounce < -1e-4 && fabsf(velocity.X) > BS * 3) {
-		velocity.X *= bounce;
-	} else {
-		velocity.X = 0.f;
-		// avoid colliding in the next interations
-		accel.X = 0.f;
-	}
-}
-
-void KineticObject::collideZ(f32 bounce)
-{
-	if (bounce < -1e-4 && fabsf(velocity.Z) > BS * 3) {
-		velocity.Z *= bounce;
-	} else {
-		velocity.Z = 0.f;
-		// avoid colliding in the next iterations
-		accel.Z = 0.f;
-	}
-}
-
-bool KineticObject::collideY(f32 bounce)
-{
-	bool result = false;
-	if (bounce < -1e-4 && fabsf(velocity.Y) > BS * 3) {
-		velocity.Y *= bounce;
-	} else {
-		if (velocity.Y < 0.0f) {
-			result = true;
-		}
-		velocity.Y = 0.f;
-		// avoid colliding in the next iterations
-		accel.Y = 0.f;
-	}
 	return result;
 }
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -80,14 +80,19 @@ struct KineticBox
 	v3f avg_speed;
 };
 
-struct KineticObject
+class KineticObject
 {
+public:
 	aabb3f collisionbox;
 	v3f *pos;
 	v3f *speed;
 	v3f *avg_speed;
 	v3f *accel;
 
+	collisionMoveResult simulateFor(std::vector<NearbyCollisionInfo> &cinfo,
+			f32 stepheight, StepUpMode step_up_mode, f32 dtime);
+
+private:
 	void moveToCollision(Collision collision, f32 &dtime, bool step_up);
 
 	CollisionMoveResult collideWith(Collision collision,
@@ -125,10 +130,6 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 static bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
 		IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo);
-
-collisionMoveResult simulate_for(KineticObject &collider,
-		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
-		StepUpMode step_up_mode, f32 dtime);
 
 static bool should_step_up(KineticBox const &movingbox, f32 dtime,
 		Collision collision, f32 stepheight,
@@ -486,7 +487,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	}
 
 	CollisionMoveResult result =
-			simulate_for(collider, cinfo, stepheight, step_up_mode, dtime);
+			collider.simulateFor(cinfo, stepheight, step_up_mode, dtime);
 
 	/*
 		Final touches: Check if standing on ground, step up stairs.
@@ -548,7 +549,7 @@ bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-collisionMoveResult simulate_for(KineticObject &collider,
+collisionMoveResult KineticObject::simulateFor(
 		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
 		StepUpMode step_up_mode, f32 dtime)
 {
@@ -563,20 +564,20 @@ collisionMoveResult simulate_for(KineticObject &collider,
 			break;
 		}
 
-		KineticBox movingbox{collider.collisionbox, *collider.avg_speed};
-		movingbox.box.MinEdge += *collider.pos;
-		movingbox.box.MaxEdge += *collider.pos;
+		KineticBox movingbox{this->collisionbox, *this->avg_speed};
+		movingbox.box.MinEdge += *this->pos;
+		movingbox.box.MaxEdge += *this->pos;
 
 		Collision collision = find_nearest_collision(movingbox, cinfo, dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
-			*collider.pos += *collider.avg_speed * dtime;
+			*this->pos += *this->avg_speed * dtime;
 			// Final speed:
-			*collider.speed += *collider.accel * dtime;
+			*this->speed += *this->accel * dtime;
 			// Limit speed for avoiding hangs
-			*collider.speed = truncate(
-					rangelimv(*collider.speed, -5000.0f, 5000.0f), 10000.0f);
+			*this->speed = truncate(
+					rangelimv(*this->speed, -5000.0f, 5000.0f), 10000.0f);
 			break;
 		}
 
@@ -587,9 +588,9 @@ collisionMoveResult simulate_for(KineticObject &collider,
 		bool step_up =
 				should_step_up(movingbox, dtime, collision, stepheight, cinfo);
 
-		collider.moveToCollision(collision, dtime, step_up);
+		this->moveToCollision(collision, dtime, step_up);
 
-		result = collider.collideWith(
+		result = this->collideWith(
 				collision, nearest_info, step_up, step_up_mode);
 
 		if (dtime < BS * 1e-10f) {
@@ -597,10 +598,10 @@ collisionMoveResult simulate_for(KineticObject &collider,
 		}
 
 		// Speed for finding the next collision
-		*collider.avg_speed = *collider.speed + *collider.accel * 0.5f * dtime;
+		*this->avg_speed = *this->speed + *this->accel * 0.5f * dtime;
 		// Limit speed for avoiding hangs
-		*collider.avg_speed = truncate(
-				rangelimv(*collider.avg_speed, -5000.0f, 5000.0f), 10000.0f);
+		*this->avg_speed = truncate(
+				rangelimv(*this->avg_speed, -5000.0f, 5000.0f), 10000.0f);
 	}
 
 	return result;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -71,6 +71,12 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
+struct MovementContext
+{
+	std::vector<NearbyCollisionInfo> cinfo;
+	f32 remaining_dtime;
+};
+
 class KineticObject
 {
 public:
@@ -79,8 +85,8 @@ public:
 	v3f velocity;
 	v3f accel;
 
-	CollisionMoveResult simulateFor(f32 dtime, std::vector<NearbyCollisionInfo> &cinfo,
-			f32 stepheight, StepUpMode step_up_mode);
+	CollisionMoveResult simulateFor(
+			MovementContext ctx, f32 stepheight, StepUpMode step_up_mode);
 
 	v3f getProjectedAvgSpeed(f32 dtime) const;
 
@@ -481,8 +487,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		add_object_boxes(env, box_0, dtime, *pos_f, collider.getProjectedAvgSpeed(dtime), self, cinfo);
 	}
 
-	CollisionMoveResult result =
-			collider.simulateFor(dtime, cinfo, stepheight, step_up_mode);
+	MovementContext ctx{cinfo, dtime};
+	CollisionMoveResult result = collider.simulateFor(ctx, stepheight, step_up_mode);
 
 	*pos_f = collider.pos;
 	*speed_f = collider.velocity;
@@ -507,8 +513,8 @@ bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-CollisionMoveResult KineticObject::simulateFor(f32 dtime,
-		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight, StepUpMode step_up_mode)
+CollisionMoveResult KineticObject::simulateFor(
+		MovementContext ctx, f32 stepheight, StepUpMode step_up_mode)
 {
 	CollisionMoveResult result;
 
@@ -521,19 +527,20 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 			break;
 		}
 
-		v3f const avg_speed_estimate{this->getProjectedAvgSpeed(dtime)};
+		v3f const avg_speed_estimate{this->getProjectedAvgSpeed(ctx.remaining_dtime)};
 
 		MovingBox movingbox{this->collisionbox, avg_speed_estimate};
 		movingbox.box.MinEdge += this->pos;
 		movingbox.box.MaxEdge += this->pos;
 
-		Collision const collision = findNearestCollision(movingbox, cinfo, dtime);
+		Collision const collision =
+				findNearestCollision(movingbox, ctx.cinfo, ctx.remaining_dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
-			this->pos += avg_speed_estimate * dtime;
+			this->pos += avg_speed_estimate * ctx.remaining_dtime;
 			// Final speed:
-			this->velocity += this->accel * dtime;
+			this->velocity += this->accel * ctx.remaining_dtime;
 			// Limit speed for avoiding hangs
 			this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
 			break;
@@ -541,21 +548,22 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 
 		assert(std::isfinite(collision.dtime));
 		// Otherwise, a collision occurred.
-		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
+		NearbyCollisionInfo &nearest_info = ctx.cinfo[collision.boxindex];
 
-		bool const step_up = shouldStepUp(movingbox, dtime, collision, stepheight, cinfo);
+		bool const step_up =
+				shouldStepUp(movingbox, ctx.remaining_dtime, collision, stepheight, ctx.cinfo);
 
-		this->moveToCollision(collision, avg_speed_estimate, dtime, step_up);
-		dtime -= collision.dtime;
+		this->moveToCollision(collision, avg_speed_estimate, ctx.remaining_dtime, step_up);
+		ctx.remaining_dtime -= collision.dtime;
 
 		result = this->collideWith(collision, nearest_info, step_up, step_up_mode);
 
-		if (dtime < BS * 1e-10f) {
+		if (ctx.remaining_dtime < BS * 1e-10f) {
 			break;
 		}
 	}
 
-	this->stepUpStairs(cinfo, result);
+	this->stepUpStairs(ctx.cinfo, result);
 	result.collides = !result.collisions.empty();
 
 	return result;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -125,6 +125,10 @@ static bool locate_cboxes_in_movement_range(KineticObject collider,
 		aabb3f box_0, f32 dtime, IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo);
 
+collisionMoveResult simulate_for(KineticObject &collider, aabb3f const &box_0,
+		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
+		StepUpMode step_up_mode, f32 dtime);
+
 static bool should_step_up(KineticBox const &movingbox, f32 dtime,
 		Collision collision, f32 stepheight,
 		std::vector<NearbyCollisionInfo> const &cinfo);
@@ -433,8 +437,6 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	ScopeProfiler sp(g_profiler, PROFILER_NAME("collisionMoveSimple()"), SPT_AVG, PRECISION_MICRO);
 
-	CollisionMoveResult result;
-
 	// Assume no collisions when no velocity and no acceleration
 	if (*speed_f == v3f() && accel_f == v3f())
 		return CollisionMoveResult{};
@@ -482,48 +484,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		add_object_boxes(env, box_0, dtime, *pos_f, aspeed_f, self, cinfo);
 	}
 
-	for (int loopcount = 0;; loopcount++) {
-		if (loopcount >= 100) {
-			warningstream << "collisionMoveSimple: Loop count exceeded, aborting to avoid infinite loop" << std::endl;
-			g_collision_problems_encountered = true;
-			break;
-		}
-
-		KineticBox movingbox{box_0, aspeed_f};
-		movingbox.box.MinEdge += *pos_f;
-		movingbox.box.MaxEdge += *pos_f;
-
-		Collision collision = find_nearest_collision(movingbox, cinfo, dtime);
-
-		if (collision.axis == COLLISION_AXIS_NONE) {
-			// No collision with any collision box.
-			*pos_f += aspeed_f * dtime;
-			// Final speed:
-			*speed_f += accel_f * dtime;
-			// Limit speed for avoiding hangs
-			*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f), 10000.0f);
-			break;
-		}
-
-		assert(!std::isinf(collision.dtime) && !std::isnan(collision.dtime));
-		// Otherwise, a collision occurred.
-		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
-
-		bool step_up = should_step_up(movingbox, dtime, collision, stepheight, cinfo);
-
-		collider.moveToCollision(collision, dtime, step_up);
-
-		result = collider.collideWith(
-				collision, nearest_info, step_up, step_up_mode);
-
-		if (dtime < BS * 1e-10f)
-			break;
-
-		// Speed for finding the next collision
-		aspeed_f = *speed_f + accel_f * 0.5f * dtime;
-		// Limit speed for avoiding hangs
-		aspeed_f = truncate(rangelimv(aspeed_f, -5000.0f, 5000.0f), 10000.0f);
-	}
+	CollisionMoveResult result = simulate_for(
+			collider, box_0, cinfo, stepheight, step_up_mode, dtime);
 
 	/*
 		Final touches: Check if standing on ground, step up stairs.
@@ -581,6 +543,64 @@ bool locate_cboxes_in_movement_range(KineticObject collider, aabb3f box_0,
 	v3s16 max = floatToInt(maxpos_f + box_0.MaxEdge, BS) + v3s16(1, 1, 1);
 
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
+}
+
+collisionMoveResult simulate_for(KineticObject &collider, aabb3f const &box_0,
+		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
+		StepUpMode step_up_mode, f32 dtime)
+{
+	collisionMoveResult result;
+
+	for (int loopcount = 0;; loopcount++) {
+		if (loopcount >= 100) {
+			warningstream << "collisionMoveSimple: Loop count exceeded, "
+							 "aborting to avoid infinite loop"
+						  << std::endl;
+			g_collision_problems_encountered = true;
+			break;
+		}
+
+		KineticBox movingbox{box_0, *collider.avg_speed};
+		movingbox.box.MinEdge += *collider.pos;
+		movingbox.box.MaxEdge += *collider.pos;
+
+		Collision collision = find_nearest_collision(movingbox, cinfo, dtime);
+
+		if (collision.axis == COLLISION_AXIS_NONE) {
+			// No collision with any collision box.
+			*collider.pos += *collider.avg_speed * dtime;
+			// Final speed:
+			*collider.speed += *collider.accel * dtime;
+			// Limit speed for avoiding hangs
+			*collider.speed = truncate(
+					rangelimv(*collider.speed, -5000.0f, 5000.0f), 10000.0f);
+			break;
+		}
+
+		assert(!std::isinf(collision.dtime) && !std::isnan(collision.dtime));
+		// Otherwise, a collision occurred.
+		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
+
+		bool step_up =
+				should_step_up(movingbox, dtime, collision, stepheight, cinfo);
+
+		collider.moveToCollision(collision, dtime, step_up);
+
+		result = collider.collideWith(
+				collision, nearest_info, step_up, step_up_mode);
+
+		if (dtime < BS * 1e-10f) {
+			break;
+		}
+
+		// Speed for finding the next collision
+		*collider.avg_speed = *collider.speed + *collider.accel * 0.5f * dtime;
+		// Limit speed for avoiding hangs
+		*collider.avg_speed = truncate(
+				rangelimv(*collider.avg_speed, -5000.0f, 5000.0f), 10000.0f);
+	}
+
+	return result;
 }
 
 bool should_step_up(KineticBox const &movingbox, f32 dtime, Collision collision,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -700,7 +700,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		if (bounce < -1e-4 && fabsf(this->velocity.X) > BS * 3) {
 			this->velocity.X *= bounce;
 		} else {
-			this->velocity.X = 0;
+			this->velocity.X = 0.f;
 			// avoid colliding in the next iterations
 			this->accel.X = 0;
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -716,12 +716,10 @@ void KineticObject::moveToCollision(
 		if (!step_up) {
 			if (collision.axis == COLLISION_AXIS_X) {
 				pos.X += avg_speed.X * collision.dtime;
-			}
-			if (collision.axis == COLLISION_AXIS_Y) {
-				pos.Y += avg_speed.Y * collision.dtime;
-			}
-			if (collision.axis == COLLISION_AXIS_Z) {
+			} else if (collision.axis == COLLISION_AXIS_Z) {
 				pos.Z += avg_speed.Z * collision.dtime;
+			} else { // collision.axis == COLLISION_AXIS_Y)
+				pos.Y += avg_speed.Y * collision.dtime;
 			}
 		}
 	} else if (collision.dtime > 0.f) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -119,7 +119,7 @@ static bool locate_cboxes_in_movement_range(KineticObject collider,
 		aabb3f box_0, f32 dtime, IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo);
 
-static bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed,
+static bool should_step_up(aabb3f movingbox, v3f avg_speed,
 		f32 dtime, Collision collision, f32 stepheight,
 		std::vector<NearbyCollisionInfo> const &cinfo);
 
@@ -504,10 +504,9 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		assert(!std::isinf(collision.dtime) && !std::isnan(collision.dtime));
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
-		const aabb3f& cbox = nearest_info.box;
 
 		bool step_up = should_step_up(
-				movingbox, cbox, aspeed_f, dtime, collision, stepheight, cinfo);
+				movingbox, aspeed_f, dtime, collision, stepheight, cinfo);
 
 		collider.moveToCollision(dtime, collision, step_up);
 
@@ -581,7 +580,7 @@ bool locate_cboxes_in_movement_range(KineticObject collider, aabb3f box_0,
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed, f32 dtime,
+bool should_step_up(aabb3f movingbox, v3f avg_speed, f32 dtime,
 		Collision collision, f32 stepheight,
 		std::vector<NearbyCollisionInfo> const &cinfo)
 {
@@ -599,6 +598,7 @@ bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed, f32 dtime,
 		stepbox.MaxEdge.X += avg_speed.X * extra_dtime;
 		stepbox.MaxEdge.Z += avg_speed.Z * extra_dtime;
 		// Check for stairs.
+		const aabb3f &cbox = cinfo[collision.boxindex].box;
 		return (movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&
 			   (movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
 			   (!wouldCollideWithCeiling(cinfo, stepbox,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -79,13 +79,17 @@ class KineticObject;
 		v3f velocity;
 	};
 
-struct MovementContext
+class MovementContext
 {
+public:
 	std::vector<NearbyCollisionInfo> cinfo;
 	f32 remaining_dtime;
 
 	CollisionMoveResult simulateFor(
 			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
+
+private:
+	Collision findNearestCollision(MovingBox const &movingbox);
 };
 
 class KineticObject
@@ -111,8 +115,6 @@ public:
 	static bool shouldStepUp(MovingBox const &movingbox, f32 dtime, Collision collision,
 		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo);
 
-	static Collision findNearestCollision(MovingBox const &movingbox,
-			std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime);
 	};
 
 // Helper functions:
@@ -534,8 +536,7 @@ CollisionMoveResult MovementContext::simulateFor(
 		movingbox.box.MinEdge += collider->pos;
 		movingbox.box.MaxEdge += collider->pos;
 
-		Collision const collision =
-				collider->findNearestCollision(movingbox, this->cinfo, this->remaining_dtime);
+		Collision const collision = this->findNearestCollision(movingbox);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
@@ -605,16 +606,15 @@ bool KineticObject::shouldStepUp(MovingBox const &movingbox, f32 dtime, Collisio
 	}
 }
 
-Collision KineticObject::findNearestCollision(
-		MovingBox const &movingbox, std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime)
+Collision MovementContext::findNearestCollision(MovingBox const &movingbox)
 {
 	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;
-	f32 nearest_dtime              = dtime;
+	f32 nearest_dtime              = this->remaining_dtime;
 	int nearest_boxindex           = -1;
 
 	// Go through every nodebox, find nearest collision
-	for (u32 boxindex = 0; boxindex < cinfo.size(); boxindex++) {
-		NearbyCollisionInfo const &box_info = cinfo[boxindex];
+	for (u32 boxindex = 0; boxindex < this->cinfo.size(); boxindex++) {
+		NearbyCollisionInfo const &box_info = this->cinfo[boxindex];
 		// Ignore if already stepped up this nodebox.
 		if (box_info.is_step_up) {
 			continue;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -725,7 +725,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {
 			this->velocity.Z *= bounce;
 		} else {
-			this->velocity.Z = 0;
+			this->velocity.Z = 0.f;
 			// avoid colliding in the next iterations
 			this->accel.Z = 0;
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -92,7 +92,7 @@ public:
 
 	aabb3f getAbsCollisionbox() const
 	{
-		return translate(this->collisionbox, this->pos);
+		return translate(collisionbox, pos);
 	}
 
 	core::aabbox3d<s16> getMovementRange(f32 dtime) const;
@@ -118,17 +118,17 @@ public:
 
 	const aabb3f &getCollisionbox() const
 	{
-		return this->collisionbox;
+		return collisionbox;
 	}
 
 	v3f getPosition() const
 	{
-		return this->pos;
+		return pos;
 	}
 
 	v3f getVelocity() const
 	{
-		return this->velocity;
+		return velocity;
 	}
 
 private:
@@ -529,10 +529,10 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 		f32 stepheight, f32 dtime, KineticObject *collider, ActiveObject *self,
 		bool collide_with_objects, StepUpMode step_up_mode)
 {
-	this->cinfo.clear();
-	this->remaining_dtime = dtime;
-	this->stepheight = stepheight;
-	this->step_up_mode = step_up_mode;
+	cinfo.clear();
+	remaining_dtime = dtime;
+	stepheight = stepheight;
+	step_up_mode = step_up_mode;
 
 	// Collect node boxes in movement range
 
@@ -540,45 +540,45 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 	// are not available for collision detection.
 	// This also intentionally occurs in the case of the object being positioned
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-	const core::aabbox3d<s16> range{collider->getMovementRange(this->remaining_dtime)};
-	if (!add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, this->cinfo)) {
+	const core::aabbox3d<s16> range{collider->getMovementRange(remaining_dtime)};
+	if (!add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, cinfo)) {
 		collider->stopInPlace();
 		return CollisionMoveResult{};
 	}
 
 	// Collect object boxes in movement range
 	if (collide_with_objects) {
-		add_object_boxes(env, collider->getCollisionbox(), this->remaining_dtime,
-				collider->getPosition(), collider->getProjectedAvgSpeed(this->remaining_dtime),
-				self, this->cinfo);
+		add_object_boxes(env, collider->getCollisionbox(), remaining_dtime,
+				collider->getPosition(), collider->getProjectedAvgSpeed(remaining_dtime),
+				self, cinfo);
 	}
 
-	return this->simulateFor(collider);
+	return simulateFor(collider);
 }
 
 
 core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
 {
 	// Movement if no collisions
-	v3f newpos = this->pos + this->velocity * dtime;
+	v3f newpos = pos + velocity * dtime;
 	v3f minpos(
-		MYMIN(this->pos.X, newpos.X),
-		MYMIN(this->pos.Y, newpos.Y) + 0.01f * BS, // bias rounding, player often at +/-n.5
-		MYMIN(this->pos.Z, newpos.Z)
+		MYMIN(pos.X, newpos.X),
+		MYMIN(pos.Y, newpos.Y) + 0.01f * BS, // bias rounding, player often at +/-n.5
+		MYMIN(pos.Z, newpos.Z)
 	);
 	v3f maxpos(
-		MYMAX(this->pos.X, newpos.X),
-		MYMAX(this->pos.Y, newpos.Y),
-		MYMAX(this->pos.Z, newpos.Z)
+		MYMAX(pos.X, newpos.X),
+		MYMAX(pos.Y, newpos.Y),
+		MYMAX(pos.Z, newpos.Z)
 	);
-	v3s16 min = floatToInt(minpos + this->collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
-	v3s16 max = floatToInt(maxpos + this->collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
+	v3s16 min = floatToInt(minpos + collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
+	v3s16 max = floatToInt(maxpos + collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
 	return core::aabbox3d<s16>{min, max};
 }
 
 void KineticObject::stopInPlace()
 {
-	this->velocity = v3f();
+	velocity = v3f();
 }
 
 CollisionMoveResult MovementContext::simulateFor(KineticObject *collider)
@@ -594,34 +594,33 @@ CollisionMoveResult MovementContext::simulateFor(KineticObject *collider)
 			break;
 		}
 
-		const v3f avg_speed_estimate{collider->getProjectedAvgSpeed(this->remaining_dtime)};
+		const v3f avg_speed_estimate{collider->getProjectedAvgSpeed(remaining_dtime)};
 
 		MovingBox movingbox{collider->getAbsCollisionbox(), avg_speed_estimate};
-		const Collision collision = this->findNearestCollision(movingbox);
+		const Collision collision = findNearestCollision(movingbox);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
-			collider->moveUnobstructed(this->remaining_dtime);
+			collider->moveUnobstructed(remaining_dtime);
 			break;
 		}
 
 		assert(std::isfinite(collision.dtime));
 		// Otherwise, a collision occurred.
-		NearbyCollisionInfo &nearest_info = this->cinfo[collision.boxindex];
+		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 
-		const bool step_up = this->shouldStepUp(movingbox, collision);
+		const bool step_up = shouldStepUp(movingbox, collision);
 
-		collider->moveToCollision(
-				collision, avg_speed_estimate, this->remaining_dtime, step_up);
-		this->remaining_dtime -= collision.dtime;
+		collider->moveToCollision(collision, avg_speed_estimate, remaining_dtime, step_up);
+		remaining_dtime -= collision.dtime;
 
-		result = this->collideWith(collider, collision.axis, nearest_info, step_up);
+		result = collideWith(collider, collision.axis, nearest_info, step_up);
 
-		if (this->remaining_dtime < BS * 1e-10f) {
+		if (remaining_dtime < BS * 1e-10f) {
 			break;
 		}
 	}
 
-	this->stepUpStairs(collider, result);
+	stepUpStairs(collider, result);
 	result.collides = !result.collisions.empty();
 
 	return result;
@@ -629,24 +628,24 @@ CollisionMoveResult MovementContext::simulateFor(KineticObject *collider)
 
 v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 {
-	const v3f avg = this->velocity + this->accel * 0.5f * dtime;
+	const v3f avg = velocity + accel * 0.5f * dtime;
 	// Limit speed for avoiding hangs
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
 
 void KineticObject::moveUnobstructed(f32 dtime)
 {
-	this->moveUnobstructed(dtime, this->getProjectedAvgSpeed(dtime));
+	moveUnobstructed(dtime, getProjectedAvgSpeed(dtime));
 }
 
 void KineticObject::moveUnobstructed(f32 dtime, v3f speed)
 {
 	// No collision with any collision box.
-	this->pos += speed * dtime;
+	pos += speed * dtime;
 	// Final speed:
-	this->velocity += this->accel * dtime;
+	velocity += accel * dtime;
 	// Limit speed for avoiding hangs
-	this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
+	velocity = truncate(rangelimv(velocity, -5000.0f, 5000.0f), 10000.0f);
 }
 
 bool MovementContext::shouldStepUp(const MovingBox &movingbox, Collision collision)
@@ -662,29 +661,28 @@ bool MovementContext::shouldStepUp(const MovingBox &movingbox, Collision collisi
 	// Look slightly ahead  for checking the height when stepping
 	// to ensure we also check above the node we collided with
 	// otherwise, might allow glitches such as a stack of stairs
-	float extra_dtime =
-			collision.dtime + 0.1f * fabsf(this->remaining_dtime - collision.dtime);
+	float extra_dtime = collision.dtime + 0.1f * fabsf(remaining_dtime - collision.dtime);
 	stepbox.MinEdge.X += movingbox.velocity.X * extra_dtime;
 	stepbox.MinEdge.Z += movingbox.velocity.Z * extra_dtime;
 	stepbox.MaxEdge.X += movingbox.velocity.X * extra_dtime;
 	stepbox.MaxEdge.Z += movingbox.velocity.Z * extra_dtime;
 	// Check for stairs.
-	const aabb3f &cbox = this->cinfo[collision.boxindex].box;
+	const aabb3f &cbox = cinfo[collision.boxindex].box;
 	return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
-		   (movingbox.box.MinEdge.Y + this->stepheight > cbox.MaxEdge.Y) &&
+		   (movingbox.box.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
 		   (!wouldCollideWithCeiling(
-				   this->cinfo, stepbox, cbox.MaxEdge.Y - movingbox.box.MinEdge.Y, 0.0f));
+				   cinfo, stepbox, cbox.MaxEdge.Y - movingbox.box.MinEdge.Y, 0.0f));
 }
 
 Collision MovementContext::findNearestCollision(const MovingBox &movingbox)
 {
 	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;
-	f32 nearest_dtime              = this->remaining_dtime;
+	f32 nearest_dtime              = remaining_dtime;
 	int nearest_boxindex           = -1;
 
 	// Go through every nodebox, find nearest collision
-	for (u32 boxindex = 0; boxindex < this->cinfo.size(); boxindex++) {
-		const NearbyCollisionInfo &box_info = this->cinfo[boxindex];
+	for (u32 boxindex = 0; boxindex < cinfo.size(); boxindex++) {
+		const NearbyCollisionInfo &box_info = cinfo[boxindex];
 		// Ignore if already stepped up this nodebox.
 		if (box_info.is_step_up) {
 			continue;
@@ -717,13 +715,13 @@ void KineticObject::moveToCollision(
 		// with above and resolve this collision
 		if (!step_up) {
 			if (collision.axis == COLLISION_AXIS_X) {
-				this->pos.X += avg_speed.X * collision.dtime;
+				pos.X += avg_speed.X * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Y) {
-				this->pos.Y += avg_speed.Y * collision.dtime;
+				pos.Y += avg_speed.Y * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Z) {
-				this->pos.Z += avg_speed.Z * collision.dtime;
+				pos.Z += avg_speed.Z * collision.dtime;
 			}
 		}
 	} else if (collision.dtime > 0.f) {
@@ -732,9 +730,8 @@ void KineticObject::moveToCollision(
 
 		// We can't use getProjectedAvgSpeed here, because we don't truncate
 		// the velocity before movement.
-		const v3f subinterval_avg_velocity =
-				this->velocity + this->accel * 0.5f * collision.dtime;
-		this->moveUnobstructed(collision.dtime, subinterval_avg_velocity);
+		const v3f subinterval_avg_velocity = velocity + accel * 0.5f * collision.dtime;
+		moveUnobstructed(collision.dtime, subinterval_avg_velocity);
 	}
 }
 
@@ -750,9 +747,9 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 
 	const f32 y_velocity = collider->getVelocity().Y;
 	// Set the speed component that caused the collision to zero
-	if (step_up && (this->step_up_mode == StepUpMode::LEGACY ||
-			(this->step_up_mode == StepUpMode::FLOATY && y_velocity <= 0.0f) ||
-			(this->step_up_mode == StepUpMode::RIGID && y_velocity == 0.0f))) {
+	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
+			(step_up_mode == StepUpMode::FLOATY && y_velocity <= 0.0f) ||
+			(step_up_mode == StepUpMode::RIGID && y_velocity == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (axis == COLLISION_AXIS_X) {
@@ -788,38 +785,38 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 
 void KineticObject::collideX(f32 bounce)
 {
-	if (bounce < -1e-4 && fabsf(this->velocity.X) > BS * 3) {
-		this->velocity.X *= bounce;
+	if (bounce < -1e-4 && fabsf(velocity.X) > BS * 3) {
+		velocity.X *= bounce;
 	} else {
-		this->velocity.X = 0.f;
+		velocity.X = 0.f;
 		// avoid colliding in the next interations
-		this->accel.X = 0.f;
+		accel.X = 0.f;
 	}
 }
 
 void KineticObject::collideZ(f32 bounce)
 {
-	if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {
-		this->velocity.Z *= bounce;
+	if (bounce < -1e-4 && fabsf(velocity.Z) > BS * 3) {
+		velocity.Z *= bounce;
 	} else {
-		this->velocity.Z = 0.f;
+		velocity.Z = 0.f;
 		// avoid colliding in the next iterations
-		this->accel.Z = 0.f;
+		accel.Z = 0.f;
 	}
 }
 
 bool KineticObject::collideY(f32 bounce)
 {
 	bool result = false;
-	if (bounce < -1e-4 && fabsf(this->velocity.Y) > BS * 3) {
-		this->velocity.Y *= bounce;
+	if (bounce < -1e-4 && fabsf(velocity.Y) > BS * 3) {
+		velocity.Y *= bounce;
 	} else {
-		if (this->velocity.Y < 0.0f) {
+		if (velocity.Y < 0.0f) {
 			result = true;
 		}
-		this->velocity.Y = 0.f;
+		velocity.Y = 0.f;
 		// avoid colliding in the next iterations
-		this->accel.Y = 0.f;
+		accel.Y = 0.f;
 	}
 	return result;
 }
@@ -830,7 +827,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 		Final touches: Check if standing on ground, step up stairs.
 	*/
 	aabb3f box = collider->getAbsCollisionbox();
-	for (const auto &box_info : this->cinfo) {
+	for (const auto &box_info : cinfo) {
 		const aabb3f &cbox = box_info.box;
 
 		/*
@@ -860,7 +857,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 
 void KineticObject::jerkUpwards(f32 dy)
 {
-	this->pos.Y += dy;
+	pos.Y += dy;
 }
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -148,6 +148,7 @@ public:
 private:
 	std::vector<NearbyCollisionInfo> cinfo;
 	f32 remaining_dtime;
+	f32 stepheight;
 	StepUpMode step_up_mode;
 
 	struct MovingBox
@@ -156,9 +157,11 @@ private:
 		v3f velocity;
 	};
 
-	CollisionMoveResult simulateFor(KineticObject *collider, f32 stepheight);
+	Collision findNearestCollision(const MovingBox &movingbox);
 
-	bool shouldStepUp(const MovingBox &movingbox, Collision collision, f32 stepheight);
+	CollisionMoveResult simulateFor(KineticObject *collider);
+
+	bool shouldStepUp(const MovingBox &movingbox, Collision collision);
 
 	CollisionMoveResult collideWith(KineticObject *collider, CollisionAxis axis,
 			NearbyCollisionInfo &nearest_info, bool step_up);
@@ -528,6 +531,7 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 {
 	this->cinfo.clear();
 	this->remaining_dtime = dtime;
+	this->stepheight = stepheight;
 	this->step_up_mode = step_up_mode;
 
 	// Collect node boxes in movement range
@@ -549,26 +553,26 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 				self, this->cinfo);
 	}
 
-	return this->simulateFor(collider, stepheight);
+	return this->simulateFor(collider);
 }
 
 
 core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
 {
 	// Movement if no collisions
-	v3f newpos_f = this->pos + this->velocity * dtime;
-	v3f minpos_f(
-		MYMIN(this->pos.X, newpos_f.X),
-		MYMIN(this->pos.Y, newpos_f.Y) + 0.01f * BS, // bias rounding, player often at +/-n.5
-		MYMIN(this->pos.Z, newpos_f.Z)
+	v3f newpos = this->pos + this->velocity * dtime;
+	v3f minpos(
+		MYMIN(this->pos.X, newpos.X),
+		MYMIN(this->pos.Y, newpos.Y) + 0.01f * BS, // bias rounding, player often at +/-n.5
+		MYMIN(this->pos.Z, newpos.Z)
 	);
-	v3f maxpos_f(
-		MYMAX(this->pos.X, newpos_f.X),
-		MYMAX(this->pos.Y, newpos_f.Y),
-		MYMAX(this->pos.Z, newpos_f.Z)
+	v3f maxpos(
+		MYMAX(this->pos.X, newpos.X),
+		MYMAX(this->pos.Y, newpos.Y),
+		MYMAX(this->pos.Z, newpos.Z)
 	);
-	v3s16 min = floatToInt(minpos_f + this->collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
-	v3s16 max = floatToInt(maxpos_f + this->collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
+	v3s16 min = floatToInt(minpos + this->collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
+	v3s16 max = floatToInt(maxpos + this->collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
 	return core::aabbox3d<s16>{min, max};
 }
 
@@ -577,7 +581,7 @@ void KineticObject::stopInPlace()
 	this->velocity = v3f();
 }
 
-CollisionMoveResult MovementContext::simulateFor(KineticObject *collider, f32 stepheight)
+CollisionMoveResult MovementContext::simulateFor(KineticObject *collider)
 {
 	CollisionMoveResult result;
 
@@ -604,7 +608,7 @@ CollisionMoveResult MovementContext::simulateFor(KineticObject *collider, f32 st
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = this->cinfo[collision.boxindex];
 
-		const bool step_up = this->shouldStepUp(movingbox, collision, stepheight);
+		const bool step_up = this->shouldStepUp(movingbox, collision);
 
 		collider->moveToCollision(
 				collision, avg_speed_estimate, this->remaining_dtime, step_up);
@@ -645,31 +649,31 @@ void KineticObject::moveUnobstructed(f32 dtime, v3f speed)
 	this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
 }
 
-bool MovementContext::shouldStepUp(
-		const MovingBox &movingbox, Collision collision, f32 stepheight)
+bool MovementContext::shouldStepUp(const MovingBox &movingbox, Collision collision)
 {
-	if (collision.axis != COLLISION_AXIS_Y) {
-		// movingbox except moved to the horizontal position it would be after
-		// step up
-		aabb3f stepbox = movingbox.box;
-		// Look slightly ahead  for checking the height when stepping
-		// to ensure we also check above the node we collided with
-		// otherwise, might allow glitches such as a stack of stairs
-		float extra_dtime =
-				collision.dtime + 0.1f * fabsf(this->remaining_dtime - collision.dtime);
-		stepbox.MinEdge.X += movingbox.velocity.X * extra_dtime;
-		stepbox.MinEdge.Z += movingbox.velocity.Z * extra_dtime;
-		stepbox.MaxEdge.X += movingbox.velocity.X * extra_dtime;
-		stepbox.MaxEdge.Z += movingbox.velocity.Z * extra_dtime;
-		// Check for stairs.
-		const aabb3f &cbox = this->cinfo[collision.boxindex].box;
-		return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
-			   (movingbox.box.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
-			   (!wouldCollideWithCeiling(
-					   this->cinfo, stepbox, cbox.MaxEdge.Y - movingbox.box.MinEdge.Y, 0.0f));
-	} else {
+	// This function applies only to X or Z collision
+	if (collision.axis == COLLISION_AXIS_Y) {
 		return false;
 	}
+
+	// movingbox except moved to the horizontal position it would be after
+	// step up
+	aabb3f stepbox = movingbox.box;
+	// Look slightly ahead  for checking the height when stepping
+	// to ensure we also check above the node we collided with
+	// otherwise, might allow glitches such as a stack of stairs
+	float extra_dtime =
+			collision.dtime + 0.1f * fabsf(this->remaining_dtime - collision.dtime);
+	stepbox.MinEdge.X += movingbox.velocity.X * extra_dtime;
+	stepbox.MinEdge.Z += movingbox.velocity.Z * extra_dtime;
+	stepbox.MaxEdge.X += movingbox.velocity.X * extra_dtime;
+	stepbox.MaxEdge.Z += movingbox.velocity.Z * extra_dtime;
+	// Check for stairs.
+	const aabb3f &cbox = this->cinfo[collision.boxindex].box;
+	return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
+		   (movingbox.box.MinEdge.Y + this->stepheight > cbox.MaxEdge.Y) &&
+		   (!wouldCollideWithCeiling(
+				   this->cinfo, stepbox, cbox.MaxEdge.Y - movingbox.box.MinEdge.Y, 0.0f));
 }
 
 Collision MovementContext::findNearestCollision(const MovingBox &movingbox)
@@ -757,13 +761,13 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 		collider->collideZ(bounce);
 	} else { // axis == COLLISION_AXIS_Y)
 		if (collider->collideY(bounce)) {
-				// FIXME: This code is necessary until
-				// `axisAlignedCollision` takes acceleration
-				// into consideration for the time calculation.
-				// Otherwise, the colliding faces never line up,
-				// especially at high step (dtime) intervals.
-				result.touching_ground    = true;
-				result.standing_on_object = nearest_info.isObject();
+			// FIXME: This code is necessary until
+			// `axisAlignedCollision` takes acceleration
+			// into consideration for the time calculation.
+			// Otherwise, the colliding faces never line up,
+			// especially at high step (dtime) intervals.
+			result.touching_ground    = true;
+			result.standing_on_object = nearest_info.isObject();
 		}
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -528,7 +528,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		if (loopcount >= 100) {
 			warningstream << "KineticObject::simulateFor: Loop count exceeded, "
 							 "aborting to avoid infinite loop"
-						  << std::endl;
+					<< std::endl;
 			g_collision_problems_encountered = true;
 			break;
 		}
@@ -690,10 +690,10 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 
 	// Set the speed component that caused the collision to zero
 	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
-						   (step_up_mode == StepUpMode::FLOATY &&
-								   this->velocity.Y <= 0.0f) ||
-						   (step_up_mode == StepUpMode::RIGID &&
-								   this->velocity.Y == 0.0f))) {
+			(step_up_mode == StepUpMode::FLOATY &&
+					this->velocity.Y <= 0.0f) ||
+			(step_up_mode == StepUpMode::RIGID &&
+					this->velocity.Y == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (collision.axis == COLLISION_AXIS_X) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -473,7 +473,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
 	if (!add_collisions_in_movement_range(
 				collider, dtime, gamedef, env, cinfo)) {
-		*speed_f = v3f(0.f, 0.f, 0.f);
+		*speed_f = v3f();
 		return CollisionMoveResult{};
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -80,6 +80,9 @@ struct KineticObject
 	v3f *speed;
 	v3f *avg_speed;
 	v3f *accel;
+
+	void moveToCollision(f32 &dtime, Collision collision, bool step_up);
+
 };
 
 // Helper functions:
@@ -120,9 +123,6 @@ static bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed,
 static Collision find_nearest_collision(
 		std::vector<NearbyCollisionInfo> const &cinfo,
 		aabb3f const &movingbox, v3f aspeed_f, f32 dtime);
-
-static void move_object_to_collision(KineticObject &collider, f32 &dtime,
-		Collision collision, bool step_up);
 
 static CollisionMoveResult collide(KineticObject &collider, Collision collision,
 		NearbyCollisionInfo &nearest_info, bool step_up,
@@ -510,7 +510,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		bool step_up = should_step_up(
 				movingbox, cbox, aspeed_f, dtime, collision, stepheight, cinfo);
 
-		move_object_to_collision(collider, dtime, collision, step_up);
+		collider.moveToCollision(dtime, collision, step_up);
 
 		result = collide(
 				collider, collision, nearest_info, step_up, step_up_mode);
@@ -641,8 +641,8 @@ Collision find_nearest_collision(std::vector<NearbyCollisionInfo> const &cinfo,
 	return Collision{nearest_dtime, nearest_boxindex, nearest_collided};
 }
 
-void move_object_to_collision(KineticObject &collider, f32 &dtime,
-		Collision collision, bool step_up)
+void KineticObject::moveToCollision(
+		f32 &dtime, Collision collision, bool step_up)
 {
 	// Move to the point of collision and reduce dtime by collision.dtime
 	if (collision.dtime < 0) {
@@ -652,26 +652,25 @@ void move_object_to_collision(KineticObject &collider, f32 &dtime,
 		// with above and resolve this collision
 		if (!step_up) {
 			if (collision.axis == COLLISION_AXIS_X) {
-				collider.pos->X += collider.avg_speed->X * collision.dtime;
+				this->pos->X += this->avg_speed->X * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Y) {
-				collider.pos->Y += collider.avg_speed->Y * collision.dtime;
+				this->pos->Y += this->avg_speed->Y * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Z) {
-				collider.pos->Z += collider.avg_speed->Z * collision.dtime;
+				this->pos->Z += this->avg_speed->Z * collision.dtime;
 			}
 		}
 	} else if (collision.dtime > 0) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
-		*collider.avg_speed =
-				*collider.speed + *collider.accel * 0.5f * collision.dtime;
-		*collider.pos += *collider.avg_speed * collision.dtime;
+		*this->avg_speed = *this->speed + *this->accel * 0.5f * collision.dtime;
+		*this->pos += *this->avg_speed * collision.dtime;
 		// Speed at (approximated) collision:
-		*collider.speed += *collider.accel * collision.dtime;
+		*this->speed += *this->accel * collision.dtime;
 		// Limit speed for avoiding hangs
-		*collider.speed = truncate(
-				rangelimv(*collider.speed, -5000.0f, 5000.0f), 10000.0f);
+		*this->speed =
+				truncate(rangelimv(*this->speed, -5000.0f, 5000.0f), 10000.0f);
 		dtime -= collision.dtime;
 	}
 }

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -478,8 +478,6 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		time_notification_done = false;
 	}
 
-	// Collect node boxes in movement range
-
 	// cached allocation
 	thread_local MovementContext ctx;
 
@@ -499,6 +497,8 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 {
 	this->cinfo.clear();
 	this->remaining_dtime = dtime;
+
+	// Collect node boxes in movement range
 
 	// Do not move if world has not loaded yet, since custom node boxes
 	// are not available for collision detection.

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -72,6 +72,14 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
+struct KineticObject
+{
+	v3f *pos;
+	v3f *speed;
+	v3f *avg_speed;
+	v3f accel;
+};
+
 // Helper functions:
 // Truncate floating point numbers to specified number of decimal places
 // in order to move all the floating point error to one side of the correct value
@@ -103,8 +111,8 @@ static Collision find_nearest_collision(
 		std::vector<NearbyCollisionInfo> const &cinfo,
 		aabb3f const &movingbox, v3f aspeed_f, f32 dtime);
 
-static void move_object_to_collision(v3f *pos_f, v3f *speed_f, v3f &aspeed_f,
-		v3f accel_f, f32 &dtime, Collision collision, bool step_up);
+static void move_object_to_collision(KineticObject &collider, f32 &dtime,
+		Collision collision, bool step_up);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -525,8 +533,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		// Get bounce multiplier
 		float bounce = -(float)nearest_info.bouncy / 100.0f;
 
-		move_object_to_collision(pos_f, speed_f, aspeed_f, accel_f,
-				dtime, collision, step_up);
+		KineticObject collider{pos_f, speed_f, &aspeed_f, accel_f};
+		move_object_to_collision(collider, dtime, collision, step_up);
 
 		v3f old_speed_f = *speed_f;
 
@@ -657,8 +665,8 @@ Collision find_nearest_collision(std::vector<NearbyCollisionInfo> const &cinfo,
 	return Collision{nearest_dtime, nearest_boxindex, nearest_collided};
 }
 
-void move_object_to_collision(v3f *pos_f, v3f *speed_f, v3f &aspeed_f,
-		v3f accel_f, f32 &dtime, Collision collision, bool step_up)
+void move_object_to_collision(KineticObject &collider, f32 &dtime,
+		Collision collision, bool step_up)
 {
 	// Move to the point of collision and reduce dtime by collision.dtime
 	if (collision.dtime < 0) {
@@ -668,24 +676,26 @@ void move_object_to_collision(v3f *pos_f, v3f *speed_f, v3f &aspeed_f,
 		// with above and resolve this collision
 		if (!step_up) {
 			if (collision.axis == COLLISION_AXIS_X) {
-				pos_f->X += aspeed_f.X * collision.dtime;
+				collider.pos->X += collider.avg_speed->X * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Y) {
-				pos_f->Y += aspeed_f.Y * collision.dtime;
+				collider.pos->Y += collider.avg_speed->Y * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Z) {
-				pos_f->Z += aspeed_f.Z * collision.dtime;
+				collider.pos->Z += collider.avg_speed->Z * collision.dtime;
 			}
 		}
 	} else if (collision.dtime > 0) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
-		aspeed_f = *speed_f + accel_f * 0.5f * collision.dtime;
-		*pos_f += aspeed_f * collision.dtime;
+		*collider.avg_speed = *collider.speed +
+				      collider.accel * 0.5f * collision.dtime;
+		*collider.pos += *collider.avg_speed * collision.dtime;
 		// Speed at (approximated) collision:
-		*speed_f += accel_f * collision.dtime;
+		*collider.speed += collider.accel * collision.dtime;
 		// Limit speed for avoiding hangs
-		*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f),
+		*collider.speed = truncate(
+				rangelimv(*collider.speed, -5000.0f, 5000.0f),
 				10000.0f);
 		dtime -= collision.dtime;
 	}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -540,7 +540,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 			break;
 		}
 
-		assert(!std::isinf(collision.dtime) && !std::isnan(collision.dtime));
+		assert(std::isfinite(collision.dtime));
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -557,12 +557,16 @@ core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
 {
 	// Movement if no collisions
 	v3f newpos_f = this->pos + this->velocity * dtime;
-	v3f minpos_f(MYMIN(this->pos.X, newpos_f.X),
-			MYMIN(this->pos.Y, newpos_f.Y) +
-					0.01f * BS, // bias rounding, player often at +/-n.5
-			MYMIN(this->pos.Z, newpos_f.Z));
-	v3f maxpos_f(MYMAX(this->pos.X, newpos_f.X), MYMAX(this->pos.Y, newpos_f.Y),
-			MYMAX(this->pos.Z, newpos_f.Z));
+	v3f minpos_f(
+		MYMIN(this->pos.X, newpos_f.X),
+		MYMIN(this->pos.Y, newpos_f.Y) + 0.01f * BS, // bias rounding, player often at +/-n.5
+		MYMIN(this->pos.Z, newpos_f.Z)
+	);
+	v3f maxpos_f(
+		MYMAX(this->pos.X, newpos_f.X),
+		MYMAX(this->pos.Y, newpos_f.Y),
+		MYMAX(this->pos.Z, newpos_f.Z)
+	);
 	v3s16 min = floatToInt(minpos_f + this->collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
 	v3s16 max = floatToInt(maxpos_f + this->collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
 	return core::aabbox3d<s16>{min, max};

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -84,9 +84,9 @@ class KineticObject
 {
 public:
 	aabb3f collisionbox;
-	v3f *pos;
-	v3f *speed;
-	v3f *accel;
+	v3f pos;
+	v3f speed;
+	v3f accel;
 
 	CollisionMoveResult simulateFor(f32 dtime,
 			std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
@@ -134,7 +134,7 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 }
 }
 
-static bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
+static bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime,
 		IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo);
 
@@ -471,7 +471,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	thread_local std::vector<NearbyCollisionInfo> cinfo;
 	cinfo.clear();
 
-	KineticObject collider{box_0, pos_f, speed_f, &accel_f};
+	KineticObject collider{box_0, *pos_f, *speed_f, accel_f};
 
 	// Do not move if world has not loaded yet, since custom node boxes
 	// are not available for collision detection.
@@ -491,22 +491,25 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	CollisionMoveResult result =
 			collider.simulateFor(dtime, cinfo, stepheight, step_up_mode);
 
+	*pos_f = collider.pos;
+	*speed_f = collider.speed;
+
 	return result;
 }
 
-bool locate_cboxes_in_movement_range(KineticObject collider, f32 dtime,
+bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime,
 		IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo)
 {
 	// Movement if no collisions
-	v3f newpos_f = *collider.pos + *collider.speed * dtime;
-	v3f minpos_f(MYMIN(collider.pos->X, newpos_f.X),
-			MYMIN(collider.pos->Y, newpos_f.Y) +
+	v3f newpos_f = collider.pos + collider.speed * dtime;
+	v3f minpos_f(MYMIN(collider.pos.X, newpos_f.X),
+			MYMIN(collider.pos.Y, newpos_f.Y) +
 					0.01f * BS, // bias rounding, player often at +/-n.5
-			MYMIN(collider.pos->Z, newpos_f.Z));
-	v3f maxpos_f(MYMAX(collider.pos->X, newpos_f.X),
-			MYMAX(collider.pos->Y, newpos_f.Y),
-			MYMAX(collider.pos->Z, newpos_f.Z));
+			MYMIN(collider.pos.Z, newpos_f.Z));
+	v3f maxpos_f(MYMAX(collider.pos.X, newpos_f.X),
+			MYMAX(collider.pos.Y, newpos_f.Y),
+			MYMAX(collider.pos.Z, newpos_f.Z));
 	v3s16 min = floatToInt(minpos_f + collider.collisionbox.MinEdge, BS) -
 				v3s16(1, 1, 1);
 	v3s16 max = floatToInt(maxpos_f + collider.collisionbox.MaxEdge, BS) +
@@ -533,19 +536,19 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		v3f const avg_speed_estimate{this->getProjectedAvgSpeed(dtime)};
 
 		MovingBox movingbox{this->collisionbox, avg_speed_estimate};
-		movingbox.box.MinEdge += *this->pos;
-		movingbox.box.MaxEdge += *this->pos;
+		movingbox.box.MinEdge += this->pos;
+		movingbox.box.MaxEdge += this->pos;
 
 		Collision collision = find_nearest_collision(movingbox, cinfo, dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
-			*this->pos += avg_speed_estimate * dtime;
+			this->pos += avg_speed_estimate * dtime;
 			// Final speed:
-			*this->speed += *this->accel * dtime;
+			this->speed += this->accel * dtime;
 			// Limit speed for avoiding hangs
-			*this->speed = truncate(
-					rangelimv(*this->speed, -5000.0f, 5000.0f), 10000.0f);
+			this->speed = truncate(
+					rangelimv(this->speed, -5000.0f, 5000.0f), 10000.0f);
 			break;
 		}
 
@@ -575,7 +578,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 
 v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 {
-	v3f const avg = *this->speed + *this->accel * 0.5f * dtime;
+	v3f const avg = this->speed + this->accel * 0.5f * dtime;
 	// Limit speed for avoiding hangs
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
@@ -650,26 +653,26 @@ void KineticObject::moveToCollision(
 		// with above and resolve this collision
 		if (!step_up) {
 			if (collision.axis == COLLISION_AXIS_X) {
-				this->pos->X += avg_speed.X * collision.dtime;
+				this->pos.X += avg_speed.X * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Y) {
-				this->pos->Y += avg_speed.Y * collision.dtime;
+				this->pos.Y += avg_speed.Y * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Z) {
-				this->pos->Z += avg_speed.Z * collision.dtime;
+				this->pos.Z += avg_speed.Z * collision.dtime;
 			}
 		}
 	} else if (collision.dtime > 0) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
 		v3f const subinterval_avg_speed =
-				*this->speed + *this->accel * 0.5f * collision.dtime;
-		*this->pos += subinterval_avg_speed * collision.dtime;
+				this->speed + this->accel * 0.5f * collision.dtime;
+		this->pos += subinterval_avg_speed * collision.dtime;
 		// Speed at (approximated) collision:
-		*this->speed += *this->accel * collision.dtime;
+		this->speed += this->accel * collision.dtime;
 		// Limit speed for avoiding hangs
-		*this->speed =
-				truncate(rangelimv(*this->speed, -5000.0f, 5000.0f), 10000.0f);
+		this->speed =
+				truncate(rangelimv(this->speed, -5000.0f, 5000.0f), 10000.0f);
 	}
 }
 
@@ -679,7 +682,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 {
 	CollisionMoveResult result;
 
-	v3f old_speed_f = *this->speed;
+	v3f old_speed_f = this->speed;
 
 	// Get bounce multiplier
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
@@ -687,24 +690,24 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 	// Set the speed component that caused the collision to zero
 	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
 						   (step_up_mode == StepUpMode::FLOATY &&
-								   this->speed->Y <= 0.0f) ||
+								   this->speed.Y <= 0.0f) ||
 						   (step_up_mode == StepUpMode::RIGID &&
-								   this->speed->Y == 0.0f))) {
+								   this->speed.Y == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (collision.axis == COLLISION_AXIS_X) {
-		if (bounce < -1e-4 && fabsf(this->speed->X) > BS * 3) {
-			this->speed->X *= bounce;
+		if (bounce < -1e-4 && fabsf(this->speed.X) > BS * 3) {
+			this->speed.X *= bounce;
 		} else {
-			this->speed->X = 0;
+			this->speed.X = 0;
 			// avoid colliding in the next iterations
-			this->accel->X = 0;
+			this->accel.X = 0;
 		}
 	} else if (collision.axis == COLLISION_AXIS_Y) {
-		if (bounce < -1e-4 && fabsf(this->speed->Y) > BS * 3) {
-			this->speed->Y *= bounce;
+		if (bounce < -1e-4 && fabsf(this->speed.Y) > BS * 3) {
+			this->speed.Y *= bounce;
 		} else {
-			if (this->speed->Y < 0.0f) {
+			if (this->speed.Y < 0.0f) {
 				// FIXME: This code is necessary until
 				// `axisAlignedCollision` takes acceleration
 				// into consideration for the time calculation.
@@ -713,17 +716,17 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 				result.touching_ground    = true;
 				result.standing_on_object = nearest_info.isObject();
 			}
-			this->speed->Y = 0;
+			this->speed.Y = 0;
 			// avoid colliding in the next iterations
-			this->accel->Y = 0;
+			this->accel.Y = 0;
 		}
 	} else { /* collision.axis == COLLISION_AXIS_Z */
-		if (bounce < -1e-4 && fabsf(this->speed->Z) > BS * 3) {
-			this->speed->Z *= bounce;
+		if (bounce < -1e-4 && fabsf(this->speed.Z) > BS * 3) {
+			this->speed.Z *= bounce;
 		} else {
-			this->speed->Z = 0;
+			this->speed.Z = 0;
 			// avoid colliding in the next iterations
-			this->accel->Z = 0;
+			this->accel.Z = 0;
 		}
 	}
 
@@ -733,9 +736,9 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		info.type = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
 		info.node_p    = nearest_info.position;
 		info.object    = nearest_info.obj;
-		info.new_pos   = *this->pos;
+		info.new_pos   = this->pos;
 		info.old_speed = old_speed_f;
-		info.new_speed = *this->speed;
+		info.new_speed = this->speed;
 		result.collisions.push_back(info);
 	}
 
@@ -749,8 +752,8 @@ void KineticObject::stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
 		Final touches: Check if standing on ground, step up stairs.
 	*/
 	aabb3f box = this->collisionbox;
-	box.MinEdge += *this->pos;
-	box.MaxEdge += *this->pos;
+	box.MinEdge += this->pos;
+	box.MaxEdge += this->pos;
 	for (auto const &box_info : cinfo) {
 		aabb3f const &cbox = box_info.box;
 
@@ -767,10 +770,10 @@ void KineticObject::stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
 				cbox.MaxEdge.Z - g_mystery_constant > box.MinEdge.Z &&
 				cbox.MinEdge.Z + g_mystery_constant < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
-				this->pos->Y += cbox.MaxEdge.Y - box.MinEdge.Y;
+				this->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
 				box = this->collisionbox;
-				box.MinEdge += *this->pos;
-				box.MaxEdge += *this->pos;
+				box.MinEdge += this->pos;
+				box.MaxEdge += this->pos;
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
 				// This is code is technically only required if

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -129,9 +129,8 @@ static bool should_step_up(KineticBox const &movingbox, f32 dtime,
 		Collision collision, f32 stepheight,
 		std::vector<NearbyCollisionInfo> const &cinfo);
 
-static Collision find_nearest_collision(
-		std::vector<NearbyCollisionInfo> const &cinfo,
-		aabb3f const &movingbox, v3f aspeed_f, f32 dtime);
+static Collision find_nearest_collision(KineticBox const &movingbox,
+		std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -490,12 +489,11 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			break;
 		}
 
-		aabb3f movingbox = box_0;
-		movingbox.MinEdge += *pos_f;
-		movingbox.MaxEdge += *pos_f;
+		KineticBox movingbox{box_0, aspeed_f};
+		movingbox.box.MinEdge += *pos_f;
+		movingbox.box.MaxEdge += *pos_f;
 
-		Collision collision = find_nearest_collision(
-				cinfo, movingbox, aspeed_f, dtime);
+		Collision collision = find_nearest_collision(movingbox, cinfo, dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
@@ -511,8 +509,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 
-		KineticBox bb{movingbox, aspeed_f};
-		bool step_up = should_step_up(bb, dtime, collision, stepheight, cinfo);
+		bool step_up = should_step_up(movingbox, dtime, collision, stepheight, cinfo);
 
 		collider.moveToCollision(dtime, collision, step_up);
 
@@ -614,8 +611,8 @@ bool should_step_up(KineticBox const &movingbox, f32 dtime, Collision collision,
 	}
 }
 
-Collision find_nearest_collision(std::vector<NearbyCollisionInfo> const &cinfo,
-		aabb3f const &movingbox, v3f aspeed_f, f32 dtime)
+Collision find_nearest_collision(KineticBox const &movingbox,
+		std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime)
 {
 	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;
 	f32 nearest_dtime              = dtime;
@@ -632,7 +629,7 @@ Collision find_nearest_collision(std::vector<NearbyCollisionInfo> const &cinfo,
 		// Find nearest collision of the two boxes (raytracing-like)
 		f32 dtime_tmp          = nearest_dtime;
 		CollisionAxis collided = axisAlignedCollision(
-				box_info.box, movingbox, aspeed_f, &dtime_tmp);
+				box_info.box, movingbox.box, movingbox.avg_speed, &dtime_tmp);
 		if (collided == -1 || dtime_tmp >= nearest_dtime) {
 			continue;
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -108,13 +108,18 @@ public:
 
 	template <float v3f::*AX> void collide(f32 bounce)
 	{
-		if (bounce < -1e-4 && fabsf(velocity.*AX) > BS * 3) {
+		if (canBounce<AX>(bounce)) {
 			velocity.*AX *= bounce;
 		} else {
 			velocity.*AX = 0.f;
 			// avoid colliding in the next iterations
 			accel.*AX = 0.f;
 		}
+	}
+
+	template <float v3f::*AX> bool canBounce(f32 bounce)
+	{
+		return bounce < -1e-4 && fabsf(velocity.*AX) <= BS * 3;
 	}
 
 	v3f getPosition() const
@@ -749,8 +754,7 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 	} else if (axis == COLLISION_AXIS_Z) {
 		collider->collide<&v3f::Z>(bounce);
 	} else { // axis == COLLISION_AXIS_Y)
-		if ((bounce >= -1e-4 || fabsf(collider->velocity.Y) <= BS * 3) &&
-				collider->velocity.Y < 0.0f) {
+		if (!collider->canBounce<&v3f::Y>(bounce) && collider->velocity.Y < 0.0f) {
 			// FIXME: This code is necessary until
 			// `axisAlignedCollision` takes acceleration
 			// into consideration for the time calculation.

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -479,7 +479,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
 	if (!locate_cboxes_in_movement_range(
 				collider, dtime, gamedef, env, cinfo)) {
-		*speed_f = v3f(0, 0, 0);
+		*speed_f = v3f(0.f, 0.f, 0.f);
 		return CollisionMoveResult{};
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -71,32 +71,6 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
-<<<<<<< HEAD
-struct KineticObject;
-
-	struct MovingBox
-	{
-		aabb3f box;
-		v3f velocity;
-	};
-
-class MovementContext
-{
-public:
-	std::vector<NearbyCollisionInfo> cinfo;
-	f32 remaining_dtime;
-
-	CollisionMoveResult simulateFor(
-			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
-
-private:
-	Collision findNearestCollision(MovingBox const &movingbox);
-
-	bool shouldStepUp(MovingBox const &movingbox, Collision collision, f32 stepheight);
-};
-
-=======
->>>>>>> fc6714645 (Move `stepUpStairs` to `MovementContext`)
 struct KineticObject
 {
 	aabb3f collisionbox;
@@ -719,7 +693,15 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 			// avoid colliding in the next iterations
 			this->accel.X = 0.f;
 		}
-	} else if (collision.axis == COLLISION_AXIS_Y) {
+	} else if (collision.axis == COLLISION_AXIS_Z) {
+		if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {
+			this->velocity.Z *= bounce;
+		} else {
+			this->velocity.Z = 0.f;
+			// avoid colliding in the next iterations
+			this->accel.Z = 0.f;
+		}
+	} else { // collision.axis == COLLISION_AXIS_Y)
 		if (bounce < -1e-4 && fabsf(this->velocity.Y) > BS * 3) {
 			this->velocity.Y *= bounce;
 		} else {
@@ -735,14 +717,6 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 			this->velocity.Y = 0.f;
 			// avoid colliding in the next iterations
 			this->accel.Y = 0.f;
-		}
-	} else { /* collision.axis == COLLISION_AXIS_Z */
-		if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {
-			this->velocity.Z *= bounce;
-		} else {
-			this->velocity.Z = 0.f;
-			// avoid colliding in the next iterations
-			this->accel.Z = 0.f;
 		}
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -86,15 +86,17 @@ public:
 	aabb3f collisionbox;
 	v3f *pos;
 	v3f *speed;
-	v3f *avg_speed;
 	v3f *accel;
 
 	collisionMoveResult simulateFor(f32 dtime,
 			std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
 			StepUpMode step_up_mode);
 
+	v3f getProjectedAvgSpeed(f32 dtime) const;
+
 private:
-	void moveToCollision(Collision collision, f32 dtime, bool step_up);
+	void moveToCollision(
+			Collision collision, v3f avg_speed, f32 dtime, bool step_up);
 
 	CollisionMoveResult collideWith(Collision collision,
 			NearbyCollisionInfo &nearest_info, bool step_up,
@@ -459,18 +461,13 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		time_notification_done = false;
 	}
 
-	// Average speed
-	v3f aspeed_f = *speed_f + accel_f * 0.5f * dtime;
-	// Limit speed for avoiding hangs
-	aspeed_f = truncate(rangelimv(aspeed_f, -5000.0f, 5000.0f), 10000.0f);
-
 	// Collect node boxes in movement range
 
 	// cached allocation
 	thread_local std::vector<NearbyCollisionInfo> cinfo;
 	cinfo.clear();
 
-	KineticObject collider{box_0, pos_f, speed_f, &aspeed_f, &accel_f};
+	KineticObject collider{box_0, pos_f, speed_f, &accel_f};
 
 	// Do not move if world has not loaded yet, since custom node boxes
 	// are not available for collision detection.
@@ -484,7 +481,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	// Collect object boxes in movement range
 	if (collide_with_objects) {
-		add_object_boxes(env, box_0, dtime, *pos_f, aspeed_f, self, cinfo);
+		add_object_boxes(env, box_0, dtime, *pos_f, collider.getProjectedAvgSpeed(dtime), self, cinfo);
 	}
 
 	CollisionMoveResult result =
@@ -565,7 +562,9 @@ collisionMoveResult KineticObject::simulateFor(f32 dtime,
 			break;
 		}
 
-		KineticBox movingbox{this->collisionbox, *this->avg_speed};
+		v3f const avg_speed_estimate{this->getProjectedAvgSpeed(dtime)};
+
+		KineticBox movingbox{this->collisionbox, avg_speed_estimate};
 		movingbox.box.MinEdge += *this->pos;
 		movingbox.box.MaxEdge += *this->pos;
 
@@ -573,7 +572,7 @@ collisionMoveResult KineticObject::simulateFor(f32 dtime,
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
-			*this->pos += *this->avg_speed * dtime;
+			*this->pos += avg_speed_estimate * dtime;
 			// Final speed:
 			*this->speed += *this->accel * dtime;
 			// Limit speed for avoiding hangs
@@ -589,7 +588,7 @@ collisionMoveResult KineticObject::simulateFor(f32 dtime,
 		bool step_up =
 				should_step_up(movingbox, dtime, collision, stepheight, cinfo);
 
-		this->moveToCollision(collision, dtime, step_up);
+		this->moveToCollision(collision, avg_speed_estimate, dtime, step_up);
 		dtime -= collision.dtime;
 
 		result = this->collideWith(
@@ -598,15 +597,16 @@ collisionMoveResult KineticObject::simulateFor(f32 dtime,
 		if (dtime < BS * 1e-10f) {
 			break;
 		}
-
-		// Speed for finding the next collision
-		*this->avg_speed = *this->speed + *this->accel * 0.5f * dtime;
-		// Limit speed for avoiding hangs
-		*this->avg_speed = truncate(
-				rangelimv(*this->avg_speed, -5000.0f, 5000.0f), 10000.0f);
 	}
 
 	return result;
+}
+
+v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
+{
+	v3f const avg = *this->speed + *this->accel * 0.5f * dtime;
+	// Limit speed for avoiding hangs
+	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
 
 bool should_step_up(KineticBox const &movingbox, f32 dtime, Collision collision,
@@ -669,7 +669,7 @@ Collision find_nearest_collision(KineticBox const &movingbox,
 }
 
 void KineticObject::moveToCollision(
-		Collision collision, f32 dtime, bool step_up)
+		Collision collision, v3f avg_speed, f32 dtime, bool step_up)
 {
 	// Move to the point of collision and reduce dtime by collision.dtime
 	if (collision.dtime < 0) {
@@ -679,20 +679,21 @@ void KineticObject::moveToCollision(
 		// with above and resolve this collision
 		if (!step_up) {
 			if (collision.axis == COLLISION_AXIS_X) {
-				this->pos->X += this->avg_speed->X * collision.dtime;
+				this->pos->X += avg_speed.X * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Y) {
-				this->pos->Y += this->avg_speed->Y * collision.dtime;
+				this->pos->Y += avg_speed.Y * collision.dtime;
 			}
 			if (collision.axis == COLLISION_AXIS_Z) {
-				this->pos->Z += this->avg_speed->Z * collision.dtime;
+				this->pos->Z += avg_speed.Z * collision.dtime;
 			}
 		}
 	} else if (collision.dtime > 0) {
 		// updated average speed for the sub-interval up to
 		// collision.dtime
-		*this->avg_speed = *this->speed + *this->accel * 0.5f * collision.dtime;
-		*this->pos += *this->avg_speed * collision.dtime;
+		v3f const subinterval_avg_speed =
+				*this->speed + *this->accel * 0.5f * collision.dtime;
+		*this->pos += subinterval_avg_speed * collision.dtime;
 		// Speed at (approximated) collision:
 		*this->speed += *this->accel * collision.dtime;
 		// Limit speed for avoiding hangs

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -103,6 +103,9 @@ static Collision find_nearest_collision(
 		std::vector<NearbyCollisionInfo> const &cinfo,
 		aabb3f const &movingbox, v3f aspeed_f, f32 dtime);
 
+static void move_object_to_collision(v3f *pos_f, v3f *speed_f, v3f &aspeed_f,
+		v3f accel_f, f32 &dtime, Collision collision, bool step_up);
+
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
 // Returns -1 if no collision, 0 if X collision, 1 if Y collision, 2 if Z collision
@@ -522,29 +525,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		// Get bounce multiplier
 		float bounce = -(float)nearest_info.bouncy / 100.0f;
 
-		// Move to the point of collision and reduce dtime by collision.dtime
-		if (collision.dtime < 0) {
-			// Handle negative collision.dtime
-			// This largely means an "instant" collision, e.g., with the floor.
-			// We use aspeed and collision.dtime to be consistent with above and resolve this collision
-			if (!step_up) {
-				if (collision.axis == COLLISION_AXIS_X)
-					pos_f->X += aspeed_f.X * collision.dtime;
-				if (collision.axis == COLLISION_AXIS_Y)
-					pos_f->Y += aspeed_f.Y * collision.dtime;
-				if (collision.axis == COLLISION_AXIS_Z)
-					pos_f->Z += aspeed_f.Z * collision.dtime;
-			}
-		} else if (collision.dtime > 0) {
-			// updated average speed for the sub-interval up to collision.dtime
-			aspeed_f = *speed_f + accel_f * 0.5f * collision.dtime;
-			*pos_f += aspeed_f * collision.dtime;
-			// Speed at (approximated) collision:
-			*speed_f += accel_f * collision.dtime;
-			// Limit speed for avoiding hangs
-			*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f), 10000.0f);
-			dtime -= collision.dtime;
-		}
+		move_object_to_collision(pos_f, speed_f, aspeed_f, accel_f,
+				dtime, collision, step_up);
 
 		v3f old_speed_f = *speed_f;
 
@@ -673,6 +655,40 @@ Collision find_nearest_collision(std::vector<NearbyCollisionInfo> const &cinfo,
 	}
 
 	return Collision{nearest_dtime, nearest_boxindex, nearest_collided};
+}
+
+void move_object_to_collision(v3f *pos_f, v3f *speed_f, v3f &aspeed_f,
+		v3f accel_f, f32 &dtime, Collision collision, bool step_up)
+{
+	// Move to the point of collision and reduce dtime by collision.dtime
+	if (collision.dtime < 0) {
+		// Handle negative collision.dtime
+		// This largely means an "instant" collision, e.g., with the
+		// floor. We use aspeed and collision.dtime to be consistent
+		// with above and resolve this collision
+		if (!step_up) {
+			if (collision.axis == COLLISION_AXIS_X) {
+				pos_f->X += aspeed_f.X * collision.dtime;
+			}
+			if (collision.axis == COLLISION_AXIS_Y) {
+				pos_f->Y += aspeed_f.Y * collision.dtime;
+			}
+			if (collision.axis == COLLISION_AXIS_Z) {
+				pos_f->Z += aspeed_f.Z * collision.dtime;
+			}
+		}
+	} else if (collision.dtime > 0) {
+		// updated average speed for the sub-interval up to
+		// collision.dtime
+		aspeed_f = *speed_f + accel_f * 0.5f * collision.dtime;
+		*pos_f += aspeed_f * collision.dtime;
+		// Speed at (approximated) collision:
+		*speed_f += accel_f * collision.dtime;
+		// Limit speed for avoiding hangs
+		*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f),
+				10000.0f);
+		dtime -= collision.dtime;
+	}
 }
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -85,9 +85,8 @@ public:
 	v3f velocity;
 	v3f accel;
 
-	CollisionMoveResult simulateFor(f32 dtime,
-			std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
-			StepUpMode step_up_mode);
+	CollisionMoveResult simulateFor(f32 dtime, std::vector<NearbyCollisionInfo> &cinfo,
+			f32 stepheight, StepUpMode step_up_mode);
 
 	v3f getProjectedAvgSpeed(f32 dtime) const;
 
@@ -132,15 +131,13 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 }
 
 static bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime,
-		IGameDef *gamedef, Environment *env,
-		std::vector<NearbyCollisionInfo> &cinfo);
+		IGameDef *gamedef, Environment *env, std::vector<NearbyCollisionInfo> &cinfo);
 
-static bool should_step_up(MovingBox const &movingbox, f32 dtime,
-		Collision collision, f32 stepheight,
-		std::vector<NearbyCollisionInfo> const &cinfo);
+static bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
+		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo);
 
-static Collision find_nearest_collision(MovingBox const &movingbox,
-		std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime);
+static Collision find_nearest_collision(
+		MovingBox const &movingbox, std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -494,9 +491,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	return result;
 }
 
-bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime,
-		IGameDef *gamedef, Environment *env,
-		std::vector<NearbyCollisionInfo> &cinfo)
+bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime, IGameDef *gamedef,
+		Environment *env, std::vector<NearbyCollisionInfo> &cinfo)
 {
 	// Movement if no collisions
 	v3f newpos_f = collider.pos + collider.velocity * dtime;
@@ -504,20 +500,16 @@ bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime,
 			MYMIN(collider.pos.Y, newpos_f.Y) +
 					0.01f * BS, // bias rounding, player often at +/-n.5
 			MYMIN(collider.pos.Z, newpos_f.Z));
-	v3f maxpos_f(MYMAX(collider.pos.X, newpos_f.X),
-			MYMAX(collider.pos.Y, newpos_f.Y),
+	v3f maxpos_f(MYMAX(collider.pos.X, newpos_f.X), MYMAX(collider.pos.Y, newpos_f.Y),
 			MYMAX(collider.pos.Z, newpos_f.Z));
-	v3s16 min = floatToInt(minpos_f + collider.collisionbox.MinEdge, BS) -
-				v3s16(1, 1, 1);
-	v3s16 max = floatToInt(maxpos_f + collider.collisionbox.MaxEdge, BS) +
-				v3s16(1, 1, 1);
+	v3s16 min = floatToInt(minpos_f + collider.collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
+	v3s16 max = floatToInt(maxpos_f + collider.collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
 
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
 CollisionMoveResult KineticObject::simulateFor(f32 dtime,
-		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight,
-		StepUpMode step_up_mode)
+		std::vector<NearbyCollisionInfo> &cinfo, f32 stepheight, StepUpMode step_up_mode)
 {
 	CollisionMoveResult result;
 
@@ -536,8 +528,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		movingbox.box.MinEdge += this->pos;
 		movingbox.box.MaxEdge += this->pos;
 
-		Collision const collision =
-				find_nearest_collision(movingbox, cinfo, dtime);
+		Collision const collision = find_nearest_collision(movingbox, cinfo, dtime);
 
 		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
@@ -545,8 +536,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 			// Final speed:
 			this->velocity += this->accel * dtime;
 			// Limit speed for avoiding hangs
-			this->velocity = truncate(
-					rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
+			this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
 			break;
 		}
 
@@ -554,14 +544,12 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 
-		bool const step_up =
-				should_step_up(movingbox, dtime, collision, stepheight, cinfo);
+		bool const step_up = should_step_up(movingbox, dtime, collision, stepheight, cinfo);
 
 		this->moveToCollision(collision, avg_speed_estimate, dtime, step_up);
 		dtime -= collision.dtime;
 
-		result = this->collideWith(
-				collision, nearest_info, step_up, step_up_mode);
+		result = this->collideWith(collision, nearest_info, step_up, step_up_mode);
 
 		if (dtime < BS * 1e-10f) {
 			break;
@@ -581,8 +569,8 @@ v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
 
-bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
-		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo)
+bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision, f32 stepheight,
+		std::vector<NearbyCollisionInfo> const &cinfo)
 {
 	if (collision.axis != COLLISION_AXIS_Y) {
 		// movingbox except moved to the horizontal position it would be after
@@ -591,8 +579,7 @@ bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
 		// Look slightly ahead  for checking the height when stepping
 		// to ensure we also check above the node we collided with
 		// otherwise, might allow glitches such as a stack of stairs
-		float extra_dtime =
-				collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
+		float extra_dtime = collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
 		stepbox.MinEdge.X += movingbox.velocity.X * extra_dtime;
 		stepbox.MinEdge.Z += movingbox.velocity.Z * extra_dtime;
 		stepbox.MaxEdge.X += movingbox.velocity.X * extra_dtime;
@@ -601,16 +588,15 @@ bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
 		aabb3f const &cbox = cinfo[collision.boxindex].box;
 		return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
 			   (movingbox.box.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
-			   (!wouldCollideWithCeiling(cinfo, stepbox,
-					   cbox.MaxEdge.Y - movingbox.box.MinEdge.Y,
-					   0.0f));
+			   (!wouldCollideWithCeiling(
+					   cinfo, stepbox, cbox.MaxEdge.Y - movingbox.box.MinEdge.Y, 0.0f));
 	} else {
 		return false;
 	}
 }
 
-Collision find_nearest_collision(MovingBox const &movingbox,
-		std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime)
+Collision find_nearest_collision(
+		MovingBox const &movingbox, std::vector<NearbyCollisionInfo> const &cinfo, f32 dtime)
 {
 	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;
 	f32 nearest_dtime              = dtime;
@@ -669,14 +655,12 @@ void KineticObject::moveToCollision(
 		// Speed at (approximated) collision:
 		this->velocity += this->accel * collision.dtime;
 		// Limit speed for avoiding hangs
-		this->velocity =
-				truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
+		this->velocity = truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
 	}
 }
 
 CollisionMoveResult KineticObject::collideWith(Collision collision,
-		NearbyCollisionInfo &nearest_info, bool step_up,
-		StepUpMode step_up_mode)
+		NearbyCollisionInfo &nearest_info, bool step_up, StepUpMode step_up_mode)
 {
 	CollisionMoveResult result;
 
@@ -687,10 +671,8 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 
 	// Set the speed component that caused the collision to zero
 	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
-			(step_up_mode == StepUpMode::FLOATY &&
-					this->velocity.Y <= 0.0f) ||
-			(step_up_mode == StepUpMode::RIGID &&
-					this->velocity.Y == 0.0f))) {
+			(step_up_mode == StepUpMode::FLOATY && this->velocity.Y <= 0.0f) ||
+			(step_up_mode == StepUpMode::RIGID && this->velocity.Y == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (collision.axis == COLLISION_AXIS_X) {
@@ -730,8 +712,8 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 
 	if (!nearest_info.is_unloaded && !step_up) {
 		CollisionInfo info;
-		info.axis = collision.axis;
-		info.type = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
+		info.axis      = collision.axis;
+		info.type      = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
 		info.node_p    = nearest_info.position;
 		info.object    = nearest_info.obj;
 		info.new_pos   = this->pos;
@@ -743,8 +725,8 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 	return result;
 }
 
-void KineticObject::stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
-		CollisionMoveResult &result)
+void KineticObject::stepUpStairs(
+		std::vector<NearbyCollisionInfo> const &cinfo, CollisionMoveResult &result)
 {
 	/*
 		Final touches: Check if standing on ground, step up stairs.
@@ -763,10 +745,8 @@ void KineticObject::stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
 			X-Z-area.
 		*/
 
-		if (cbox.MaxEdge.X > box.MinEdge.X &&
-				cbox.MinEdge.X < box.MaxEdge.X &&
-				cbox.MaxEdge.Z > box.MinEdge.Z &&
-				cbox.MinEdge.Z < box.MaxEdge.Z) {
+		if (cbox.MaxEdge.X > box.MinEdge.X && cbox.MinEdge.X < box.MaxEdge.X &&
+				cbox.MaxEdge.Z > box.MinEdge.Z && cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
 				this->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
 				box = this->collisionbox;
@@ -774,9 +754,9 @@ void KineticObject::stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
 				box.MaxEdge += this->pos;
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
-				// This is code is technically only required if
-				// `box_info.is_step_up == true`. However, players rely on this
-				// check/condition to climb stairs faster. See PR #10587.
+				// This is code is technically only required if `box_info.is_step_up == true`.
+				// However, players rely on this check/condition to climb stairs faster.
+				// See PR #10587.
 				result.touching_ground    = true;
 				result.standing_on_object = box_info.isObject();
 			}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -71,6 +71,7 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
+<<<<<<< HEAD
 struct KineticObject;
 
 	struct MovingBox
@@ -94,6 +95,8 @@ private:
 	bool shouldStepUp(MovingBox const &movingbox, Collision collision, f32 stepheight);
 };
 
+=======
+>>>>>>> fc6714645 (Move `stepUpStairs` to `MovementContext`)
 struct KineticObject
 {
 	aabb3f collisionbox;
@@ -109,9 +112,29 @@ struct KineticObject
 	CollisionMoveResult collideWith(Collision collision,
 			NearbyCollisionInfo &nearest_info, bool step_up,
 			StepUpMode step_up_mode);
+};
 
-	void stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
-			CollisionMoveResult &result);
+class MovementContext
+{
+public:
+	std::vector<NearbyCollisionInfo> cinfo;
+	f32 remaining_dtime;
+
+	CollisionMoveResult simulateFor(
+			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
+
+private:
+	struct MovingBox
+	{
+		aabb3f box;
+		v3f velocity;
+	};
+
+	Collision findNearestCollision(MovingBox const &movingbox);
+
+	bool shouldStepUp(MovingBox const &movingbox, Collision collision, f32 stepheight);
+
+	void stepUpStairs(KineticObject *collider, CollisionMoveResult &result);
 };
 
 // Helper functions:
@@ -563,7 +586,7 @@ CollisionMoveResult MovementContext::simulateFor(
 		}
 	}
 
-	collider->stepUpStairs(this->cinfo, result);
+	this->stepUpStairs(collider, result);
 	result.collides = !result.collisions.empty();
 
 	return result;
@@ -732,16 +755,15 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 	return result;
 }
 
-void KineticObject::stepUpStairs(
-		std::vector<NearbyCollisionInfo> const &cinfo, CollisionMoveResult &result)
+void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult &result)
 {
 	/*
 		Final touches: Check if standing on ground, step up stairs.
 	*/
-	aabb3f box = this->collisionbox;
-	box.MinEdge += this->pos;
-	box.MaxEdge += this->pos;
-	for (auto const &box_info : cinfo) {
+	aabb3f box = collider->collisionbox;
+	box.MinEdge += collider->pos;
+	box.MaxEdge += collider->pos;
+	for (auto const &box_info : this->cinfo) {
 		aabb3f const &cbox = box_info.box;
 
 		/*
@@ -755,10 +777,10 @@ void KineticObject::stepUpStairs(
 		if (cbox.MaxEdge.X > box.MinEdge.X && cbox.MinEdge.X < box.MaxEdge.X &&
 				cbox.MaxEdge.Z > box.MinEdge.Z && cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
-				this->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
-				box = this->collisionbox;
-				box.MinEdge += this->pos;
-				box.MaxEdge += this->pos;
+				collider->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
+				box = collider->collisionbox;
+				box.MinEdge += collider->pos;
+				box.MaxEdge += collider->pos;
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
 				// This is code is technically only required if `box_info.is_step_up == true`.

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -110,6 +110,14 @@ public:
 	std::vector<NearbyCollisionInfo> cinfo;
 	f32 remaining_dtime;
 
+	void clear()
+	{
+		this->cinfo.clear();
+	}
+
+	bool addCollisionsInMovementRange(
+			KineticObject const &collider, IGameDef *gamedef, Environment *env);
+
 	CollisionMoveResult simulateFor(
 			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
 
@@ -153,9 +161,6 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 	);
 }
 }
-
-static bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
-		IGameDef *gamedef, Environment *env, std::vector<NearbyCollisionInfo> &cinfo);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -485,8 +490,10 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// are not available for collision detection.
 	// This also intentionally occurs in the case of the object being positioned
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-	if (!add_collisions_in_movement_range(
-				collider, dtime, gamedef, env, cinfo)) {
+
+	thread_local MovementContext ctx{cinfo, dtime};
+
+	if (!ctx.addCollisionsInMovementRange(collider, gamedef, env)) {
 		*speed_f = v3f();
 		return CollisionMoveResult{};
 	}
@@ -496,7 +503,6 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		add_object_boxes(env, box_0, dtime, *pos_f, collider.getProjectedAvgSpeed(dtime), self, cinfo);
 	}
 
-	MovementContext ctx{cinfo, dtime};
 	CollisionMoveResult result = ctx.simulateFor(&collider, stepheight, step_up_mode);
 
 	*pos_f = collider.pos;
@@ -505,11 +511,11 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	return result;
 }
 
-bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
-		IGameDef *gamedef, Environment *env, std::vector<NearbyCollisionInfo> &cinfo)
+bool MovementContext::addCollisionsInMovementRange(
+		KineticObject const &collider, IGameDef *gamedef, Environment *env)
 {
 	// Movement if no collisions
-	v3f newpos_f = collider.pos + collider.velocity * dtime;
+	v3f newpos_f = collider.pos + collider.velocity * this->remaining_dtime;
 	v3f minpos_f(MYMIN(collider.pos.X, newpos_f.X),
 			MYMIN(collider.pos.Y, newpos_f.Y) +
 					0.01f * BS, // bias rounding, player often at +/-n.5
@@ -519,7 +525,7 @@ bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
 	v3s16 min = floatToInt(minpos_f + collider.collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
 	v3s16 max = floatToInt(maxpos_f + collider.collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
 
-	return add_area_node_boxes(min, max, gamedef, env, cinfo);
+	return add_area_node_boxes(min, max, gamedef, env, this->cinfo);
 }
 
 CollisionMoveResult MovementContext::simulateFor(

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -727,7 +727,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		} else {
 			this->velocity.Z = 0.f;
 			// avoid colliding in the next iterations
-			this->accel.Z = 0;
+			this->accel.Z = 0.f;
 		}
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -109,6 +109,10 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 }
 }
 
+static bool locate_cboxes_in_movement_range(KineticObject collider,
+		aabb3f box_0, f32 dtime, IGameDef *gamedef, Environment *env,
+		std::vector<NearbyCollisionInfo> &cinfo);
+
 static bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed,
 		f32 dtime, Collision collision, f32 stepheight,
 		std::vector<NearbyCollisionInfo> const &cinfo);
@@ -456,32 +460,17 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// cached allocation
 	thread_local std::vector<NearbyCollisionInfo> cinfo;
 	cinfo.clear();
-	{
-		// Movement if no collisions
-		v3f newpos_f = *pos_f + aspeed_f * dtime;
-		v3f minpos_f(
-			MYMIN(pos_f->X, newpos_f.X),
-			MYMIN(pos_f->Y, newpos_f.Y) + 0.01f * BS, // bias rounding, player often at +/-n.5
-			MYMIN(pos_f->Z, newpos_f.Z)
-		);
-		v3f maxpos_f(
-			MYMAX(pos_f->X, newpos_f.X),
-			MYMAX(pos_f->Y, newpos_f.Y),
-			MYMAX(pos_f->Z, newpos_f.Z)
-		);
-		v3s16 min = floatToInt(minpos_f + box_0.MinEdge, BS) - v3s16(1, 1, 1);
-		v3s16 max = floatToInt(maxpos_f + box_0.MaxEdge, BS) + v3s16(1, 1, 1);
 
-		bool any_position_valid = add_area_node_boxes(min, max, gamedef, env, cinfo);
+	KineticObject collider{pos_f, speed_f, &aspeed_f, &accel_f};
 
-		// Do not move if world has not loaded yet, since custom node boxes
-		// are not available for collision detection.
-		// This also intentionally occurs in the case of the object being positioned
-		// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-		if (!any_position_valid) {
-			*speed_f = v3f(0, 0, 0);
-			return CollisionMoveResult{};
-		}
+	// Do not move if world has not loaded yet, since custom node boxes
+	// are not available for collision detection.
+	// This also intentionally occurs in the case of the object being positioned
+	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
+	if (!locate_cboxes_in_movement_range(
+				collider, box_0, dtime, gamedef, env, cinfo)) {
+		*speed_f = v3f(0, 0, 0);
+		return CollisionMoveResult{};
 	}
 
 	// Collect object boxes in movement range
@@ -521,7 +510,6 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		bool step_up = should_step_up(
 				movingbox, cbox, aspeed_f, dtime, collision, stepheight, cinfo);
 
-		KineticObject collider{pos_f, speed_f, &aspeed_f, &accel_f};
 		move_object_to_collision(collider, dtime, collision, step_up);
 
 		result = collide(
@@ -573,6 +561,25 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	result.collides = !result.collisions.empty();
 	return result;
+}
+
+bool locate_cboxes_in_movement_range(KineticObject collider, aabb3f box_0,
+		f32 dtime, IGameDef *gamedef, Environment *env,
+		std::vector<NearbyCollisionInfo> &cinfo)
+{
+	// Movement if no collisions
+	v3f newpos_f = *collider.pos + *collider.speed * dtime;
+	v3f minpos_f(MYMIN(collider.pos->X, newpos_f.X),
+			MYMIN(collider.pos->Y, newpos_f.Y) +
+					0.01f * BS, // bias rounding, player often at +/-n.5
+			MYMIN(collider.pos->Z, newpos_f.Z));
+	v3f maxpos_f(MYMAX(collider.pos->X, newpos_f.X),
+			MYMAX(collider.pos->Y, newpos_f.Y),
+			MYMAX(collider.pos->Z, newpos_f.Z));
+	v3s16 min = floatToInt(minpos_f + box_0.MinEdge, BS) - v3s16(1, 1, 1);
+	v3s16 max = floatToInt(maxpos_f + box_0.MaxEdge, BS) + v3s16(1, 1, 1);
+
+	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
 bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed, f32 dtime,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -20,9 +20,14 @@
 #include "profiler.h"
 #include "object_properties.h"
 
+#include <cassert>
+#include <limits>
+#include <vector>
+
 #ifdef __FAST_MATH__
 #warning "-ffast-math is known to cause bugs in collision code, do not use!"
 #endif
+
 
 bool g_collision_problems_encountered = false;
 
@@ -58,6 +63,15 @@ struct NearbyCollisionInfo {
 	bool is_unloaded:1, is_step_up:1;
 };
 
+struct Collision
+{
+	// This is the delta between the current dtime and the time at
+	// which the collision is predicted to occur.
+	f32 dtime{std::numeric_limits<f32>::infinity()};
+	int boxindex{-1};
+	CollisionAxis axis{COLLISION_AXIS_NONE};
+};
+
 // Helper functions:
 // Truncate floating point numbers to specified number of decimal places
 // in order to move all the floating point error to one side of the correct value
@@ -84,6 +98,10 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 	);
 }
 }
+
+static Collision find_nearest_collision(
+		std::vector<NearbyCollisionInfo> const &cinfo,
+		aabb3f const &movingbox, v3f aspeed_f, f32 dtime);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -463,30 +481,10 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		movingbox.MinEdge += *pos_f;
 		movingbox.MaxEdge += *pos_f;
 
-		CollisionAxis nearest_collided = COLLISION_AXIS_NONE;
-		f32 nearest_dtime = dtime;
-		int nearest_boxindex = -1;
+		Collision collision = find_nearest_collision(
+				cinfo, movingbox, aspeed_f, dtime);
 
-		// Go through every nodebox, find nearest collision
-		for (u32 boxindex = 0; boxindex < cinfo.size(); boxindex++) {
-			const NearbyCollisionInfo &box_info = cinfo[boxindex];
-			// Ignore if already stepped up this nodebox.
-			if (box_info.is_step_up)
-				continue;
-
-			// Find nearest collision of the two boxes (raytracing-like)
-			f32 dtime_tmp = nearest_dtime;
-			CollisionAxis collided = axisAlignedCollision(box_info.box,
-					movingbox, aspeed_f, &dtime_tmp);
-			if (collided == -1 || dtime_tmp >= nearest_dtime)
-				continue;
-
-			nearest_dtime = dtime_tmp;
-			nearest_collided = collided;
-			nearest_boxindex = boxindex;
-		}
-
-		if (nearest_collided == COLLISION_AXIS_NONE) {
+		if (collision.axis == COLLISION_AXIS_NONE) {
 			// No collision with any collision box.
 			*pos_f += aspeed_f * dtime;
 			// Final speed:
@@ -495,18 +493,20 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f), 10000.0f);
 			break;
 		}
+
+		assert(!std::isinf(collision.dtime) && !std::isnan(collision.dtime));
 		// Otherwise, a collision occurred.
-		NearbyCollisionInfo &nearest_info = cinfo[nearest_boxindex];
+		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 		const aabb3f& cbox = nearest_info.box;
 
 		//movingbox except moved to the horizontal position it would be after step up
 		bool step_up = false;
-		if (nearest_collided != COLLISION_AXIS_Y) {
+		if (collision.axis != COLLISION_AXIS_Y) {
 			aabb3f stepbox = movingbox;
 			// Look slightly ahead  for checking the height when stepping
 			// to ensure we also check above the node we collided with
 			// otherwise, might allow glitches such as a stack of stairs
-			float extra_dtime = nearest_dtime + 0.1f * fabsf(dtime - nearest_dtime);
+			float extra_dtime = collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
 			stepbox.MinEdge.X += aspeed_f.X * extra_dtime;
 			stepbox.MinEdge.Z += aspeed_f.Z * extra_dtime;
 			stepbox.MaxEdge.X += aspeed_f.X * extra_dtime;
@@ -522,28 +522,28 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		// Get bounce multiplier
 		float bounce = -(float)nearest_info.bouncy / 100.0f;
 
-		// Move to the point of collision and reduce dtime by nearest_dtime
-		if (nearest_dtime < 0) {
-			// Handle negative nearest_dtime
+		// Move to the point of collision and reduce dtime by collision.dtime
+		if (collision.dtime < 0) {
+			// Handle negative collision.dtime
 			// This largely means an "instant" collision, e.g., with the floor.
-			// We use aspeed and nearest_dtime to be consistent with above and resolve this collision
+			// We use aspeed and collision.dtime to be consistent with above and resolve this collision
 			if (!step_up) {
-				if (nearest_collided == COLLISION_AXIS_X)
-					pos_f->X += aspeed_f.X * nearest_dtime;
-				if (nearest_collided == COLLISION_AXIS_Y)
-					pos_f->Y += aspeed_f.Y * nearest_dtime;
-				if (nearest_collided == COLLISION_AXIS_Z)
-					pos_f->Z += aspeed_f.Z * nearest_dtime;
+				if (collision.axis == COLLISION_AXIS_X)
+					pos_f->X += aspeed_f.X * collision.dtime;
+				if (collision.axis == COLLISION_AXIS_Y)
+					pos_f->Y += aspeed_f.Y * collision.dtime;
+				if (collision.axis == COLLISION_AXIS_Z)
+					pos_f->Z += aspeed_f.Z * collision.dtime;
 			}
-		} else if (nearest_dtime > 0) {
-			// updated average speed for the sub-interval up to nearest_dtime
-			aspeed_f = *speed_f + accel_f * 0.5f * nearest_dtime;
-			*pos_f += aspeed_f * nearest_dtime;
+		} else if (collision.dtime > 0) {
+			// updated average speed for the sub-interval up to collision.dtime
+			aspeed_f = *speed_f + accel_f * 0.5f * collision.dtime;
+			*pos_f += aspeed_f * collision.dtime;
 			// Speed at (approximated) collision:
-			*speed_f += accel_f * nearest_dtime;
+			*speed_f += accel_f * collision.dtime;
 			// Limit speed for avoiding hangs
 			*speed_f = truncate(rangelimv(*speed_f, -5000.0f, 5000.0f), 10000.0f);
-			dtime -= nearest_dtime;
+			dtime -= collision.dtime;
 		}
 
 		v3f old_speed_f = *speed_f;
@@ -554,14 +554,14 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				(step_up_mode == StepUpMode::RIGID && speed_f->Y == 0.0f))) {
 			// Special case: Handle stairs
 			nearest_info.is_step_up = true;
-		} else if (nearest_collided == COLLISION_AXIS_X) {
+		} else if (collision.axis == COLLISION_AXIS_X) {
 			if (bounce < -1e-4 && fabsf(speed_f->X) > BS * 3) {
 				speed_f->X *= bounce;
 			} else {
 				speed_f->X = 0;
 				accel_f.X = 0; // avoid colliding in the next iterations
 			}
-		} else if (nearest_collided == COLLISION_AXIS_Y) {
+		} else if (collision.axis == COLLISION_AXIS_Y) {
 			if (bounce < -1e-4 && fabsf(speed_f->Y) > BS * 3) {
 				speed_f->Y *= bounce;
 			} else {
@@ -575,7 +575,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 				speed_f->Y = 0;
 				accel_f.Y = 0; // avoid colliding in the next iterations
 			}
-		} else { /* nearest_collided == COLLISION_AXIS_Z */
+		} else { /* collision.axis == COLLISION_AXIS_Z */
 			if (bounce < -1e-4 && fabsf(speed_f->Z) > BS * 3) {
 				speed_f->Z *= bounce;
 			} else {
@@ -586,7 +586,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 		if (!nearest_info.is_unloaded && !step_up) {
 			CollisionInfo info;
-			info.axis = nearest_collided;
+			info.axis = collision.axis;
 			info.type = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
 			info.node_p = nearest_info.position;
 			info.object = nearest_info.obj;
@@ -642,6 +642,37 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	result.collides = !result.collisions.empty();
 	return result;
+}
+
+Collision find_nearest_collision(std::vector<NearbyCollisionInfo> const &cinfo,
+		aabb3f const &movingbox, v3f aspeed_f, f32 dtime)
+{
+	CollisionAxis nearest_collided = COLLISION_AXIS_NONE;
+	f32 nearest_dtime              = dtime;
+	int nearest_boxindex           = -1;
+
+	// Go through every nodebox, find nearest collision
+	for (u32 boxindex = 0; boxindex < cinfo.size(); boxindex++) {
+		NearbyCollisionInfo const &box_info = cinfo[boxindex];
+		// Ignore if already stepped up this nodebox.
+		if (box_info.is_step_up) {
+			continue;
+		}
+
+		// Find nearest collision of the two boxes (raytracing-like)
+		f32 dtime_tmp          = nearest_dtime;
+		CollisionAxis collided = axisAlignedCollision(
+				box_info.box, movingbox, aspeed_f, &dtime_tmp);
+		if (collided == -1 || dtime_tmp >= nearest_dtime) {
+			continue;
+		}
+
+		nearest_dtime    = dtime_tmp;
+		nearest_collided = collided;
+		nearest_boxindex = boxindex;
+	}
+
+	return Collision{nearest_dtime, nearest_boxindex, nearest_collided};
 }
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -114,9 +114,9 @@ static Collision find_nearest_collision(
 static void move_object_to_collision(KineticObject &collider, f32 &dtime,
 		Collision collision, bool step_up);
 
-static void collide(KineticObject &collider, Collision collision,
+static CollisionMoveResult collide(KineticObject &collider, Collision collision,
 		NearbyCollisionInfo &nearest_info, bool step_up,
-		StepUpMode step_up_mode, CollisionMoveResult &result);
+		StepUpMode step_up_mode);
 
 // Helper function:
 // Checks for collision of a moving aabbox with a static aabbox
@@ -423,7 +423,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	// Assume no collisions when no velocity and no acceleration
 	if (*speed_f == v3f() && accel_f == v3f())
-		return result;
+		return CollisionMoveResult{};
 
 	/*
 		Calculate new velocity
@@ -474,7 +474,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
 		if (!any_position_valid) {
 			*speed_f = v3f(0, 0, 0);
-			return result;
+			return CollisionMoveResult{};
 		}
 	}
 
@@ -537,22 +537,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		KineticObject collider{pos_f, speed_f, &aspeed_f, &accel_f};
 		move_object_to_collision(collider, dtime, collision, step_up);
 
-		v3f old_speed_f = *speed_f;
-
-		collide(collider, collision, nearest_info, step_up, step_up_mode,
-				result);
-
-		if (!nearest_info.is_unloaded && !step_up) {
-			CollisionInfo info;
-			info.axis = collision.axis;
-			info.type = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
-			info.node_p = nearest_info.position;
-			info.object = nearest_info.obj;
-			info.new_pos = *pos_f;
-			info.old_speed = old_speed_f;
-			info.new_speed = *speed_f;
-			result.collisions.push_back(info);
-		}
+		result = collide(
+				collider, collision, nearest_info, step_up, step_up_mode);
 
 		if (dtime < BS * 1e-10f)
 			break;
@@ -668,10 +654,14 @@ void move_object_to_collision(KineticObject &collider, f32 &dtime,
 	}
 }
 
-void collide(KineticObject &collider, Collision collision,
+CollisionMoveResult collide(KineticObject &collider, Collision collision,
 		NearbyCollisionInfo &nearest_info, bool step_up,
-		StepUpMode step_up_mode, CollisionMoveResult &result)
+		StepUpMode step_up_mode)
 {
+	CollisionMoveResult result;
+
+	v3f old_speed_f = *collider.speed;
+
 	// Get bounce multiplier
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
 
@@ -717,8 +707,21 @@ void collide(KineticObject &collider, Collision collision,
 			collider.accel->Z = 0;
 		}
 	}
-}
 
+	if (!nearest_info.is_unloaded && !step_up) {
+		CollisionInfo info;
+		info.axis = collision.axis;
+		info.type = nearest_info.isObject() ? COLLISION_OBJECT : COLLISION_NODE;
+		info.node_p    = nearest_info.position;
+		info.object    = nearest_info.obj;
+		info.new_pos   = *collider.pos;
+		info.old_speed = old_speed_f;
+		info.new_speed = *collider.speed;
+		result.collisions.push_back(info);
+	}
+
+	return result;
+}
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,
 		const aabb3f &box_0, const v3f &pos_f, ActiveObject *self,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -125,9 +125,6 @@ private:
 
 	Collision findNearestCollision(MovingBox const &movingbox);
 
-	bool addCollisionsInMovementRange(
-			KineticObject const &collider, IGameDef *gamedef, Environment *env);
-
 	CollisionMoveResult simulateFor(
 			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
 
@@ -505,7 +502,8 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 	// are not available for collision detection.
 	// This also intentionally occurs in the case of the object being positioned
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-	if (!this->addCollisionsInMovementRange(*collider, gamedef, env)) {
+	core::aabbox3d<s16> const range{collider->getMovementRange(this->remaining_dtime)};
+	if (!add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, this->cinfo)) {
 		collider->velocity = v3f();
 		return CollisionMoveResult{};
 	}
@@ -518,13 +516,6 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 	return this->simulateFor(collider, stepheight, step_up_mode);
 }
 
-
-bool MovementContext::addCollisionsInMovementRange(
-		KineticObject const &collider, IGameDef *gamedef, Environment *env)
-{
-	core::aabbox3d<s16> const range{collider.getMovementRange(this->remaining_dtime)};
-	return add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, this->cinfo);
-}
 
 core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
 {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -717,7 +717,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 				result.touching_ground    = true;
 				result.standing_on_object = nearest_info.isObject();
 			}
-			this->velocity.Y = 0;
+			this->velocity.Y = 0.f;
 			// avoid colliding in the next iterations
 			this->accel.Y = 0;
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -90,6 +90,8 @@ public:
 
 private:
 	Collision findNearestCollision(MovingBox const &movingbox);
+
+	bool shouldStepUp(MovingBox const &movingbox, Collision collision, f32 stepheight);
 };
 
 class KineticObject
@@ -111,11 +113,7 @@ public:
 
 	void stepUpStairs(std::vector<NearbyCollisionInfo> const &cinfo,
 			CollisionMoveResult &result);
-
-	static bool shouldStepUp(MovingBox const &movingbox, f32 dtime, Collision collision,
-		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo);
-
-	};
+};
 
 // Helper functions:
 // Truncate floating point numbers to specified number of decimal places
@@ -553,8 +551,7 @@ CollisionMoveResult MovementContext::simulateFor(
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = this->cinfo[collision.boxindex];
 
-		bool const step_up = collider->shouldStepUp(
-				movingbox, this->remaining_dtime, collision, stepheight, this->cinfo);
+		bool const step_up = this->shouldStepUp(movingbox, collision, stepheight);
 
 		collider->moveToCollision(
 				collision, avg_speed_estimate, this->remaining_dtime, step_up);
@@ -580,8 +577,8 @@ v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
 
-bool KineticObject::shouldStepUp(MovingBox const &movingbox, f32 dtime, Collision collision,
-		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo)
+bool MovementContext::shouldStepUp(
+		MovingBox const &movingbox, Collision collision, f32 stepheight)
 {
 	if (collision.axis != COLLISION_AXIS_Y) {
 		// movingbox except moved to the horizontal position it would be after
@@ -590,17 +587,18 @@ bool KineticObject::shouldStepUp(MovingBox const &movingbox, f32 dtime, Collisio
 		// Look slightly ahead  for checking the height when stepping
 		// to ensure we also check above the node we collided with
 		// otherwise, might allow glitches such as a stack of stairs
-		float extra_dtime = collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
+		float extra_dtime =
+				collision.dtime + 0.1f * fabsf(this->remaining_dtime - collision.dtime);
 		stepbox.MinEdge.X += movingbox.velocity.X * extra_dtime;
 		stepbox.MinEdge.Z += movingbox.velocity.Z * extra_dtime;
 		stepbox.MaxEdge.X += movingbox.velocity.X * extra_dtime;
 		stepbox.MaxEdge.Z += movingbox.velocity.Z * extra_dtime;
 		// Check for stairs.
-		aabb3f const &cbox = cinfo[collision.boxindex].box;
+		aabb3f const &cbox = this->cinfo[collision.boxindex].box;
 		return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
 			   (movingbox.box.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
 			   (!wouldCollideWithCeiling(
-					   cinfo, stepbox, cbox.MaxEdge.Y - movingbox.box.MinEdge.Y, 0.0f));
+					   this->cinfo, stepbox, cbox.MaxEdge.Y - movingbox.box.MinEdge.Y, 0.0f));
 	} else {
 		return false;
 	}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -719,7 +719,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 			}
 			this->velocity.Y = 0.f;
 			// avoid colliding in the next iterations
-			this->accel.Y = 0;
+			this->accel.Y = 0.f;
 		}
 	} else { /* collision.axis == COLLISION_AXIS_Z */
 		if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -77,7 +77,7 @@ struct Collision
 struct MovingBox
 {
 	aabb3f box;
-	v3f avg_speed;
+	v3f velocity;
 };
 
 class KineticObject
@@ -592,10 +592,10 @@ bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
 		// otherwise, might allow glitches such as a stack of stairs
 		float extra_dtime =
 				collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
-		stepbox.MinEdge.X += movingbox.avg_speed.X * extra_dtime;
-		stepbox.MinEdge.Z += movingbox.avg_speed.Z * extra_dtime;
-		stepbox.MaxEdge.X += movingbox.avg_speed.X * extra_dtime;
-		stepbox.MaxEdge.Z += movingbox.avg_speed.Z * extra_dtime;
+		stepbox.MinEdge.X += movingbox.velocity.X * extra_dtime;
+		stepbox.MinEdge.Z += movingbox.velocity.Z * extra_dtime;
+		stepbox.MaxEdge.X += movingbox.velocity.X * extra_dtime;
+		stepbox.MaxEdge.Z += movingbox.velocity.Z * extra_dtime;
 		// Check for stairs.
 		aabb3f const &cbox = cinfo[collision.boxindex].box;
 		return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
@@ -626,7 +626,7 @@ Collision find_nearest_collision(MovingBox const &movingbox,
 		// Find nearest collision of the two boxes (raytracing-like)
 		f32 dtime_tmp          = nearest_dtime;
 		CollisionAxis collided = axisAlignedCollision(
-				box_info.box, movingbox.box, movingbox.avg_speed, &dtime_tmp);
+				box_info.box, movingbox.box, movingbox.velocity, &dtime_tmp);
 		if (collided == -1 || dtime_tmp >= nearest_dtime) {
 			continue;
 		}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -74,6 +74,12 @@ struct Collision
 	CollisionAxis axis{COLLISION_AXIS_NONE};
 };
 
+struct KineticBox
+{
+	aabb3f box;
+	v3f avg_speed;
+};
+
 struct KineticObject
 {
 	v3f *pos;
@@ -119,8 +125,8 @@ static bool locate_cboxes_in_movement_range(KineticObject collider,
 		aabb3f box_0, f32 dtime, IGameDef *gamedef, Environment *env,
 		std::vector<NearbyCollisionInfo> &cinfo);
 
-static bool should_step_up(aabb3f movingbox, v3f avg_speed,
-		f32 dtime, Collision collision, f32 stepheight,
+static bool should_step_up(KineticBox const &movingbox, f32 dtime,
+		Collision collision, f32 stepheight,
 		std::vector<NearbyCollisionInfo> const &cinfo);
 
 static Collision find_nearest_collision(
@@ -505,8 +511,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		// Otherwise, a collision occurred.
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 
-		bool step_up = should_step_up(
-				movingbox, aspeed_f, dtime, collision, stepheight, cinfo);
+		KineticBox bb{movingbox, aspeed_f};
+		bool step_up = should_step_up(bb, dtime, collision, stepheight, cinfo);
 
 		collider.moveToCollision(dtime, collision, step_up);
 
@@ -580,29 +586,28 @@ bool locate_cboxes_in_movement_range(KineticObject collider, aabb3f box_0,
 	return add_area_node_boxes(min, max, gamedef, env, cinfo);
 }
 
-bool should_step_up(aabb3f movingbox, v3f avg_speed, f32 dtime,
-		Collision collision, f32 stepheight,
-		std::vector<NearbyCollisionInfo> const &cinfo)
+bool should_step_up(KineticBox const &movingbox, f32 dtime, Collision collision,
+		f32 stepheight, std::vector<NearbyCollisionInfo> const &cinfo)
 {
 	if (collision.axis != COLLISION_AXIS_Y) {
 		// movingbox except moved to the horizontal position it would be after
 		// step up
-		aabb3f stepbox = movingbox;
+		aabb3f stepbox = movingbox.box;
 		// Look slightly ahead  for checking the height when stepping
 		// to ensure we also check above the node we collided with
 		// otherwise, might allow glitches such as a stack of stairs
 		float extra_dtime =
 				collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
-		stepbox.MinEdge.X += avg_speed.X * extra_dtime;
-		stepbox.MinEdge.Z += avg_speed.Z * extra_dtime;
-		stepbox.MaxEdge.X += avg_speed.X * extra_dtime;
-		stepbox.MaxEdge.Z += avg_speed.Z * extra_dtime;
+		stepbox.MinEdge.X += movingbox.avg_speed.X * extra_dtime;
+		stepbox.MinEdge.Z += movingbox.avg_speed.Z * extra_dtime;
+		stepbox.MaxEdge.X += movingbox.avg_speed.X * extra_dtime;
+		stepbox.MaxEdge.Z += movingbox.avg_speed.Z * extra_dtime;
 		// Check for stairs.
-		const aabb3f &cbox = cinfo[collision.boxindex].box;
-		return (movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&
-			   (movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
+		aabb3f const &cbox = cinfo[collision.boxindex].box;
+		return (movingbox.box.MinEdge.Y < cbox.MaxEdge.Y) &&
+			   (movingbox.box.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
 			   (!wouldCollideWithCeiling(cinfo, stepbox,
-					   cbox.MaxEdge.Y - movingbox.MinEdge.Y,
+					   cbox.MaxEdge.Y - movingbox.box.MinEdge.Y,
 					   g_mystery_constant));
 	} else {
 		return false;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -110,6 +110,8 @@ struct KineticObject
 	void collideZ(f32 bounce);
 
 	bool collideY(f32 bounce);
+
+	void jerkUpwards(float dy);
 };
 
 class MovementContext
@@ -803,7 +805,7 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 		if (cbox.MaxEdge.X > box.MinEdge.X && cbox.MinEdge.X < box.MaxEdge.X &&
 				cbox.MaxEdge.Z > box.MinEdge.Z && cbox.MinEdge.Z < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
-				collider->pos.Y += cbox.MaxEdge.Y - box.MinEdge.Y;
+				collider->jerkUpwards(cbox.MaxEdge.Y - box.MinEdge.Y);
 				box = collider->getAbsCollisionbox();
 			}
 			if (std::fabs(cbox.MaxEdge.Y - box.MinEdge.Y) < 0.05f) {
@@ -815,6 +817,11 @@ void MovementContext::stepUpStairs(KineticObject *collider, CollisionMoveResult 
 			}
 		}
 	}
+}
+
+void KineticObject::jerkUpwards(f32 dy)
+{
+	this->pos.Y += dy;
 }
 
 bool collision_check_intersection(Environment *env, IGameDef *gamedef,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -92,6 +92,8 @@ struct KineticObject
 		return translate(this->collisionbox, this->pos);
 	}
 
+	core::aabbox3d<s16> getMovementRange(f32 dtime) const;
+
 	v3f getProjectedAvgSpeed(f32 dtime) const;
 
 	void moveUnobstructed(f32 dtime);
@@ -107,21 +109,14 @@ struct KineticObject
 class MovementContext
 {
 public:
+	CollisionMoveResult collideMove(Environment *env, IGameDef *gamedef, f32 stepheight,
+			f32 dtime, KineticObject *collider, ActiveObject *self, bool collide_with_objects,
+			StepUpMode step_up_mode);
+
+private:
 	std::vector<NearbyCollisionInfo> cinfo;
 	f32 remaining_dtime;
 
-	void clear()
-	{
-		this->cinfo.clear();
-	}
-
-	bool addCollisionsInMovementRange(
-			KineticObject const &collider, IGameDef *gamedef, Environment *env);
-
-	CollisionMoveResult simulateFor(
-			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
-
-private:
 	struct MovingBox
 	{
 		aabb3f box;
@@ -129,6 +124,12 @@ private:
 	};
 
 	Collision findNearestCollision(MovingBox const &movingbox);
+
+	bool addCollisionsInMovementRange(
+			KineticObject const &collider, IGameDef *gamedef, Environment *env);
+
+	CollisionMoveResult simulateFor(
+			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
 
 	bool shouldStepUp(MovingBox const &movingbox, Collision collision, f32 stepheight);
 
@@ -481,29 +482,11 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// Collect node boxes in movement range
 
 	// cached allocation
-	thread_local std::vector<NearbyCollisionInfo> cinfo;
-	cinfo.clear();
+	thread_local MovementContext ctx;
 
 	KineticObject collider{box_0, *pos_f, *speed_f, accel_f};
-
-	// Do not move if world has not loaded yet, since custom node boxes
-	// are not available for collision detection.
-	// This also intentionally occurs in the case of the object being positioned
-	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-
-	thread_local MovementContext ctx{cinfo, dtime};
-
-	if (!ctx.addCollisionsInMovementRange(collider, gamedef, env)) {
-		*speed_f = v3f();
-		return CollisionMoveResult{};
-	}
-
-	// Collect object boxes in movement range
-	if (collide_with_objects) {
-		add_object_boxes(env, box_0, dtime, *pos_f, collider.getProjectedAvgSpeed(dtime), self, cinfo);
-	}
-
-	CollisionMoveResult result = ctx.simulateFor(&collider, stepheight, step_up_mode);
+	CollisionMoveResult result{ctx.collideMove(env, gamedef, stepheight, dtime, &collider,
+			self, collide_with_objects, step_up_mode)};
 
 	*pos_f = collider.pos;
 	*speed_f = collider.velocity;
@@ -511,21 +494,51 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	return result;
 }
 
+CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gamedef,
+		f32 stepheight, f32 dtime, KineticObject *collider, ActiveObject *self,
+		bool collide_with_objects, StepUpMode step_up_mode)
+{
+	this->cinfo.clear();
+	this->remaining_dtime = dtime;
+
+	// Do not move if world has not loaded yet, since custom node boxes
+	// are not available for collision detection.
+	// This also intentionally occurs in the case of the object being positioned
+	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
+	if (!this->addCollisionsInMovementRange(*collider, gamedef, env)) {
+		collider->velocity = v3f();
+		return CollisionMoveResult{};
+	}
+
+	// Collect object boxes in movement range
+	if (collide_with_objects) {
+		add_object_boxes(env, collider->collisionbox, this->remaining_dtime, collider->pos, collider->getProjectedAvgSpeed(this->remaining_dtime), self, this->cinfo);
+	}
+
+	return this->simulateFor(collider, stepheight, step_up_mode);
+}
+
+
 bool MovementContext::addCollisionsInMovementRange(
 		KineticObject const &collider, IGameDef *gamedef, Environment *env)
 {
-	// Movement if no collisions
-	v3f newpos_f = collider.pos + collider.velocity * this->remaining_dtime;
-	v3f minpos_f(MYMIN(collider.pos.X, newpos_f.X),
-			MYMIN(collider.pos.Y, newpos_f.Y) +
-					0.01f * BS, // bias rounding, player often at +/-n.5
-			MYMIN(collider.pos.Z, newpos_f.Z));
-	v3f maxpos_f(MYMAX(collider.pos.X, newpos_f.X), MYMAX(collider.pos.Y, newpos_f.Y),
-			MYMAX(collider.pos.Z, newpos_f.Z));
-	v3s16 min = floatToInt(minpos_f + collider.collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
-	v3s16 max = floatToInt(maxpos_f + collider.collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
+	core::aabbox3d<s16> const range{collider.getMovementRange(this->remaining_dtime)};
+	return add_area_node_boxes(range.MinEdge, range.MaxEdge, gamedef, env, this->cinfo);
+}
 
-	return add_area_node_boxes(min, max, gamedef, env, this->cinfo);
+core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
+{
+	// Movement if no collisions
+	v3f newpos_f = this->pos + this->velocity * dtime;
+	v3f minpos_f(MYMIN(this->pos.X, newpos_f.X),
+			MYMIN(this->pos.Y, newpos_f.Y) +
+					0.01f * BS, // bias rounding, player often at +/-n.5
+			MYMIN(this->pos.Z, newpos_f.Z));
+	v3f maxpos_f(MYMAX(this->pos.X, newpos_f.X), MYMAX(this->pos.Y, newpos_f.Y),
+			MYMAX(this->pos.Z, newpos_f.Z));
+	v3s16 min = floatToInt(minpos_f + this->collisionbox.MinEdge, BS) - v3s16(1, 1, 1);
+	v3s16 max = floatToInt(maxpos_f + this->collisionbox.MaxEdge, BS) + v3s16(1, 1, 1);
+	return core::aabbox3d<s16>{min, max};
 }
 
 CollisionMoveResult MovementContext::simulateFor(

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -130,7 +130,7 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 }
 }
 
-static bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime,
+static bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
 		IGameDef *gamedef, Environment *env, std::vector<NearbyCollisionInfo> &cinfo);
 
 static bool should_step_up(MovingBox const &movingbox, f32 dtime, Collision collision,
@@ -471,7 +471,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	// are not available for collision detection.
 	// This also intentionally occurs in the case of the object being positioned
 	// solely on loaded CONTENT_IGNORE nodes, no matter where they come from.
-	if (!locate_cboxes_in_movement_range(
+	if (!add_collisions_in_movement_range(
 				collider, dtime, gamedef, env, cinfo)) {
 		*speed_f = v3f(0.f, 0.f, 0.f);
 		return CollisionMoveResult{};
@@ -491,8 +491,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 	return result;
 }
 
-bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime, IGameDef *gamedef,
-		Environment *env, std::vector<NearbyCollisionInfo> &cinfo)
+bool add_collisions_in_movement_range(KineticObject const &collider, f32 dtime,
+		IGameDef *gamedef, Environment *env, std::vector<NearbyCollisionInfo> &cinfo)
 {
 	// Movement if no collisions
 	v3f newpos_f = collider.pos + collider.velocity * dtime;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -122,6 +122,7 @@ public:
 private:
 	std::vector<NearbyCollisionInfo> cinfo;
 	f32 remaining_dtime;
+	StepUpMode step_up_mode;
 
 	struct MovingBox
 	{
@@ -129,15 +130,12 @@ private:
 		v3f velocity;
 	};
 
-	Collision findNearestCollision(const MovingBox &movingbox);
-
-	CollisionMoveResult simulateFor(
-			KineticObject *collider, f32 stepheight, StepUpMode step_up_mode);
+	CollisionMoveResult simulateFor(KineticObject *collider, f32 stepheight);
 
 	bool shouldStepUp(const MovingBox &movingbox, Collision collision, f32 stepheight);
 
 	CollisionMoveResult collideWith(KineticObject *collider, CollisionAxis axis,
-			NearbyCollisionInfo &nearest_info, bool step_up, StepUpMode step_up_mode);
+			NearbyCollisionInfo &nearest_info, bool step_up);
 
 	void stepUpStairs(KineticObject *collider, CollisionMoveResult &result);
 };
@@ -504,6 +502,7 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 {
 	this->cinfo.clear();
 	this->remaining_dtime = dtime;
+	this->step_up_mode = step_up_mode;
 
 	// Collect node boxes in movement range
 
@@ -523,7 +522,7 @@ CollisionMoveResult MovementContext::collideMove(Environment *env, IGameDef *gam
 				collider->getProjectedAvgSpeed(this->remaining_dtime), self, this->cinfo);
 	}
 
-	return this->simulateFor(collider, stepheight, step_up_mode);
+	return this->simulateFor(collider, stepheight);
 }
 
 
@@ -542,8 +541,7 @@ core::aabbox3d<s16> KineticObject::getMovementRange(f32 dtime) const
 	return core::aabbox3d<s16>{min, max};
 }
 
-CollisionMoveResult MovementContext::simulateFor(
-		KineticObject *collider, f32 stepheight, StepUpMode step_up_mode)
+CollisionMoveResult MovementContext::simulateFor(KineticObject *collider, f32 stepheight)
 {
 	CollisionMoveResult result;
 
@@ -576,8 +574,7 @@ CollisionMoveResult MovementContext::simulateFor(
 				collision, avg_speed_estimate, this->remaining_dtime, step_up);
 		this->remaining_dtime -= collision.dtime;
 
-		result = this->collideWith(
-				collider, collision.axis, nearest_info, step_up, step_up_mode);
+		result = this->collideWith(collider, collision.axis, nearest_info, step_up);
 
 		if (this->remaining_dtime < BS * 1e-10f) {
 			break;
@@ -702,7 +699,7 @@ void KineticObject::moveToCollision(
 }
 
 CollisionMoveResult MovementContext::collideWith(KineticObject *collider, CollisionAxis axis,
-		NearbyCollisionInfo &nearest_info, bool step_up, StepUpMode step_up_mode)
+		NearbyCollisionInfo &nearest_info, bool step_up)
 {
 	CollisionMoveResult result;
 
@@ -712,9 +709,9 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
 
 	// Set the speed component that caused the collision to zero
-	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
-			(step_up_mode == StepUpMode::FLOATY && collider->velocity.Y <= 0.0f) ||
-			(step_up_mode == StepUpMode::RIGID && collider->velocity.Y == 0.0f))) {
+	if (step_up && (this->step_up_mode == StepUpMode::LEGACY ||
+			(this->step_up_mode == StepUpMode::FLOATY && collider->velocity.Y <= 0.0f) ||
+			(this->step_up_mode == StepUpMode::RIGID && collider->velocity.Y == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (axis == COLLISION_AXIS_X) {

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -33,6 +33,8 @@ bool g_collision_problems_encountered = false;
 
 namespace {
 
+f32 constexpr g_mystery_constant{0.0f};
+
 struct NearbyCollisionInfo {
 	// node
 	NearbyCollisionInfo(bool is_ul, int bouncy, v3s16 pos, const aabb3f &box) :
@@ -106,6 +108,10 @@ inline v3f rangelimv(const v3f vec, const f32 low, const f32 high)
 	);
 }
 }
+
+static bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed,
+		f32 dtime, Collision collision, f32 stepheight,
+		std::vector<NearbyCollisionInfo> const &cinfo);
 
 static Collision find_nearest_collision(
 		std::vector<NearbyCollisionInfo> const &cinfo,
@@ -483,8 +489,6 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		add_object_boxes(env, box_0, dtime, *pos_f, aspeed_f, self, cinfo);
 	}
 
-	// Collision detection
-	f32 d = 0.0f;
 	for (int loopcount = 0;; loopcount++) {
 		if (loopcount >= 100) {
 			warningstream << "collisionMoveSimple: Loop count exceeded, aborting to avoid infinite loop" << std::endl;
@@ -514,25 +518,8 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 		NearbyCollisionInfo &nearest_info = cinfo[collision.boxindex];
 		const aabb3f& cbox = nearest_info.box;
 
-		//movingbox except moved to the horizontal position it would be after step up
-		bool step_up = false;
-		if (collision.axis != COLLISION_AXIS_Y) {
-			aabb3f stepbox = movingbox;
-			// Look slightly ahead  for checking the height when stepping
-			// to ensure we also check above the node we collided with
-			// otherwise, might allow glitches such as a stack of stairs
-			float extra_dtime = collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
-			stepbox.MinEdge.X += aspeed_f.X * extra_dtime;
-			stepbox.MinEdge.Z += aspeed_f.Z * extra_dtime;
-			stepbox.MaxEdge.X += aspeed_f.X * extra_dtime;
-			stepbox.MaxEdge.Z += aspeed_f.Z * extra_dtime;
-			// Check for stairs.
-			step_up = (movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&
-				(movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
-				(!wouldCollideWithCeiling(cinfo, stepbox,
-						cbox.MaxEdge.Y - movingbox.MinEdge.Y,
-						d));
-		}
+		bool step_up = should_step_up(
+				movingbox, cbox, aspeed_f, dtime, collision, stepheight, cinfo);
 
 		KineticObject collider{pos_f, speed_f, &aspeed_f, &accel_f};
 		move_object_to_collision(collider, dtime, collision, step_up);
@@ -566,9 +553,9 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			X-Z-area.
 		*/
 
-		if (cbox.MaxEdge.X - d > box.MinEdge.X && cbox.MinEdge.X + d < box.MaxEdge.X &&
-				cbox.MaxEdge.Z - d > box.MinEdge.Z &&
-				cbox.MinEdge.Z + d < box.MaxEdge.Z) {
+		if (cbox.MaxEdge.X - g_mystery_constant > box.MinEdge.X && cbox.MinEdge.X + g_mystery_constant < box.MaxEdge.X &&
+				cbox.MaxEdge.Z - g_mystery_constant > box.MinEdge.Z &&
+				cbox.MinEdge.Z + g_mystery_constant < box.MaxEdge.Z) {
 			if (box_info.is_step_up) {
 				pos_f->Y += cbox.MaxEdge.Y - box.MinEdge.Y;
 				box = box_0;
@@ -586,6 +573,34 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 
 	result.collides = !result.collisions.empty();
 	return result;
+}
+
+bool should_step_up(aabb3f movingbox, aabb3f cbox, v3f avg_speed, f32 dtime,
+		Collision collision, f32 stepheight,
+		std::vector<NearbyCollisionInfo> const &cinfo)
+{
+	if (collision.axis != COLLISION_AXIS_Y) {
+		// movingbox except moved to the horizontal position it would be after
+		// step up
+		aabb3f stepbox = movingbox;
+		// Look slightly ahead  for checking the height when stepping
+		// to ensure we also check above the node we collided with
+		// otherwise, might allow glitches such as a stack of stairs
+		float extra_dtime =
+				collision.dtime + 0.1f * fabsf(dtime - collision.dtime);
+		stepbox.MinEdge.X += avg_speed.X * extra_dtime;
+		stepbox.MinEdge.Z += avg_speed.Z * extra_dtime;
+		stepbox.MaxEdge.X += avg_speed.X * extra_dtime;
+		stepbox.MaxEdge.Z += avg_speed.Z * extra_dtime;
+		// Check for stairs.
+		return (movingbox.MinEdge.Y < cbox.MaxEdge.Y) &&
+			   (movingbox.MinEdge.Y + stepheight > cbox.MaxEdge.Y) &&
+			   (!wouldCollideWithCeiling(cinfo, stepbox,
+					   cbox.MaxEdge.Y - movingbox.MinEdge.Y,
+					   g_mystery_constant));
+	} else {
+		return false;
+	}
 }
 
 Collision find_nearest_collision(std::vector<NearbyCollisionInfo> const &cinfo,

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -85,7 +85,7 @@ class KineticObject
 public:
 	aabb3f collisionbox;
 	v3f pos;
-	v3f speed;
+	v3f velocity;
 	v3f accel;
 
 	CollisionMoveResult simulateFor(f32 dtime,
@@ -492,7 +492,7 @@ CollisionMoveResult collisionMoveSimple(Environment *env, IGameDef *gamedef,
 			collider.simulateFor(dtime, cinfo, stepheight, step_up_mode);
 
 	*pos_f = collider.pos;
-	*speed_f = collider.speed;
+	*speed_f = collider.velocity;
 
 	return result;
 }
@@ -502,7 +502,7 @@ bool locate_cboxes_in_movement_range(KineticObject &collider, f32 dtime,
 		std::vector<NearbyCollisionInfo> &cinfo)
 {
 	// Movement if no collisions
-	v3f newpos_f = collider.pos + collider.speed * dtime;
+	v3f newpos_f = collider.pos + collider.velocity * dtime;
 	v3f minpos_f(MYMIN(collider.pos.X, newpos_f.X),
 			MYMIN(collider.pos.Y, newpos_f.Y) +
 					0.01f * BS, // bias rounding, player often at +/-n.5
@@ -546,10 +546,10 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 			// No collision with any collision box.
 			this->pos += avg_speed_estimate * dtime;
 			// Final speed:
-			this->speed += this->accel * dtime;
+			this->velocity += this->accel * dtime;
 			// Limit speed for avoiding hangs
-			this->speed = truncate(
-					rangelimv(this->speed, -5000.0f, 5000.0f), 10000.0f);
+			this->velocity = truncate(
+					rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
 			break;
 		}
 
@@ -579,7 +579,7 @@ CollisionMoveResult KineticObject::simulateFor(f32 dtime,
 
 v3f KineticObject::getProjectedAvgSpeed(f32 dtime) const
 {
-	v3f const avg = this->speed + this->accel * 0.5f * dtime;
+	v3f const avg = this->velocity + this->accel * 0.5f * dtime;
 	// Limit speed for avoiding hangs
 	return truncate(rangelimv(avg, -5000.0f, 5000.0f), 10000.0f);
 }
@@ -667,13 +667,13 @@ void KineticObject::moveToCollision(
 		// updated average speed for the sub-interval up to
 		// collision.dtime
 		v3f const subinterval_avg_speed =
-				this->speed + this->accel * 0.5f * collision.dtime;
+				this->velocity + this->accel * 0.5f * collision.dtime;
 		this->pos += subinterval_avg_speed * collision.dtime;
 		// Speed at (approximated) collision:
-		this->speed += this->accel * collision.dtime;
+		this->velocity += this->accel * collision.dtime;
 		// Limit speed for avoiding hangs
-		this->speed =
-				truncate(rangelimv(this->speed, -5000.0f, 5000.0f), 10000.0f);
+		this->velocity =
+				truncate(rangelimv(this->velocity, -5000.0f, 5000.0f), 10000.0f);
 	}
 }
 
@@ -683,7 +683,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 {
 	CollisionMoveResult result;
 
-	v3f old_speed_f = this->speed;
+	v3f old_speed_f = this->velocity;
 
 	// Get bounce multiplier
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
@@ -691,24 +691,24 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 	// Set the speed component that caused the collision to zero
 	if (step_up && (step_up_mode == StepUpMode::LEGACY ||
 						   (step_up_mode == StepUpMode::FLOATY &&
-								   this->speed.Y <= 0.0f) ||
+								   this->velocity.Y <= 0.0f) ||
 						   (step_up_mode == StepUpMode::RIGID &&
-								   this->speed.Y == 0.0f))) {
+								   this->velocity.Y == 0.0f))) {
 		// Special case: Handle stairs
 		nearest_info.is_step_up = true;
 	} else if (collision.axis == COLLISION_AXIS_X) {
-		if (bounce < -1e-4 && fabsf(this->speed.X) > BS * 3) {
-			this->speed.X *= bounce;
+		if (bounce < -1e-4 && fabsf(this->velocity.X) > BS * 3) {
+			this->velocity.X *= bounce;
 		} else {
-			this->speed.X = 0;
+			this->velocity.X = 0;
 			// avoid colliding in the next iterations
 			this->accel.X = 0;
 		}
 	} else if (collision.axis == COLLISION_AXIS_Y) {
-		if (bounce < -1e-4 && fabsf(this->speed.Y) > BS * 3) {
-			this->speed.Y *= bounce;
+		if (bounce < -1e-4 && fabsf(this->velocity.Y) > BS * 3) {
+			this->velocity.Y *= bounce;
 		} else {
-			if (this->speed.Y < 0.0f) {
+			if (this->velocity.Y < 0.0f) {
 				// FIXME: This code is necessary until
 				// `axisAlignedCollision` takes acceleration
 				// into consideration for the time calculation.
@@ -717,15 +717,15 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 				result.touching_ground    = true;
 				result.standing_on_object = nearest_info.isObject();
 			}
-			this->speed.Y = 0;
+			this->velocity.Y = 0;
 			// avoid colliding in the next iterations
 			this->accel.Y = 0;
 		}
 	} else { /* collision.axis == COLLISION_AXIS_Z */
-		if (bounce < -1e-4 && fabsf(this->speed.Z) > BS * 3) {
-			this->speed.Z *= bounce;
+		if (bounce < -1e-4 && fabsf(this->velocity.Z) > BS * 3) {
+			this->velocity.Z *= bounce;
 		} else {
-			this->speed.Z = 0;
+			this->velocity.Z = 0;
 			// avoid colliding in the next iterations
 			this->accel.Z = 0;
 		}
@@ -739,7 +739,7 @@ CollisionMoveResult KineticObject::collideWith(Collision collision,
 		info.object    = nearest_info.obj;
 		info.new_pos   = this->pos;
 		info.old_speed = old_speed_f;
-		info.new_speed = this->speed;
+		info.new_speed = this->velocity;
 		result.collisions.push_back(info);
 	}
 

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -748,7 +748,7 @@ CollisionMoveResult MovementContext::collideWith(KineticObject *collider, Collis
 	// Get bounce multiplier
 	float bounce = -(float) nearest_info.bouncy / 100.0f;
 
-	const f32 y_velocity{collider->getVelocity().Y};
+	const f32 y_velocity = collider->getVelocity().Y;
 	// Set the speed component that caused the collision to zero
 	if (step_up && (this->step_up_mode == StepUpMode::LEGACY ||
 			(this->step_up_mode == StepUpMode::FLOATY && y_velocity <= 0.0f) ||
@@ -810,7 +810,7 @@ void KineticObject::collideZ(f32 bounce)
 
 bool KineticObject::collideY(f32 bounce)
 {
-	bool result{false};
+	bool result = false;
 	if (bounce < -1e-4 && fabsf(this->velocity.Y) > BS * 3) {
 		this->velocity.Y *= bounce;
 	} else {


### PR DESCRIPTION
When I heard how much trouble the `collisionMoveSimple` function routinely causes, I saw an opportunity to practice my refactoring skills. I don't contribute to this project a lot, but I spent a lot of time playing Luanti in my childhood and I want to give back to the community.

The primary focus of this particular refactor is to restructure `collisionMoveSimple` to identify meaningful subroutines and reduce the cognitive burden for contributors who want to understand how the collision-based movement system works.

I have tried to make the new structure relatively clear. I left the algorithm intact; the goal here was only to improve structure, not to modify the logic, which many people have already worked on and refined. I doubt the unit tests are thorough enough to catch every mistake that could have been made, but they do pass.

I changed one warning message to print the name of the new routine the warning check was moved to. That could possibly be considered a behavior change and not a refactor; please let me know if it should be handled differently.

There is room for more work, here. The `KineticObject` class this PR introduces could logically be a superclass of the various active object classes, for example. The `KineticObject` interface is much easier to leverage for unit tests than `collisionMoveSimple`. I want to simplify the `collisionMoveSimple` interface, but I did not do so in this PR, because that interface is relatively stable. To keep this PR focused, I don't want to touch the unit tests or update `collisionMoveSimple` callsites.

## To do
Work in Progress

[x] Test in-game movement

## How to test

Ensure the unit tests pass and verify in-game that movement still feels like it did before.
