### PR TITLE
[WIP] Remember previously entered login info for servers with system keychains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ lib/irrlichtmt
 
 # Generated mod storage database
 client/mod_storage.sqlite
+
+# Client keyring
+client/keyring.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib/keychain"]
+	path = lib/keychain
+	url = https://github.com/hrantzsch/keychain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,8 @@ endif()
 
 add_subdirectory(lib/tiniergltf)
 
+add_subdirectory(lib/keychain)
+
 # Subdirectories
 # Be sure to add all relevant definitions above this
 add_subdirectory(src)

--- a/builtin/mainmenu/dlg_register.lua
+++ b/builtin/mainmenu/dlg_register.lua
@@ -82,6 +82,7 @@ local function register_buttonhandler(this, fields)
 		core.settings:set("name", fields.name)
 		core.settings:set("address",     gamedata.address)
 		core.settings:set("remote_port", gamedata.port)
+		keyringmgr.set_login(gamedata.address, gamedata.port, fields.name, fields.password)
 
 		core.start()
 	end

--- a/builtin/mainmenu/init.lua
+++ b/builtin/mainmenu/init.lua
@@ -23,6 +23,7 @@ dofile(basepath .. "fstk" .. DIR_DELIM .. "ui.lua")
 dofile(menupath .. DIR_DELIM .. "async_event.lua")
 dofile(menupath .. DIR_DELIM .. "common.lua")
 dofile(menupath .. DIR_DELIM .. "serverlistmgr.lua")
+dofile(menupath .. DIR_DELIM .. "keyringmgr.lua")
 dofile(menupath .. DIR_DELIM .. "game_theme.lua")
 dofile(menupath .. DIR_DELIM .. "content" .. DIR_DELIM .. "init.lua")
 

--- a/builtin/mainmenu/keyringmgr.lua
+++ b/builtin/mainmenu/keyringmgr.lua
@@ -1,0 +1,169 @@
+keyringmgr = {
+    keyring = nil
+}
+
+local function get_keyring_path()
+    return core.get_user_path() .. DIR_DELIM .. "client" .. DIR_DELIM .. core.settings:get("keyring_file")
+end
+
+local function save_keyring(keyring)
+    core.safe_file_write(get_keyring_path(), core.write_json(keyring))
+end
+
+local function read_keyring()
+    local path = get_keyring_path()
+
+    local file = io.open(path, "r")
+    if file then
+        local json = file:read("*all")
+        file:close()
+        return core.parse_json(json)
+    end
+end
+
+local function is_for_server(keys, address, port)
+    return keys.address == address and keys.port == port
+end
+
+local function delete_keys(keyring, address, port)
+    for i = 1, #keyring do
+        local keys = keyring[i]
+
+        if is_for_server(keys, address, port) then
+            table.remove(keyring, i)
+            return
+        end
+    end
+end
+
+local function get_keys(keyring, address, port)
+    for i = 1, #keyring do
+        local keys = keyring[i]
+
+        if is_for_server(keys, address, port) then
+            return keys
+        end
+    end
+    -- If we don't find any existing keys, we make a blank set for the server
+    local keys = {
+        address = address,
+        port = port,
+        logins = {},
+        last_login = false
+    }
+    table.insert(keyring, 1, keys)
+    save_keyring(keyring)
+    return keys
+end
+
+local function rewrite_keys(keyring, address, port, new_keys)
+    delete_keys(keyring, address, port)
+    table.insert(keyring, 1, new_keys)
+    save_keyring(keyring)
+end
+
+function keyringmgr.get_keyring()
+    if keyringmgr.keyring then
+        return keyringmgr.keyring
+    end
+
+    keyringmgr.keyring = {}
+
+    -- Add keyring, removing duplicates
+    local seen = {}
+    for _, keys in ipairs(read_keyring() or {}) do
+        local key = ("%s:%d"):format(keys.address:lower(), keys.port)
+        if not seen[key] then
+            seen[key] = true
+            keyringmgr.keyring[#keyringmgr.keyring + 1] = keys
+        end
+    end
+
+    return keyringmgr.keyring
+end
+
+function keyringmgr.set_last_login(address, port, playername)
+    local keyring = keyringmgr.get_keyring()
+    local new_keys = get_keys(keyring, address, port)
+    new_keys.last_login = playername
+
+    rewrite_keys(keyring, address, port, new_keys)
+end
+
+function keyringmgr.set_login(address, port, playername, password)
+    -- If the user doesn't want to remember logins, we completely skip the process
+    if not core.settings:get_bool("remember_login") then
+        return
+    end
+    assert(type(port) == "number")
+
+    local keyring = keyringmgr.get_keyring()
+    local new_keys = get_keys(keyring, address, port);
+
+    -- Check for existing entires for playername
+    for _, login in ipairs(new_keys.logins or {}) do
+        if login.playername and login.playername == playername then
+            login.password = password
+            break
+        end
+    end
+
+    -- If not, we add a new key
+    if not new_keys.logins then
+        new_keys.logins = {}
+    end
+    table.insert(new_keys.logins, 1, {
+        playername = playername,
+        password = password
+    })
+
+    keyringmgr.set_last_login(address, port, playername)
+
+    rewrite_keys(keyring, address, port, new_keys)
+end
+
+function keyringmgr.get_login(address, port, playername)
+    assert(type(port) == "number")
+
+    local keyring = keyringmgr.get_keyring()
+    local new_keys = get_keys(keyring, address, port);
+
+    -- Check for existing entires for playername
+    for _, login in ipairs(new_keys.logins) do
+        if login.playername and login.playername == playername then
+            return login
+        end
+    end
+    error("No login found on " .. address .. ":" .. port .. " for player " .. playername)
+end
+
+function keyringmgr.remove_login(address, port, playername)
+    assert(type(port) == "number")
+
+    local keyring = keyringmgr.get_keyring()
+    local new_keys = get_keys(keyring, address, port);
+    for i = 1, #new_keys.logins do
+        local login = new_keys.logins[i]
+
+        if (login.playername == playername) then
+            table.remove(new_keys.logins, i)
+            break
+        end
+    end
+
+    rewrite_keys(keyring, address, port, new_keys)
+end
+
+function keyringmgr.delete_keys(address, port)
+    local keyring = keyringmgr.get_keyring()
+    delete_keys(keyring, address, port)
+    save_keyring(keyring)
+end
+
+function keyringmgr.get_last_login(address, port)
+    local playername = get_keys(keyringmgr.get_keyring(), address, port).last_login
+    if playername then
+        return keyringmgr.get_login(address, port, playername)
+    end
+    return false
+end

--- a/builtin/mainmenu/keyringmgr.lua
+++ b/builtin/mainmenu/keyringmgr.lua
@@ -21,149 +21,27 @@ local function read_keyring()
     end
 end
 
-local function is_for_server(keys, address, port)
-    return keys.address == address and keys.port == port
-end
-
-local function delete_keys(keyring, address, port)
-    for i = 1, #keyring do
-        local keys = keyring[i]
-
-        if is_for_server(keys, address, port) then
-            table.remove(keyring, i)
-            return
-        end
-    end
-end
-
-local function get_keys(keyring, address, port)
-    for i = 1, #keyring do
-        local keys = keyring[i]
-
-        if is_for_server(keys, address, port) then
-            return keys
-        end
-    end
-    -- If we don't find any existing keys, we make a blank set for the server
-    local keys = {
-        address = address,
-        port = port,
-        logins = {},
-        last_login = false
-    }
-    table.insert(keyring, 1, keys)
-    save_keyring(keyring)
-    return keys
-end
-
-local function rewrite_keys(keyring, address, port, new_keys)
-    delete_keys(keyring, address, port)
-    table.insert(keyring, 1, new_keys)
-    save_keyring(keyring)
-end
-
-function keyringmgr.get_keyring()
-    if keyringmgr.keyring then
-        return keyringmgr.keyring
-    end
-
-    keyringmgr.keyring = {}
-
-    -- Add keyring, removing duplicates
-    local seen = {}
-    for _, keys in ipairs(read_keyring() or {}) do
-        local key = ("%s:%d"):format(keys.address:lower(), keys.port)
-        if not seen[key] then
-            seen[key] = true
-            keyringmgr.keyring[#keyringmgr.keyring + 1] = keys
-        end
-    end
-
-    return keyringmgr.keyring
-end
-
-function keyringmgr.set_last_login(address, port, playername)
-    local keyring = keyringmgr.get_keyring()
-    local new_keys = get_keys(keyring, address, port)
-    new_keys.last_login = playername
-
-    rewrite_keys(keyring, address, port, new_keys)
-end
-
 function keyringmgr.set_login(address, port, playername, password)
-    -- If the user doesn't want to remember logins, we completely skip the process
-    if not core.settings:get_bool("remember_login") then
-        return
-    end
-    assert(type(port) == "number")
-
-    local keyring = keyringmgr.get_keyring()
-    local new_keys = get_keys(keyring, address, port);
-
-    -- Check for existing entires for playername
-    for _, login in ipairs(new_keys.logins or {}) do
-        if login.playername and login.playername == playername then
-            login.password = password
-            break
-        end
-    end
-
-    -- If not, we add a new key
-    if not new_keys.logins then
-        new_keys.logins = {}
-    end
-    table.insert(new_keys.logins, 1, {
-        playername = playername,
-        password = password
-    })
-
-    keyringmgr.set_last_login(address, port, playername)
-
-    rewrite_keys(keyring, address, port, new_keys)
-end
-
-function keyringmgr.get_login(address, port, playername)
-    assert(type(port) == "number")
-
-    local keyring = keyringmgr.get_keyring()
-    local new_keys = get_keys(keyring, address, port);
-
-    -- Check for existing entires for playername
-    for _, login in ipairs(new_keys.logins) do
-        if login.playername and login.playername == playername then
-            return login
-        end
-    end
-    error("No login found on " .. address .. ":" .. port .. " for player " .. playername)
-end
-
-function keyringmgr.remove_login(address, port, playername)
-    assert(type(port) == "number")
-
-    local keyring = keyringmgr.get_keyring()
-    local new_keys = get_keys(keyring, address, port);
-    for i = 1, #new_keys.logins do
-        local login = new_keys.logins[i]
-
-        if (login.playername == playername) then
-            table.remove(new_keys.logins, i)
-            break
-        end
-    end
-
-    rewrite_keys(keyring, address, port, new_keys)
-end
-
-function keyringmgr.delete_keys(address, port)
-    local keyring = keyringmgr.get_keyring()
-    delete_keys(keyring, address, port)
-    save_keyring(keyring)
+	local url = address .. ":" .. port
+	local keyring = read_keyring() or {}
+	local entry = keyring[url] or {playernames = {}}
+	entry.last_playername = playername
+	entry.playernames[playername] = 1
+	keyring[url] = entry
+	-- TODO error handling
+	core.keychain_set_password(url, playername, password)
+	save_keyring(keyring)
 end
 
 function keyringmgr.get_last_login(address, port)
-    local playername = get_keys(keyringmgr.get_keyring(), address, port).last_login
-    if playername then
-        return keyringmgr.get_login(address, port, playername)
-    end
-    return false
+	local url = address .. ":" .. port
+	local keyring = read_keyring()
+	local entry = keyring[url]
+	if entry == nil then return nil end
+	local got_password,password_or_error = core.keychain_get_password(url, entry.last_playername)
+	-- TODO error handling
+	return {
+		playername = entry.last_playername,
+		password = password_or_error,
+	}
 end

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -55,7 +55,15 @@ local function is_selected_fav(server)
 end
 
 -- Persists the selected server in the "address" and "remote_port" settings
+local function get_default_playername()
+	return core.settings:get("name")
+end
+local function get_default_password()
+	return ""
+end
 
+local input_playername = get_default_playername()
+local input_password = get_default_password()
 local function set_selected_server(server)
 	if server == nil then -- reset selection
 		core.settings:remove("address")
@@ -69,6 +77,18 @@ local function set_selected_server(server)
 	if address and port then
 		core.settings:set("address", address)
 		core.settings:set("remote_port", port)
+
+		-- Pull info from last login (if exists)
+		-- This will always fail if remember_login is false
+		-- because nothing has been stored, nor will it ever be
+		local login = keyringmgr.get_last_login(address, port)
+		if login then
+			input_playername = login.playername
+			input_password = login.password
+		else
+			input_playername = get_default_playername()
+			input_password = get_default_password()
+		end
 	end
 end
 
@@ -137,8 +157,8 @@ local function get_formspec(tabview, name, tabdata)
 		"container[0,4.8]" ..
 		"label[0.25,0;" .. fgettext("Name") .. "]" ..
 		"label[2.875,0;" .. fgettext("Password") .. "]" ..
-		"field[0.25,0.2;2.625,0.75;te_name;;" .. core.formspec_escape(core.settings:get("name")) .. "]" ..
-		"pwdfield[2.875,0.2;2.625,0.75;te_pwd;]" ..
+		"field[0.25,0.2;2.625,0.75;te_name;;" .. core.formspec_escape(input_playername) .. "]" ..
+		"pwdfield[2.875,0.2;2.625,0.75;te_pwd;;" .. core.formspec_escape(input_password) .. "]" ..
 		"container_end[]"
 
 	-- Connect
@@ -500,7 +520,6 @@ end
 local function main_button_handler(tabview, fields, name, tabdata)
 	if fields.te_name then
 		gamedata.playername = fields.te_name
-		core.settings:set("name", fields.te_name)
 	end
 
 	if fields.servers then
@@ -615,6 +634,7 @@ local function main_button_handler(tabview, fields, name, tabdata)
 		if server and server.address == gamedata.address and
 				server.port == gamedata.port then
 
+			keyringmgr.set_login(server.address, server.port, gamedata.playername, gamedata.password)
 			serverlistmgr.add_favorite(server)
 
 			gamedata.servername        = server.name

--- a/builtin/mainmenu/tab_online.lua
+++ b/builtin/mainmenu/tab_online.lua
@@ -82,6 +82,7 @@ local function set_selected_server(server)
 		-- This will always fail if remember_login is false
 		-- because nothing has been stored, nor will it ever be
 		local login = keyringmgr.get_last_login(address, port)
+		-- FIXME: I have to click on a server to have the password field pre-filled. it should also be filled when clicking on the join game tab and at startup.
 		if login then
 			input_playername = login.playername
 			input_password = login.password

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -903,6 +903,10 @@ menu_clouds (Clouds in menu) bool true
 #    Choose theme colors for the main menu background.
 menu_theme (Menu theme) enum light dark,light
 
+#    Remember each server's entered login info in the 'Join Game' tab
+#    ***WARNING, THIS IS NOT SECURE WHATSOEVER. DO NOT ENABLE THIS***:
+remember_login (Remember logins) bool false
+
 [**HUD]
 
 #    Modifies the size of the HUD elements.
@@ -2480,6 +2484,9 @@ enable_remote_media_server (Connect to external media server) [client] bool true
 #    File in client/serverlist/ that contains your favorite servers displayed in the
 #    Multiplayer Tab.
 serverlist_file (Serverlist file) [client] string favoriteservers.json
+
+#    File in client/ that contains your saved usernames and passwords for Multiplayer
+keyring_file (Keyring file) [client] string keyring.json
 
 
 [*Gamepads] [client]

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3266,7 +3266,7 @@ Elements
   (`x` and `y` are used as offset values, `w` and `h` are ignored)
 * Available since formspec version 2
 
-### `pwdfield[<X>,<Y>;<W>,<H>;<name>;<label>]`
+### `pwdfield[<X>,<Y>;<W>,<H>;<name>;<label>;<default>]`
 
 * Textual password style field; will be sent to server when a button is clicked
 * When enter is pressed in field, `fields.key_enter_field` will be sent with the
@@ -3276,6 +3276,10 @@ Elements
 * `name` is the name of the field as returned in fields to `on_receive_fields`
 * `label`, if not blank, will be text printed on the top left above the field
 * See `field_close_on_enter` to stop enter closing the formspec
+* `default` (optional) is the default value of the password
+    * `default` may contain variable references such as `${text}` which
+      will fill the value from the metadata value `text`
+    * **Note**: no extra text or more than a single variable is supported ATM.
 
 ### `field[<X>,<Y>;<W>,<H>;<name>;<label>;<default>]`
 

--- a/doc/menu_lua_api.md
+++ b/doc/menu_lua_api.md
@@ -191,6 +191,12 @@ Passed to `HTTPApiTable.fetch` callback. Returned by
 ```
 
 
+HTTP Requests
+-------------
+
+<!-- TODO -->
+
+
 Formspec
 --------
 

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -271,7 +271,7 @@ local scroll_fs =
 		"button[0,1;1,1;lorem;Lorem]"..
 		"animated_image[0,1;4.5,1;clip_animated_image;testformspec_animation.png;4;100]" ..
 		"button[0,10;1,1;ipsum;Ipsum]"..
-		"pwdfield[2,2;1,1;lorem2;Lorem]"..
+		"pwdfield[2,2;1,1;lorem2;Lorem;password]"..
 		"list[current_player;main;4,4;1,5;]"..
 		"box[2,5;3,2;#ffff00]"..
 		"image[1,10;3,2;testformspec_item.png]"..
@@ -377,7 +377,7 @@ local pages = {
 		item_image_button[0,6;1,1;testformspec:node;rc_item_image_button_1x1;1x1]
 		item_image_button[1,6;2,2;testformspec:node;rc_item_image_button_2x2;2x2]
 		field[3,.5;3,.5;rc_field;Field;text]
-		pwdfield[6,.5;3,1;rc_pwdfield;Password Field]
+		pwdfield[6,.5;3,1;rc_pwdfield;Password Field;password]
 		field[3,1;3,1;;Read-Only Field;text]
 		textarea[3,2;3,.5;rc_textarea_small;Textarea;text]
 		textarea[6,2;3,2;rc_textarea_big;Textarea;text\nmore text]

--- a/minetest.conf.example
+++ b/minetest.conf.example
@@ -3700,6 +3700,10 @@
 #    type: string
 # serverlist_file = favoriteservers.json
 
+#    File in client/ that contains your saved usernames and passwords for Multiplayer
+#    type: string
+# keyring_file = keyring.json
+
 ## Gamepads
 
 #    Enable joysticks. Requires a restart to take effect

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -695,6 +695,7 @@ if(BUILD_CLIENT)
 		${LUA_LIBRARY}
 		${GMP_LIBRARY}
 		${JSON_LIBRARY}
+		keychain
 		${LUA_BIT_LIBRARY}
 		lstrpack
 		sha256

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -391,6 +391,7 @@ void set_default_settings()
 	// Main menu
 	settings->setDefault("main_menu_path", "");
 	settings->setDefault("serverlist_file", "favoriteservers.json");
+	settings->setDefault("keyring_file", "keyring.json");
 
 	// General font settings
 	settings->setDefault("font_path", porting::getDataPath("fonts" DIR_DELIM "Arimo-Regular.ttf"));

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1440,13 +1440,16 @@ void GUIFormSpecMenu::parseFieldCloseOnEnter(parserData *data, const std::string
 void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
-	if (!precheckElement("pwdfield", element, 4, 4, parts))
+	if (!precheckElement("pwdfield", element, 4, 5, parts))
 		return;
 
 	std::vector<std::string> v_pos = split(parts[0],',');
 	std::vector<std::string> v_geom = split(parts[1],',');
 	std::string name = parts[2];
 	std::string label = parts[3];
+	std::string default_val = "";
+	if(parts.size() == 5) // If the field has a default value (for backwards compatibility)
+		default_val = parts[4];
 
 	MY_CHECKPOS("pwdfield",0);
 	MY_CHECKGEOM("pwdfield",1);
@@ -1468,6 +1471,9 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		geom.Y = m_btn_height*2;
 	}
 
+	if(m_form_src)
+		default_val = m_form_src->resolveText(default_val);
+
 	core::rect<s32> rect = core::rect<s32>(pos.X, pos.Y, pos.X+geom.X, pos.Y+geom.Y);
 
 	std::wstring wlabel = translate_string(utf8_to_wide(unescape_string(label)));
@@ -1482,7 +1488,7 @@ void GUIFormSpecMenu::parsePwdField(parserData* data, const std::string &element
 		);
 
 	spec.send = true;
-	gui::IGUIEditBox *e = Environment->addEditBox(0, rect, true,
+	gui::IGUIEditBox *e = Environment->addEditBox(utf8_to_wide(unescape_string(default_val)).c_str(), rect, true,
 			data->current_parent, spec.fid);
 
 	if (spec.fname == m_focused_element) {

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -28,6 +28,7 @@
 #include "gettext.h"
 #include "log.h"
 #include "util/string.h"
+#include "keychain/keychain.h"
 
 #include <cassert>
 #include <iostream>
@@ -937,6 +938,85 @@ int ModApiMainMenu::l_download_file(lua_State *L)
 }
 
 /******************************************************************************/
+int ModApiMainMenu::l_keychain_is_available(lua_State *L)
+{
+	keychain::Error error;
+	// TODO return error details
+	lua_pushboolean(L, keychain::isAvailable(error));
+	return 1;
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_keychain_set_password(lua_State *L)
+{
+	const char *url      = luaL_checkstring(L, 1);
+	const char *user     = luaL_checkstring(L, 2);
+	const char *password = luaL_checkstring(L, 3);
+
+	keychain::Error error;
+
+    keychain::setPassword("org.luanti.luanti", url, user, password, error);
+
+    if (error) {
+	    lua_pushboolean(L, false);
+	    lua_pushstring(L, error.message.c_str());
+	    return 2;
+    } else {
+	    lua_pushboolean(L, true);
+		return 1;
+	}
+
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_keychain_get_password(lua_State *L)
+{
+	const char *url      = luaL_checkstring(L, 1);
+	const char *user     = luaL_checkstring(L, 2);
+
+	keychain::Error error;
+
+	std::string password = keychain::getPassword("org.luanti.luanti", url, user, error);
+
+    if (error.type == keychain::ErrorType::NotFound) {
+		// No error getting the password
+	    lua_pushboolean(L, true);
+		// But no password was found
+		lua_pushnil(L);
+        return 2;
+    } else if (error) {
+	    lua_pushboolean(L, false);
+	    lua_pushstring(L, error.message.c_str());
+	    return 2;
+    } else {
+	    lua_pushboolean(L, true);
+		lua_pushstring(L, password.c_str());
+	    return 2;
+	}
+}
+
+/******************************************************************************/
+int ModApiMainMenu::l_keychain_delete_password(lua_State *L)
+{
+	const char *url      = luaL_checkstring(L, 1);
+	const char *user     = luaL_checkstring(L, 2);
+
+	keychain::Error error;
+
+	keychain::deletePassword("org.luanti.luanti", url, user, error);
+
+    if (error) {
+	    lua_pushboolean(L, false);
+	    lua_pushstring(L, error.message.c_str());
+	    return 2;
+    } else {
+	    lua_pushboolean(L, true);
+	    return 1;
+	}
+
+}
+
+/******************************************************************************/
 int ModApiMainMenu::l_get_language(lua_State *L)
 {
 	std::string lang = gettext("LANG_CODE");
@@ -1150,6 +1230,10 @@ void ModApiMainMenu::Initialize(lua_State *L, int top)
 	API_FCT(get_mainmenu_path);
 	API_FCT(show_path_select_dialog);
 	API_FCT(download_file);
+	API_FCT(keychain_is_available);
+	API_FCT(keychain_set_password);
+	API_FCT(keychain_get_password);
+	API_FCT(keychain_delete_password);
 	API_FCT(get_language);
 	API_FCT(get_window_info);
 	API_FCT(get_active_renderer);

--- a/src/script/lua_api/l_mainmenu.h
+++ b/src/script/lua_api/l_mainmenu.h
@@ -130,6 +130,13 @@ private:
 
 	static int l_download_file(lua_State *L);
 
+	//keychain
+
+	static int l_keychain_is_available(lua_State *L);
+	static int l_keychain_set_password(lua_State *L);
+	static int l_keychain_get_password(lua_State *L);
+	static int l_keychain_delete_password(lua_State *L);
+
 	//version compatibility
 	static int l_get_min_supp_proto(lua_State *L);
 

--- a/src/script/lua_api/l_settings.cpp
+++ b/src/script/lua_api/l_settings.cpp
@@ -48,7 +48,7 @@ static inline int checkSettingSecurity(lua_State* L, const std::string &name)
 
 	const char *disallowed[] = {
 		"main_menu_script", "shader_path", "texture_path", "screenshot_path",
-		"serverlist_file", "serverlist_url", "map-dir", "contentdb_url",
+		"serverlist_file", "keyring_file", "serverlist_url", "map-dir", "contentdb_url",
 	};
 	for (const char *name2 : disallowed) {
 		if (name == name2)


### PR DESCRIPTION
Based on #16294 according to my comment https://github.com/luanti-org/luanti/issues/1566#issuecomment-4360557003

### Goal

Implements and closes #1566, using the system's keychain.

The end result (unless marked as experimental and disabled by default) must include the dropdown as specified in the issue, a way to view the stored passwords, and an overwrite confirmation prompt. Otherwise the user risks accidentally forgetting and overwriting saved passwords.

### How

The current state is:

* We modify the formspec API to include a 'default' field in pwdfield so that we can actually populate it
* We use https://github.com/hrantzsch/keychain to store the credentials in the system's keychain and to get them when logging in

See below for future plans

## To do

This PR is a Work in Progress <!-- / Ready for Review. -->

### Phase 1: PoC

- [x] Complete PR description
- [x] Add hrantzsch/keychain submodule
- [x] Expose keychain to lua
- [x] Change keyringmgr.lua to use a different schema that only contains urls and usernames. Something like `{"example.com:1234": ["user1", "user2"]}`.
- [x] Use keychain to set and get passwords
- [ ] Address TODOs left in code
- [x] Get core dev support before proceeding to the next phase

### Phase 2: usability

As is, the system makes it too easy to forget the password you use and then accidentally overwrite it, locking you out of your account.

If the feature is marked as experimental and disabled by default, this can be done later.

- [ ] Add a dropdown for saved credentials (instead of or in addition to the username field)
  - [ ] May need a new kind of editable dropdown, like HTML datalist
- [ ] Ask before overwriting credentials
- [ ] Either ensure the credentials can be easily viewed from the system keychains, or add a way to reveal/export passwords

### Phase 3: cleanup

- [ ] Split splittable stuff into separate PRs (eg. default pwd field)
- [ ] Check if the use of synchronous functions is a problem in practice
- [ ] Add to hrantzsch/keychain a function that lists all credentials for a service, eliminating the need for keyring.json https://github.com/hrantzsch/keychain/issues/52
- [ ] Link to system hrantzsch/keychain if present
- [ ] Check whether a submodule is ok or we have to vendor hrantzsch/keychain

## How to test

1. Connect to a server using your credentials
2. The next time you connect, the password should be pre-filled
   * bug: you have to click on the server in the list to get it to pre-fill the password
4. On linux, you can see that the password has been saved in the system's keychain by running `lssecret` and looking for `org.luanti.luanti`, or by using your keychain's GUI (eg. gnome seahorse)
   <img width="1060" height="165" alt="image" src="https://github.com/user-attachments/assets/839bb380-69d7-4e4f-b103-b3f235e8abbd" />
6. (phase 2) You can select the saved credential to use
7. (phase 2) You get a warning when overwriting a password

---

No AI or LLM has been used while working on this.
