### PR TITLE
Add QUIC connection implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,11 @@ endif()
 
 add_subdirectory(lib/tiniergltf)
 
+# QUIC support
+if(ENABLE_EXPERIMENTAL_QUIC_TRANSPORT)
+	find_package(Ngtcp2 REQUIRED)
+endif()
+
 # Subdirectories
 # Be sure to add all relevant definitions above this
 add_subdirectory(src)

--- a/cmake/Modules/FindNgtcp2.cmake
+++ b/cmake/Modules/FindNgtcp2.cmake
@@ -1,0 +1,51 @@
+# Locate ngtcp2
+# This module defines
+#  NGTCP2_FOUND, true if libngtcp2 was located
+#  NGTCP2_INCLUDE_DIRS, header search paths
+#  NGTCP2_LIBRARIES, libraries to link against
+#
+# Imported target:
+#  Ngtcp2::Ngtcp2
+#  Ngtcp2::CryptoOssl
+
+include(FindPackageHandleStandardArgs)
+
+find_path(NGTCP2_INCLUDE_DIR
+	NAMES ngtcp2/ngtcp2.h
+)
+
+find_library(NGTCP2_LIBRARY
+	NAMES ngtcp2
+)
+
+find_path(NGTCP2_CRYPTO_OSSL_INCLUDE_DIR
+	NAMES ngtcp2/ngtcp2_crypto_ossl.h
+)
+
+find_library(NGTCP2_CRYPTO_OSSL_LIBRARY
+	NAMES ngtcp2_crypto_ossl
+)
+
+find_package_handle_standard_args(Ngtcp2
+	REQUIRED_VARS NGTCP2_LIBRARY NGTCP2_INCLUDE_DIR NGTCP2_CRYPTO_OSSL_INCLUDE_DIR NGTCP2_CRYPTO_OSSL_LIBRARY
+)
+
+if(NGTCP2_FOUND)
+	if(NOT TARGET Ngtcp2::Ngtcp2)
+		add_library(Ngtcp2::Ngtcp2 UNKNOWN IMPORTED)
+		set_target_properties(Ngtcp2::Ngtcp2 PROPERTIES
+			IMPORTED_LOCATION "${NGTCP2_LIBRARY}"
+			INTERFACE_INCLUDE_DIRECTORIES "${NGTCP2_INCLUDE_DIR}"
+		)
+	endif()
+
+	if(NOT TARGET Ngtcp2::CryptoOssl)
+		add_library(Ngtcp2::CryptoOssl UNKNOWN IMPORTED)
+		set_target_properties(Ngtcp2::CryptoOssl PROPERTIES
+			IMPORTED_LOCATION "${NGTCP2_CRYPTO_OSSL_LIBRARY}"
+			INTERFACE_INCLUDE_DIRECTORIES "${NGTCP2_CRYPTO_OSSL_INCLUDE_DIR}"
+		)
+	endif()
+endif()
+
+mark_as_advanced(NGTCP2_INCLUDE_DIR NGTCP2_LIBRARY NGTCP2_CRYPTO_OSSL_INCLUDE_DIR NGTCP2_CRYPTO_OSSL_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -251,18 +251,31 @@ if(ENABLE_SPATIAL)
 endif(ENABLE_SPATIAL)
 
 option(ENABLE_OPENSSL "Use OpenSSL's libcrypto for faster SHA implementations" TRUE)
+option(ENABLE_EXPERIMENTAL_QUIC_TRANSPORT "Build experimental QUIC transport" FALSE)
 set(USE_OPENSSL FALSE)
+set(USE_NGTCP2_QUIC FALSE)
 
-if(ENABLE_OPENSSL)
-	find_package(OpenSSL 3.0)
+if(ENABLE_OPENSSL OR ENABLE_EXPERIMENTAL_QUIC_TRANSPORT)
+	# QUIC needs both libssl and libcrypto
+	# Plain SHA acceleration only needs Crypto
+	if(ENABLE_EXPERIMENTAL_QUIC_TRANSPORT)
+		find_package(OpenSSL 3.5 COMPONENTS SSL Crypto)
+	else()
+		find_package(OpenSSL 3.0 COMPONENTS Crypto)
+	endif()
 	if(OPENSSL_FOUND)
 		set(USE_OPENSSL TRUE)
-		message(STATUS "OpenSSL's libcrypto SHA enabled.")
+		message(STATUS "OpenSSL enabled (version ${OPENSSL_VERSION}).")
 	else()
 		message(STATUS "OpenSSL not found!")
 	endif()
-endif(ENABLE_OPENSSL)
+endif()
 
+if(ENABLE_EXPERIMENTAL_QUIC_TRANSPORT)
+	find_package(Ngtcp2 REQUIRED)
+	set(USE_NGTCP2_QUIC TRUE)
+	add_compile_definitions(USE_NGTCP2_QUIC=1)
+endif()
 
 find_package(ZLIB REQUIRED)
 find_package(Zstd REQUIRED)
@@ -615,6 +628,13 @@ target_link_libraries(EngineCommon
 if(USE_OPENSSL)
 	target_link_libraries(EngineCommon OpenSSL::Crypto)
 endif()
+if(USE_NGTCP2_QUIC)
+	target_link_libraries(EngineCommon
+		Ngtcp2::Ngtcp2
+		Ngtcp2::CryptoOssl
+		OpenSSL::SSL
+		OpenSSL::Crypto)
+endif()
 get_target_property(
 	IRRLICHT_INCLUDES IrrlichtMt::IrrlichtMt INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(EngineCommon PRIVATE ${IRRLICHT_INCLUDES})
@@ -752,6 +772,13 @@ if(BUILD_CLIENT)
 	if (USE_OPENSSL)
 		target_link_libraries(${PROJECT_NAME} OpenSSL::Crypto)
 	endif()
+	if (USE_NGTCP2_QUIC)
+		target_link_libraries(${PROJECT_NAME}
+			Ngtcp2::Ngtcp2
+			Ngtcp2::CryptoOssl
+			OpenSSL::SSL
+			OpenSSL::Crypto)
+	endif()
 	if(BUILD_UNITTESTS OR BUILD_BENCHMARKS)
 		target_link_libraries(${PROJECT_NAME} Catch2::Catch2)
 	endif()
@@ -824,6 +851,13 @@ if(BUILD_SERVER)
 	endif()
 	if (USE_OPENSSL)
 		target_link_libraries(${PROJECT_NAME}server OpenSSL::Crypto)
+	endif()
+	if (USE_NGTCP2_QUIC)
+		target_link_libraries(${PROJECT_NAME}server
+			Ngtcp2::Ngtcp2
+			Ngtcp2::CryptoOssl
+			OpenSSL::SSL
+			OpenSSL::Crypto)
 	endif()
 	if(USE_CURL)
 		target_link_libraries(

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -447,6 +447,8 @@ void set_default_settings()
 	settings->setDefault("ipv6_server", "true");
 	settings->setDefault("max_packets_per_iteration", "1024");
 	settings->setDefault("port", "30000");
+	settings->setDefault("quic_cert_file", "");
+	settings->setDefault("quic_key_file", "");
 	settings->setDefault("strict_protocol_version_checking", "false");
 	settings->setDefault("protocol_version_min", "1");
 	settings->setDefault("player_transfer_distance", "0");

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -9,8 +9,15 @@ set(common_network_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/networkpacket.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/networkprotocol.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/socket.cpp
-	PARENT_SCOPE
 )
+
+if (ENABLE_EXPERIMENTAL_QUIC_TRANSPORT)
+	list(APPEND common_network_SRCS
+		${CMAKE_CURRENT_SOURCE_DIR}/quic_connection.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/quic_tls.cpp
+	)
+endif()
+set(common_network_SRCS ${common_network_SRCS} PARENT_SCOPE)
 
 set(server_network_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/serveropcodes.cpp

--- a/src/network/address.cpp
+++ b/src/network/address.cpp
@@ -7,8 +7,14 @@
 #include <iostream>
 #include <cstring>
 #include <cerrno>
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+
 #include "network/networkexceptions.h"
 #include "settings.h"
+#include "util/base64.h"
+#include "util/hashing.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -28,6 +34,44 @@ typedef int socklen_t;
 #define LAST_SOCKET_ERR() (errno)
 typedef int socket_t;
 #endif
+
+namespace {
+
+struct ParsedEndpoint {
+	std::string host;
+	std::string pinned_cert_sha256_base64;
+};
+
+bool isNumericHost(const std::string &host)
+{
+	in_addr ipv4 {};
+	if (inet_pton(AF_INET, host.c_str(), &ipv4) == 1)
+		return true;
+
+	in6_addr ipv6 {};
+	return inet_pton(AF_INET6, host.c_str(), &ipv6) == 1;
+}
+
+ParsedEndpoint parseEndpoint(std::string name)
+{
+	ParsedEndpoint out;
+
+	auto plus_pos = name.find('+');
+	if (plus_pos != std::string::npos) {
+		out.pinned_cert_sha256_base64 = name.substr(plus_pos + 1);
+		name.resize(plus_pos);
+
+		if (!base64_is_valid(out.pinned_cert_sha256_base64))
+			throw ResolveError("Pinned certificate fingerprint is not valid base64");
+		if (base64_decode(out.pinned_cert_sha256_base64).size() != hashing::SHA256_DIGEST_SIZE)
+			throw ResolveError("Pinned certificate fingerprint must decode to 32 bytes");
+	}
+
+	out.host = name;
+	return out;
+}
+
+} // namespace
 
 /*
 	Address
@@ -80,6 +124,9 @@ bool Address::operator==(const Address &other) const
 void Address::Resolve(const char *name, Address *fallback)
 {
 	if (!name || name[0] == 0) {
+		m_hostname.clear();
+		m_pinned_cert_sha256_base64.clear();
+		m_name_was_numeric = false;
 		if (m_addr_family == AF_INET)
 			setAddress(static_cast<u32>(0));
 		else if (m_addr_family == AF_INET6)
@@ -87,6 +134,14 @@ void Address::Resolve(const char *name, Address *fallback)
 		if (fallback)
 			*fallback = Address();
 		return;
+	}
+
+	ParsedEndpoint parsed = parseEndpoint(name);
+
+	// We keep the same pinned certificate fingerprint if we were already given one
+	if (parsed.pinned_cert_sha256_base64.empty()
+			&& !m_pinned_cert_sha256_base64.empty()) {
+		parsed.pinned_cert_sha256_base64 = m_pinned_cert_sha256_base64;
 	}
 
 	const auto &copy_from_ai = [] (const struct addrinfo *ai, Address *to) {
@@ -118,17 +173,25 @@ void Address::Resolve(const char *name, Address *fallback)
 
 	// Do getaddrinfo()
 	struct addrinfo *resolved = nullptr;
-	int e = getaddrinfo(name, nullptr, &hints, &resolved);
+	int e = getaddrinfo(parsed.host.c_str(), nullptr, &hints, &resolved);
 	if (e != 0)
 		throw ResolveError(gai_strerror(e));
 	assert(resolved);
 
 	// Copy data
 	copy_from_ai(resolved, this);
+	m_hostname = parsed.host;
+	m_pinned_cert_sha256_base64 = parsed.pinned_cert_sha256_base64;
+	m_name_was_numeric = isNumericHost(parsed.host);
+
 	if (fallback) {
 		*fallback = Address();
-		if (resolved->ai_next)
+		if (resolved->ai_next) {
 			copy_from_ai(resolved->ai_next, fallback);
+			fallback->m_hostname = parsed.host;
+			fallback->m_pinned_cert_sha256_base64 = parsed.pinned_cert_sha256_base64;
+			fallback->m_name_was_numeric = m_name_was_numeric;
+		}
 	}
 
 	freeaddrinfo(resolved);

--- a/src/network/address.h
+++ b/src/network/address.h
@@ -15,6 +15,7 @@
 
 #include <ostream>
 #include <cstring>
+#include <string>
 #include "irrlichttypes.h"
 
 struct IPv6AddressBytes
@@ -41,6 +42,26 @@ public:
 	struct in6_addr getAddress6() const { return m_address.ipv6; }
 	u16 getPort() const { return m_port; }
 
+	const std::string &getHostName() const { return m_hostname; }
+	const std::string &getPinnedCertSha256Base64() const { return m_pinned_cert_sha256_base64; }
+
+	// These setters are for testing address parsing
+	void setHostName(const std::string &h) { m_hostname = h; }
+	void setNumericHostName(bool numeric) { m_name_was_numeric = numeric; }
+	void setPinnedCertSha256Base64(const std::string &b64)
+		{ m_pinned_cert_sha256_base64 = b64; }
+
+	bool hasPinnedCertSha256() const { return !m_pinned_cert_sha256_base64.empty(); }
+	bool isNumericHostName() const { return m_name_was_numeric; }
+	bool shouldUseWebPki() const
+	{
+		return !m_hostname.empty() && !m_name_was_numeric && !hasPinnedCertSha256();
+	}
+	bool requiresPinnedCertSha256() const
+	{
+		return m_name_was_numeric || hasPinnedCertSha256();
+	}
+
 	void print(std::ostream &s) const;
 	std::string serializeString() const;
 
@@ -49,7 +70,8 @@ public:
 	// Is this an address referring to the local host?
 	bool isLocalhost() const;
 
-	// `name`: hostname or numeric IP
+	// `name`: hostname or numeric IP optionally followed by `+` and the
+	// base64 certificate fingerprint
 	// `fallback`: fallback IP to try gets written here
 	// any empty name resets the IP to the "any address"
 	// may throw ResolveError (address is unchanged in this case)
@@ -69,4 +91,7 @@ private:
 	} m_address;
 	// port is separate from in_addr structures
 	u16 m_port = 0;
+	std::string m_hostname;
+	std::string m_pinned_cert_sha256_base64;
+	bool m_name_was_numeric = false;
 };

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -4,14 +4,22 @@
 #include "network/connection.h"
 #include "network/mtp/impl.h"
 
+#ifdef USE_NGTCP2_QUIC
+#include "network/quic_connection.h"
+#endif
+
 namespace con
 {
 
 IConnection *createMTP(float timeout, bool ipv6, PeerHandler *handler)
 {
+#ifdef USE_NGTCP2_QUIC
+	return createQUIC(timeout, ipv6, handler);
+#else
 	// safe minimum across internet networks for ipv4 and ipv6
 	constexpr u32 MAX_PACKET_SIZE = 512;
 	return new con::Connection(MAX_PACKET_SIZE, timeout, ipv6, handler);
+#endif
 }
 
 }

--- a/src/network/quic_connection.cpp
+++ b/src/network/quic_connection.cpp
@@ -1,0 +1,1045 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "network/quic_connection.h"
+
+#include "network/quic_tls.h"
+
+#include <ngtcp2/ngtcp2.h>
+#include <ngtcp2/ngtcp2_crypto.h>
+#include <ngtcp2/ngtcp2_crypto_ossl.h>
+
+#include <openssl/err.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+
+#include <cassert>
+#include <chrono>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+
+#include "constants.h"
+#include "util/base64.h"
+#include "util/serialize.h"
+
+namespace con
+{
+
+namespace {
+
+// ngtcp2 requires a monotonic counter at nanosecond resolution
+uint64_t timestamp_ns()
+{
+	using namespace std::chrono;
+	return static_cast<uint64_t>(duration_cast<nanoseconds>(
+		steady_clock::now().time_since_epoch()).count());
+}
+
+// Convert a Luanti Address to a sockaddr_storage. Returns the actual length used.
+socklen_t to_sockaddr(const Address &a, struct sockaddr_storage *ss)
+{
+	std::memset(ss, 0, sizeof(*ss));
+	if (a.getFamily() == AF_INET) {
+		auto *sin = reinterpret_cast<struct sockaddr_in *>(ss);
+		sin->sin_family = AF_INET;
+		sin->sin_port = htons(a.getPort());
+		sin->sin_addr = a.getAddress();
+		return sizeof(*sin);
+	}
+	auto *sin6 = reinterpret_cast<struct sockaddr_in6 *>(ss);
+	sin6->sin6_family = AF_INET6;
+	sin6->sin6_port = htons(a.getPort());
+	sin6->sin6_addr = a.getAddress6();
+	return sizeof(*sin6);
+}
+
+Address from_sockaddr(const struct sockaddr_storage *ss)
+{
+	Address a;
+	if (ss->ss_family == AF_INET) {
+		const auto *sin = reinterpret_cast<const struct sockaddr_in *>(ss);
+		a.setAddress(ntohl(sin->sin_addr.s_addr));
+		a.setPort(ntohs(sin->sin_port));
+	} else if (ss->ss_family == AF_INET6) {
+		const auto *sin6 = reinterpret_cast<const struct sockaddr_in6 *>(ss);
+		IPv6AddressBytes b;
+		std::memcpy(b.bytes, sin6->sin6_addr.s6_addr, 16);
+		a.setAddress(&b);
+		a.setPort(ntohs(sin6->sin6_port));
+	}
+	return a;
+}
+
+// This is how we get to the QuicSession we are using when receiving a
+// callback from ngtcp2 which gives a ngtcp2_crypto_conn_ref pointer
+struct ConnRefImpl {
+	ngtcp2_crypto_conn_ref ref;
+	QuicSession *session;
+};
+
+void log_printf(void *, const char *fmt, ...)
+{
+	// Set LUANTI_QUIC_DEBUG=1 in the environment to get verbose ngtcp2 logs
+	static const bool verbose = std::getenv("LUANTI_QUIC_DEBUG") != nullptr;
+	if (!verbose)
+		return;
+	va_list ap;
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fputc('\n', stderr);
+}
+
+void rand_bytes(uint8_t *dest, size_t destlen)
+{
+	if (RAND_bytes(dest, static_cast<int>(destlen)) == 1)
+		return;
+
+	// Fallback to std::random_device (though I think it's rare for RAND_bytes to fail)
+	std::random_device rd;
+	for (size_t i = 0; i < destlen; ++i)
+		dest[i] = static_cast<uint8_t>(rd());
+}
+
+// Build the ngtcp2 callback table once per direction, since the pointers stay the same
+const ngtcp2_callbacks &client_callbacks()
+{
+	static const ngtcp2_callbacks cb = []() {
+		ngtcp2_callbacks c{};
+		c.client_initial = ngtcp2_crypto_client_initial_cb;
+		c.recv_crypto_data = ngtcp2_crypto_recv_crypto_data_cb;
+		c.encrypt = ngtcp2_crypto_encrypt_cb;
+		c.decrypt = ngtcp2_crypto_decrypt_cb;
+		c.hp_mask = ngtcp2_crypto_hp_mask_cb;
+		c.recv_retry = ngtcp2_crypto_recv_retry_cb;
+		c.update_key = ngtcp2_crypto_update_key_cb;
+		c.delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb;
+		c.delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb;
+		c.get_path_challenge_data = ngtcp2_crypto_get_path_challenge_data_cb;
+		c.version_negotiation = ngtcp2_crypto_version_negotiation_cb;
+		c.rand = QuicConnection::cb_rand;
+		c.get_new_connection_id = QuicConnection::cb_get_new_connection_id;
+		c.handshake_completed = QuicConnection::cb_handshake_completed;
+		c.recv_stream_data = QuicConnection::cb_recv_stream_data;
+		c.acked_stream_data_offset = QuicConnection::cb_acked_stream_data_offset;
+		c.stream_open = QuicConnection::cb_stream_open;
+		c.stream_close = QuicConnection::cb_stream_close;
+		return c;
+	}();
+	return cb;
+}
+
+const ngtcp2_callbacks &server_callbacks()
+{
+	static const ngtcp2_callbacks cb = []() {
+		ngtcp2_callbacks c = client_callbacks();
+		c.client_initial = nullptr;
+		c.recv_retry = nullptr;
+		c.recv_client_initial = ngtcp2_crypto_recv_client_initial_cb;
+		return c;
+	}();
+	return cb;
+}
+
+void make_transport_params(ngtcp2_transport_params &params)
+{
+	ngtcp2_transport_params_default(&params);
+	params.initial_max_streams_bidi = 4;
+	params.initial_max_streams_uni = 0;
+	params.initial_max_stream_data_bidi_local = 1024 * 1024;
+	params.initial_max_stream_data_bidi_remote = 1024 * 1024;
+	params.initial_max_data = 4 * 1024 * 1024;
+	params.max_idle_timeout = 30 * NGTCP2_SECONDS;
+}
+
+void make_default_settings(ngtcp2_settings &settings)
+{
+	ngtcp2_settings_default(&settings);
+	settings.initial_ts = timestamp_ns();
+	settings.log_printf = log_printf;
+}
+
+} // namespace
+
+/*
+	QuicSession
+*/
+
+QuicSession::~QuicSession()
+{
+	if (conn) {
+		ngtcp2_conn_del(conn);
+		conn = nullptr;
+	}
+	if (ossl_ctx) {
+		ngtcp2_crypto_ossl_ctx_del(ossl_ctx);
+		ossl_ctx = nullptr;
+	}
+	if (ssl) {
+		SSL_set_app_data(ssl, nullptr);
+		SSL_free(ssl);
+		ssl = nullptr;
+	}
+	if (conn_ref) {
+		delete static_cast<ConnRefImpl *>(static_cast<void *>(conn_ref));
+		conn_ref = nullptr;
+	}
+}
+
+void QuicSession::send_app_frame(u8 channel, bool reliable, const uint8_t *data, size_t len)
+{
+	if (len > QUIC_FRAME_MAX_LEN)
+		throw ConnectionException("Outbound NetworkPacket exceeds frame size limit");
+
+	// Compact the buffer
+	if (tx_head > 0 && tx_head >= tx_buffer.size() / 2) {
+		tx_buffer.erase(tx_buffer.begin(), tx_buffer.begin() + tx_head);
+		tx_head = 0;
+	}
+
+	size_t old = tx_buffer.size();
+	tx_buffer.resize(old + QUIC_FRAME_HEADER_LEN + len);
+	uint8_t *p = tx_buffer.data() + old;
+	p[0] = channel;
+	p[1] = reliable ? 1 : 0;
+	writeU32(p + 2, static_cast<u32>(len));
+	if (len > 0)
+		std::memcpy(p + QUIC_FRAME_HEADER_LEN, data, len);
+}
+
+void QuicSession::tx_advance(size_t n)
+{
+	tx_head += n;
+	if (tx_head >= tx_buffer.size()) {
+		tx_buffer.clear();
+		tx_head = 0;
+	}
+}
+
+/*
+	QuicConnection
+*/
+
+QuicConnection::QuicConnection(float timeout, bool ipv6, PeerHandler *handler)
+	: m_handler(handler), m_timeout(timeout), m_ipv6(ipv6)
+{
+	// One-time init for ngtcp2_crypto_ossl which is safe to call repeatedly
+	ngtcp2_crypto_ossl_init();
+}
+
+QuicConnection::~QuicConnection()
+{
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		m_sessions.clear();
+	}
+	if (m_socket_fd >= 0) {
+		::close(m_socket_fd);
+		m_socket_fd = -1;
+	}
+}
+
+void QuicConnection::setServerCertificates(const std::string &cert_pem_path,
+	const std::string &key_pem_path)
+{
+	m_server_cert_pem = cert_pem_path;
+	m_server_key_pem = key_pem_path;
+}
+
+ngtcp2_conn *QuicConnection::get_conn_from_ref(ngtcp2_crypto_conn_ref *ref)
+{
+	auto *impl = reinterpret_cast<ConnRefImpl *>(ref);
+	return impl->session->conn;
+}
+
+void QuicConnection::cb_rand(uint8_t *dest, size_t destlen, const ngtcp2_rand_ctx *)
+{
+	rand_bytes(dest, destlen);
+}
+
+int QuicConnection::cb_get_new_connection_id(ngtcp2_conn *, ngtcp2_cid *cid,
+	uint8_t *token, size_t cidlen, void *)
+{
+	rand_bytes(cid->data, cidlen);
+	cid->datalen = cidlen;
+	if (token)
+		rand_bytes(token, NGTCP2_STATELESS_RESET_TOKENLEN);
+	return 0;
+}
+
+int QuicConnection::cb_handshake_completed(ngtcp2_conn *, void *user_data)
+{
+	auto *s = static_cast<QuicSession *>(user_data);
+	s->handshake_completed = true;
+	return 0;
+}
+
+int QuicConnection::cb_stream_open(ngtcp2_conn *, int64_t stream_id, void *user_data)
+{
+	auto *s = static_cast<QuicSession *>(user_data);
+	if (s->app_stream_id < 0)
+		s->app_stream_id = stream_id;
+	return 0;
+}
+
+int QuicConnection::cb_stream_close(ngtcp2_conn *, uint32_t, int64_t, uint64_t,
+	void *, void *)
+{
+	return 0;
+}
+
+int QuicConnection::cb_acked_stream_data_offset(ngtcp2_conn *, int64_t, uint64_t,
+	uint64_t, void *, void *)
+{
+	// We hand bytes to ngtcp2_conn_writev_stream and don't keep a separate
+	// resend buffer, so there's nothing to free here.
+	return 0;
+}
+
+int QuicConnection::cb_recv_stream_data(ngtcp2_conn *, uint32_t /* flags */,
+	int64_t stream_id, uint64_t /* offset */, const uint8_t *data,
+	size_t datalen, void *user_data, void *)
+{
+	auto *s = static_cast<QuicSession *>(user_data);
+	if (s->app_stream_id < 0)
+		s->app_stream_id = stream_id;
+
+	if (datalen) {
+		s->rx_buffer.insert(s->rx_buffer.end(), data, data + datalen);
+		ngtcp2_conn_extend_max_stream_offset(s->conn, stream_id, datalen);
+		ngtcp2_conn_extend_max_offset(s->conn, datalen);
+	}
+	return 0;
+}
+
+void QuicConnection::extractFrames(QuicSession &s)
+{
+	// Parse as many complete frames as possible out of the unread region
+	size_t avail = s.rx_buffer.size() - s.rx_head;
+	while (avail >= QUIC_FRAME_HEADER_LEN) {
+		const uint8_t *p = s.rx_buffer.data() + s.rx_head;
+		u8 channel = p[0];
+		// We're not currently using the reliable flag p[1]
+		u32 len = readU32(p + 2);
+		if (len > QUIC_FRAME_MAX_LEN)
+			throw InvalidIncomingDataException("QUIC frame too large");
+		if (avail < QUIC_FRAME_HEADER_LEN + len)
+			// We haven't received the whole frame header yet, so wait for more bytes
+			break;
+
+		s.rx_frames.emplace_back(channel,
+			std::vector<uint8_t>(p + QUIC_FRAME_HEADER_LEN, p + QUIC_FRAME_HEADER_LEN + len));
+		s.rx_head += QUIC_FRAME_HEADER_LEN + len;
+		avail -= QUIC_FRAME_HEADER_LEN + len;
+	}
+	// Compact only when more than half the buffer is already consumed
+	if (s.rx_head > 0 && s.rx_head >= s.rx_buffer.size() / 2) {
+		if (s.rx_head == s.rx_buffer.size()) {
+			s.rx_buffer.clear();
+		} else {
+			std::memmove(s.rx_buffer.data(),
+				s.rx_buffer.data() + s.rx_head,
+				s.rx_buffer.size() - s.rx_head);
+			s.rx_buffer.resize(s.rx_buffer.size() - s.rx_head);
+		}
+		s.rx_head = 0;
+	}
+}
+
+/*
+	Socket helpers
+*/
+
+namespace {
+
+int open_udp_socket(bool ipv6)
+{
+	int fd = ::socket(ipv6 ? AF_INET6 : AF_INET, SOCK_DGRAM, 0);
+	if (fd < 0) {
+		throw ConnectionBindFailed(
+			(std::string("socket() failed: ") + std::strerror(errno)).c_str());
+	}
+	int yes = 1;
+	::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
+	if (ipv6) {
+		if (::setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &yes, sizeof(yes)) < 0) {
+			::close(fd);
+			throw ConnectionBindFailed(
+				(std::string("setsockopt(IPV6_V6ONLY) failed: ")
+				+ std::strerror(errno)).c_str());
+		}
+	}
+	int flags = ::fcntl(fd, F_GETFL, 0);
+	::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	return fd;
+}
+
+} // namespace
+
+void QuicConnection::cacheLocalSockaddr()
+{
+	m_local_slen = sizeof(m_local_ss);
+	std::memset(&m_local_ss, 0, sizeof(m_local_ss));
+	if (::getsockname(m_socket_fd,
+			reinterpret_cast<struct sockaddr *>(&m_local_ss),
+			&m_local_slen) != 0) {
+		// Should never happen on a successfully bound socket
+		m_local_slen = 0;
+		return;
+	}
+	m_local_addr_observed = from_sockaddr(&m_local_ss);
+}
+
+void QuicConnection::Serve(Address bind_addr)
+{
+	std::lock_guard<std::mutex> lk(m_mutex);
+	m_bind_addr = bind_addr;
+	m_serving = true;
+
+	if (m_server_cert_pem.empty() || m_server_key_pem.empty())
+		throw ConnectionException(
+			"QuicConnection::Serve() requires setServerCertificates() first");
+
+	m_server_tls = std::make_unique<TlsServerContext>();
+	if (!m_server_tls->init(m_server_cert_pem, m_server_key_pem))
+		throw ConnectionException("Failed to initialize server TLS context");
+
+	m_socket_fd = open_udp_socket(bind_addr.isIPv6());
+	struct sockaddr_storage ss;
+	socklen_t slen = to_sockaddr(bind_addr, &ss);
+	if (::bind(m_socket_fd, reinterpret_cast<struct sockaddr *>(&ss), slen) < 0) {
+		::close(m_socket_fd);
+		m_socket_fd = -1;
+		throw ConnectionBindFailed(
+			(std::string("bind() failed: ") + std::strerror(errno)).c_str());
+	}
+
+	cacheLocalSockaddr();
+	if (m_local_slen == 0)
+		m_local_addr_observed = bind_addr;
+}
+
+std::unique_ptr<QuicSession> QuicConnection::makeClientSession(
+	const Address &remote)
+{
+	auto s = std::make_unique<QuicSession>();
+	s->remote = remote;
+
+	// SSL_CTX with our verification policy
+	if (!m_client_tls) {
+		m_client_tls = std::make_unique<TlsClientContext>();
+		if (!m_client_tls->init())
+			throw ConnectionException("Client TLS init failed");
+	}
+
+	s->ssl = SSL_new(m_client_tls->get());
+	if (!s->ssl)
+		throw ConnectionException("SSL_new failed");
+
+	VerifyConfig vc;
+	vc.hostname = remote.getHostName();
+	if (vc.hostname.empty())
+		vc.hostname = remote.serializeString();
+	if (remote.hasPinnedCertSha256()) {
+		vc.pinned_sha256_raw = ::base64_decode(remote.getPinnedCertSha256Base64());
+	} else if (remote.isNumericHostName()) {
+		vc.numeric_no_pin = true;
+	}
+	if (!m_client_tls->configureSession(s->ssl, vc))
+		throw ConnectionException("Client TLS session configuration failed");
+
+	if (ngtcp2_crypto_ossl_ctx_new(&s->ossl_ctx, s->ssl) != 0)
+		throw ConnectionException("ngtcp2_crypto_ossl_ctx_new failed");
+
+	auto *ref_impl = new ConnRefImpl;
+	std::memset(ref_impl, 0, sizeof(*ref_impl));
+	ref_impl->ref.get_conn = &QuicConnection::get_conn_from_ref;
+	ref_impl->session = s.get();
+	s->conn_ref = &ref_impl->ref;
+	SSL_set_app_data(s->ssl, &ref_impl->ref);
+
+	// Connection IDs
+	ngtcp2_cid scid, dcid;
+	scid.datalen = 8;
+	rand_bytes(scid.data, scid.datalen);
+	dcid.datalen = 18;
+	rand_bytes(dcid.data, dcid.datalen);
+	s->scid.assign(scid.data, scid.data + scid.datalen);
+
+	struct sockaddr_storage remote_ss;
+	socklen_t remote_slen = to_sockaddr(remote, &remote_ss);
+
+	ngtcp2_path path;
+	path.local.addr = reinterpret_cast<ngtcp2_sockaddr *>(&m_local_ss);
+	path.local.addrlen = m_local_slen;
+	path.remote.addr = reinterpret_cast<ngtcp2_sockaddr *>(&remote_ss);
+	path.remote.addrlen = remote_slen;
+	path.user_data = nullptr;
+
+	ngtcp2_settings settings;
+	make_default_settings(settings);
+
+	ngtcp2_transport_params params;
+	make_transport_params(params);
+
+	int rv = ngtcp2_conn_client_new(&s->conn, &dcid, &scid, &path,
+		NGTCP2_PROTO_VER_V1, &client_callbacks(), &settings, &params,
+		nullptr, s.get());
+	if (rv != 0) {
+		throw ConnectionException(
+			(std::string("ngtcp2_conn_client_new: ") + ngtcp2_strerror(rv)).c_str());
+	}
+	ngtcp2_conn_set_tls_native_handle(s->conn, s->ossl_ctx);
+	return s;
+}
+
+void QuicConnection::Connect(Address address)
+{
+	// We currently don't allow connecting to an IP address without a pinned certificate.
+	// If we didn't catch the case here, it would throw a somewhat ambiguous ERR_CRYPTO
+	if (address.isNumericHostName() && !address.hasPinnedCertSha256()) {
+		throw ConnectionException(
+			"A numeric IP target requires a certificate fingerprint pin. Use "
+			"'host:port+<base64-sha256>' (paste the line printed by the server on "
+			"startup), or connect by hostname for validation against the system CA store.");
+	}
+
+	std::lock_guard<std::mutex> lk(m_mutex);
+	m_connecting = true;
+
+	m_socket_fd = open_udp_socket(address.isIPv6());
+
+	// Bind to ephemeral local port
+	struct sockaddr_storage local_ss;
+	std::memset(&local_ss, 0, sizeof(local_ss));
+	socklen_t local_slen;
+	if (address.isIPv6()) {
+		auto *sin6 = reinterpret_cast<struct sockaddr_in6 *>(&local_ss);
+		sin6->sin6_family = AF_INET6;
+		sin6->sin6_port = 0;
+		local_slen = sizeof(*sin6);
+	} else {
+		auto *sin = reinterpret_cast<struct sockaddr_in *>(&local_ss);
+		sin->sin_family = AF_INET;
+		sin->sin_port = 0;
+		local_slen = sizeof(*sin);
+	}
+	if (::bind(m_socket_fd, reinterpret_cast<struct sockaddr *>(&local_ss),
+			local_slen) < 0) {
+		::close(m_socket_fd);
+		m_socket_fd = -1;
+		throw ConnectionBindFailed("bind() of client socket failed");
+	}
+
+	cacheLocalSockaddr();
+
+	auto session = makeClientSession(address);
+	session->peer_id = PEER_ID_SERVER;
+	m_local_peer_id = PEER_ID_SERVER;
+
+	auto *raw = session.get();
+	m_sessions[PEER_ID_SERVER] = std::move(session);
+
+	writeAndSendPackets(*raw);
+}
+
+bool QuicConnection::Connected()
+{
+	std::lock_guard<std::mutex> lk(m_mutex);
+	auto it = m_sessions.find(PEER_ID_SERVER);
+	return it != m_sessions.end() && it->second->handshake_completed;
+}
+
+void QuicConnection::writeConnectionClose(QuicSession &s)
+{
+	if (!s.conn || m_socket_fd < 0 || m_local_slen == 0)
+		return;
+
+	uint8_t buf[NGTCP2_MAX_UDP_PAYLOAD_SIZE];
+	struct sockaddr_storage remote_ss;
+	socklen_t remote_slen = to_sockaddr(s.remote, &remote_ss);
+
+	ngtcp2_path_storage ps;
+	ngtcp2_path_storage_init(&ps,
+		reinterpret_cast<ngtcp2_sockaddr *>(&m_local_ss), m_local_slen,
+		reinterpret_cast<ngtcp2_sockaddr *>(&remote_ss), remote_slen,
+		nullptr);
+
+	ngtcp2_pkt_info pi;
+	ngtcp2_ccerr ccerr;
+	ngtcp2_ccerr_default(&ccerr);
+	ngtcp2_ssize n = ngtcp2_conn_write_connection_close(s.conn, &ps.path,
+		&pi, buf, sizeof(buf), &ccerr, timestamp_ns());
+	if (n > 0) {
+		(void)::sendto(m_socket_fd, buf, n, 0,
+			reinterpret_cast<struct sockaddr *>(&remote_ss), remote_slen);
+	}
+}
+
+void QuicConnection::Disconnect()
+{
+	// Move sessions out of the map under the lock, then notify the handler and free
+	// them with the lock released. (We need to do this because PeerHandler could
+	// re-enter QuicConnection e.g. via DeleteClient and might need the mutex.)
+	std::map<session_t, std::unique_ptr<QuicSession>> drained;
+	{
+		std::lock_guard<std::mutex> lk(m_mutex);
+		// Send a CONNECTION_CLOSE for each live session before tearing it down.
+		// Without this the other side would have to wait until the idle timeout.
+		for (auto &kv : m_sessions)
+			writeConnectionClose(*kv.second);
+		drained.swap(m_sessions);
+	}
+	for (auto &kv : drained) {
+		if (m_handler && kv.second->peer_added_emitted) {
+			QuicPeer p(kv.second->peer_id, kv.second->remote);
+			m_handler->deletingPeer(&p, false);
+		}
+	}
+	drained.clear();
+}
+
+void QuicConnection::DisconnectPeer(session_t peer_id)
+{
+	std::lock_guard<std::mutex> lk(m_mutex);
+	auto it = m_sessions.find(peer_id);
+	if (it == m_sessions.end())
+		throw PeerNotFoundException("Peer not found");
+
+	// Send the CONNECTION_CLOSE frame to the peer
+	writeConnectionClose(*it->second);
+
+	// We mark the session as draining. reapDeadSessions() will get called in stepIO()
+	it->second->draining = true;
+	// This is an explicit disconnection
+	it->second->timed_out = false;
+}
+
+Address QuicConnection::GetPeerAddress(session_t peer_id)
+{
+	std::lock_guard<std::mutex> lk(m_mutex);
+	auto it = m_sessions.find(peer_id);
+	if (it == m_sessions.end())
+		throw PeerNotFoundException("Peer not found");
+	return it->second->remote;
+}
+
+void QuicConnection::writeAndSendPackets(QuicSession &s)
+{
+	if (!s.conn || s.draining || m_local_slen == 0)
+		return;
+
+	uint8_t buf[NGTCP2_MAX_UDP_PAYLOAD_SIZE];
+	struct sockaddr_storage remote_ss;
+	socklen_t remote_slen = to_sockaddr(s.remote, &remote_ss);
+
+	ngtcp2_path_storage ps;
+	ngtcp2_path_storage_init(&ps,
+		reinterpret_cast<ngtcp2_sockaddr *>(&m_local_ss), m_local_slen,
+		reinterpret_cast<ngtcp2_sockaddr *>(&remote_ss), remote_slen, nullptr);
+
+	for (;;) {
+		ngtcp2_pkt_info pi;
+		ngtcp2_ssize ndatalen = 0;
+		int64_t stream_id = -1;
+		uint32_t flags = NGTCP2_WRITE_STREAM_FLAG_MORE;
+		ngtcp2_vec vec_storage;
+		const ngtcp2_vec *vecs = nullptr;
+		size_t vec_count = 0;
+
+		// Open the bidi stream on the client after the handshake is complete
+		if (m_connecting && s.handshake_completed && s.app_stream_id < 0) {
+			int64_t sid;
+			int rv = ngtcp2_conn_open_bidi_stream(s.conn, &sid, &s);
+			if (rv == 0) {
+				s.app_stream_id = sid;
+				s.stream_open_sent = true;
+			}
+		}
+
+		size_t unread = s.tx_unread_size();
+		if (s.app_stream_id >= 0 && unread > 0) {
+			vec_storage.base = const_cast<uint8_t *>(s.tx_unread());
+			vec_storage.len = unread;
+			vecs = &vec_storage;
+			vec_count = 1;
+			stream_id = s.app_stream_id;
+		} else {
+			flags = 0;
+		}
+
+		ngtcp2_ssize n = ngtcp2_conn_writev_stream(s.conn, &ps.path, &pi,
+			buf, sizeof(buf), &ndatalen, flags, stream_id, vecs, vec_count,
+			timestamp_ns());
+
+		if (n == 0)
+			break;
+		if (n == NGTCP2_ERR_WRITE_MORE) {
+			if (ndatalen > 0)
+				s.tx_advance(static_cast<size_t>(ndatalen));
+			continue;
+		}
+		if (n < 0) {
+			fprintf(stderr, "QUIC: writev_stream error: %s\n",
+				ngtcp2_strerror(static_cast<int>(n)));
+			s.draining = true;
+			return;
+		}
+
+		if (ndatalen > 0)
+			s.tx_advance(static_cast<size_t>(ndatalen));
+
+		// Send the packet on the wire
+		ssize_t sent = ::sendto(m_socket_fd, buf, n, 0,
+			reinterpret_cast<struct sockaddr *>(&remote_ss), remote_slen);
+		if (sent < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+			fprintf(stderr, "QUIC: sendto failed: %s\n", std::strerror(errno));
+	}
+
+	ngtcp2_conn_update_pkt_tx_time(s.conn, timestamp_ns());
+}
+
+int QuicConnection::handleIncomingPacket(QuicSession &s, const uint8_t *pkt, size_t pktlen)
+{
+	struct sockaddr_storage remote_ss;
+	socklen_t remote_slen = to_sockaddr(s.remote, &remote_ss);
+
+	ngtcp2_path path;
+	path.local.addr = reinterpret_cast<ngtcp2_sockaddr *>(&m_local_ss);
+	path.local.addrlen = m_local_slen;
+	path.remote.addr = reinterpret_cast<ngtcp2_sockaddr *>(&remote_ss);
+	path.remote.addrlen = remote_slen;
+	path.user_data = nullptr;
+
+	ngtcp2_pkt_info pi;
+	std::memset(&pi, 0, sizeof(pi));
+
+	int rv = ngtcp2_conn_read_pkt(s.conn, &path, &pi, pkt, pktlen,
+		timestamp_ns());
+	if (rv != 0) {
+		if (rv == NGTCP2_ERR_DRAINING || rv == NGTCP2_ERR_CLOSING) {
+			s.draining = true;
+			return rv;
+		}
+		fprintf(stderr, "QUIC: read_pkt error: %s\n", ngtcp2_strerror(rv));
+	}
+	return rv;
+}
+
+QuicSession *QuicConnection::getOrCreateServerSession(const Address &remote,
+	const uint8_t *pkt, size_t pktlen)
+{
+	for (auto &kv : m_sessions) {
+		if (kv.second->remote == remote)
+			return kv.second.get();
+	}
+	auto s = makeServerSession(remote, pkt, pktlen);
+	if (!s)
+		return nullptr;
+	session_t pid = m_next_server_peer_id++;
+	s->peer_id = pid;
+	auto *raw = s.get();
+	m_sessions.emplace(pid, std::move(s));
+	return raw;
+}
+
+std::unique_ptr<QuicSession> QuicConnection::makeServerSession(
+	const Address &remote, const uint8_t *initial_pkt, size_t initial_pktlen)
+{
+	ngtcp2_pkt_hd hd;
+	int rv = ngtcp2_accept(&hd, initial_pkt, initial_pktlen);
+	if (rv != 0)
+		return nullptr;
+
+	auto s = std::make_unique<QuicSession>();
+	s->remote = remote;
+
+	s->ssl = SSL_new(m_server_tls->get());
+	if (!s->ssl)
+		throw ConnectionException("SSL_new (server) failed");
+	SSL_set_accept_state(s->ssl);
+	if (ngtcp2_crypto_ossl_configure_server_session(s->ssl) != 0)
+		throw ConnectionException("configure_server_session failed");
+	if (ngtcp2_crypto_ossl_ctx_new(&s->ossl_ctx, s->ssl) != 0)
+		throw ConnectionException("ngtcp2_crypto_ossl_ctx_new (server) failed");
+
+	auto *ref_impl = new ConnRefImpl;
+	std::memset(ref_impl, 0, sizeof(*ref_impl));
+	ref_impl->ref.get_conn = &QuicConnection::get_conn_from_ref;
+	ref_impl->session = s.get();
+	s->conn_ref = &ref_impl->ref;
+	SSL_set_app_data(s->ssl, &ref_impl->ref);
+
+	ngtcp2_cid scid;
+	scid.datalen = 8;
+	rand_bytes(scid.data, scid.datalen);
+	s->scid.assign(scid.data, scid.data + scid.datalen);
+
+	struct sockaddr_storage remote_ss;
+	socklen_t remote_slen = to_sockaddr(remote, &remote_ss);
+
+	ngtcp2_path path;
+	path.local.addr = reinterpret_cast<ngtcp2_sockaddr *>(&m_local_ss);
+	path.local.addrlen = m_local_slen;
+	path.remote.addr = reinterpret_cast<ngtcp2_sockaddr *>(&remote_ss);
+	path.remote.addrlen = remote_slen;
+	path.user_data = nullptr;
+
+	ngtcp2_settings settings;
+	make_default_settings(settings);
+	settings.token = nullptr;
+	settings.tokenlen = 0;
+
+	ngtcp2_transport_params params;
+	make_transport_params(params);
+	params.original_dcid = hd.dcid;
+	params.original_dcid_present = 1;
+
+	rv = ngtcp2_conn_server_new(&s->conn, &hd.scid, &scid, &path,
+		hd.version, &server_callbacks(), &settings, &params, nullptr, s.get());
+	if (rv != 0) {
+		throw ConnectionException(
+			(std::string("ngtcp2_conn_server_new: ") + ngtcp2_strerror(rv)).c_str());
+	}
+	ngtcp2_conn_set_tls_native_handle(s->conn, s->ossl_ctx);
+	return s;
+}
+
+void QuicConnection::drainSocket()
+{
+	// Defer peer callbacks until after we drop m_mutex so the
+	// PeerHandler can safely call back into the connection
+	struct PendingPeerAdded {
+		session_t pid;
+		Address remote;
+	};
+	std::vector<PendingPeerAdded> pending_added;
+
+	uint8_t buf[2048];
+	for (;;) {
+		struct sockaddr_storage from_ss;
+		socklen_t from_slen = sizeof(from_ss);
+		ssize_t n = ::recvfrom(m_socket_fd, buf, sizeof(buf), 0,
+			reinterpret_cast<struct sockaddr *>(&from_ss), &from_slen);
+		if (n < 0) {
+			if (errno == EAGAIN || errno == EWOULDBLOCK)
+				break;
+			fprintf(stderr, "QUIC: recvfrom failed: %s\n", std::strerror(errno));
+			break;
+		}
+		if (n == 0)
+			continue;
+
+		Address remote = from_sockaddr(&from_ss);
+		size_t plen = static_cast<size_t>(n);
+
+		QuicSession *target = nullptr;
+		if (m_serving) {
+			target = getOrCreateServerSession(remote, buf, plen);
+			if (!target) {
+				fprintf(stderr, "QUIC: dropping packet from unknown peer\n");
+				continue;
+			}
+			if (m_handler && !target->peer_added_emitted) {
+				pending_added.push_back({target->peer_id, target->remote});
+				target->peer_added_emitted = true;
+			}
+		} else {
+			auto it = m_sessions.find(PEER_ID_SERVER);
+			if (it == m_sessions.end())
+				continue;
+			target = it->second.get();
+		}
+
+		handleIncomingPacket(*target, buf, plen);
+		extractFrames(*target);
+
+		if (!m_serving && m_handler && target->handshake_completed
+				&& !target->peer_added_emitted) {
+			pending_added.push_back({target->peer_id, target->remote});
+			target->peer_added_emitted = true;
+		}
+	}
+
+	if (m_handler && !pending_added.empty()) {
+		m_mutex.unlock();
+		for (auto &p : pending_added) {
+			QuicPeer peer(p.pid, p.remote);
+			m_handler->peerAdded(&peer);
+		}
+		m_mutex.lock();
+	}
+}
+
+void QuicConnection::flushAllSessions()
+{
+	for (auto &kv : m_sessions)
+		writeAndSendPackets(*kv.second);
+}
+
+void QuicConnection::handleAllExpiries()
+{
+	const uint64_t now = timestamp_ns();
+	for (auto &kv : m_sessions) {
+		QuicSession &s = *kv.second;
+		if (!s.conn || s.draining)
+			continue;
+
+		ngtcp2_tstamp expiry = ngtcp2_conn_get_expiry(s.conn);
+		if (expiry == UINT64_MAX || expiry > now)
+			continue;
+
+		int rv = ngtcp2_conn_handle_expiry(s.conn, now);
+		if (rv != 0) {
+			// IDLE_CLOSE / DRAINING / CLOSING all end the session
+			s.draining = true;
+			s.timed_out = (rv == NGTCP2_ERR_IDLE_CLOSE);
+		}
+	}
+}
+
+// Removes sessions marked as closing or draining by ngtcp2 and returns them in a vector
+// The caller must release m_mutex before invoking any m_handler callbacks
+std::vector<QuicConnection::PendingDelete> QuicConnection::reapDeadSessions()
+{
+	std::vector<PendingDelete> reaped;
+	for (auto it = m_sessions.begin(); it != m_sessions.end();) {
+		QuicSession *s = it->second.get();
+		bool dead = !s->conn
+			|| s->draining
+			|| ngtcp2_conn_in_closing_period(s->conn)
+			|| ngtcp2_conn_in_draining_period(s->conn);
+		if (dead) {
+			PendingDelete pd;
+			pd.pid = s->peer_id;
+			pd.remote = s->remote;
+			pd.timed_out = s->timed_out;
+			pd.emit_callback = m_handler && s->peer_added_emitted;
+			pd.session = std::move(it->second);
+			reaped.push_back(std::move(pd));
+			it = m_sessions.erase(it);
+		} else {
+			++it;
+		}
+	}
+	// If the map is now empty, we can recycle peer IDs from 2 again
+	if (m_serving && m_sessions.empty())
+		m_next_server_peer_id = 2;
+	return reaped;
+}
+
+bool QuicConnection::stepIO(int timeout_ms)
+{
+	struct pollfd pfd;
+	pfd.fd = m_socket_fd;
+	pfd.events = POLLIN;
+	pfd.revents = 0;
+	int rc = ::poll(&pfd, 1, timeout_ms);
+	if (rc < 0)
+		// EINTR, etc.
+		return false;
+
+	if (pfd.revents & POLLIN)
+		drainSocket();
+
+	// Run ngtcp2's internal timers for closing/draining sessions
+	handleAllExpiries();
+
+	// Flush any pending bytes
+	flushAllSessions();
+
+	// Reap sessions that ngtcp2 considers dead
+	auto reaped = reapDeadSessions();
+	if (!reaped.empty() && m_handler) {
+		m_mutex.unlock();
+		for (auto &pd : reaped) {
+			if (pd.emit_callback) {
+				QuicPeer p(pd.pid, pd.remote);
+				m_handler->deletingPeer(&p, pd.timed_out);
+			}
+		}
+		reaped.clear();
+		m_mutex.lock();
+	}
+
+	// Return true if something arrived to process
+	for (auto &kv : m_sessions) {
+		if (!kv.second->rx_frames.empty())
+			return true;
+	}
+	return false;
+}
+
+bool QuicConnection::ReceiveTimeoutMs(NetworkPacket *pkt, u32 timeout_ms)
+{
+	std::unique_lock<std::mutex> lk(m_mutex);
+
+	auto next_frame = [&]() -> bool {
+		for (auto &kv : m_sessions) {
+			if (!kv.second->rx_frames.empty()) {
+				auto frame = std::move(kv.second->rx_frames.front());
+				kv.second->rx_frames.pop_front();
+				const auto &payload = frame.second;
+				if (payload.size() < 2)
+					return false;
+				pkt->putRawPacket(payload.data(),
+					static_cast<u32>(payload.size()), kv.first);
+				return true;
+			}
+		}
+		return false;
+	};
+
+	if (next_frame())
+		return true;
+
+	// I/O loop until either we have a frame or the timeout expires
+	auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+	for (;;) {
+		auto now = std::chrono::steady_clock::now();
+		int remaining_ms = (timeout_ms == 0) ? 0
+			: static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(
+				deadline - now).count());
+		if (remaining_ms < 0)
+			remaining_ms = 0;
+
+		stepIO(remaining_ms);
+
+		if (next_frame())
+			return true;
+		if (timeout_ms == 0 || std::chrono::steady_clock::now() >= deadline)
+			return false;
+	}
+}
+
+void QuicConnection::Send(session_t peer_id, u8 channelnum, NetworkPacket *pkt, bool reliable)
+{
+	std::lock_guard<std::mutex> lk(m_mutex);
+	auto it = m_sessions.find(peer_id);
+	if (it == m_sessions.end())
+		throw PeerNotFoundException("Peer not found");
+
+	auto buf = pkt->oldForgePacket();
+	std::string_view sv = static_cast<std::string_view>(buf);
+	it->second->send_app_frame(channelnum, reliable,
+		reinterpret_cast<const uint8_t *>(sv.data()), sv.size());
+
+	writeAndSendPackets(*it->second);
+}
+
+IConnection *createQUIC(float timeout, bool ipv6, PeerHandler *handler)
+{
+	return new QuicConnection(timeout, ipv6, handler);
+}
+
+} // namespace con

--- a/src/network/quic_connection.h
+++ b/src/network/quic_connection.h
@@ -1,0 +1,187 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <ngtcp2/ngtcp2.h>
+
+#include <sys/socket.h> // sockaddr_storage, socklen_t
+
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "network/address.h"
+#include "network/connection.h"
+#include "network/networkexceptions.h"
+#include "network/networkpacket.h"
+#include "network/peerhandler.h"
+
+struct ngtcp2_crypto_conn_ref;
+struct ngtcp2_crypto_ossl_ctx;
+struct ssl_st;
+typedef struct ssl_st SSL;
+
+namespace con
+{
+
+class TlsClientContext;
+class TlsServerContext;
+
+/*
+ * The Luanti NetworkPackets are put into the QUIC stream like this:
+ * [u8 channel] [u8 reliable_flag] [u32 length] [u8[length] payload]
+ */
+constexpr size_t QUIC_FRAME_HEADER_LEN = 1 + 1 + 4;
+constexpr u32 QUIC_FRAME_MAX_LEN = 16 * 1024 * 1024;
+
+class QuicPeer final : public IPeer
+{
+public:
+	QuicPeer(session_t peer_id, const Address &address)
+		: IPeer(peer_id), m_address(address) {}
+	const Address &getAddress() const override { return m_address; }
+	void setAddress(const Address &a) { m_address = a; }
+private:
+	Address m_address;
+};
+
+struct QuicSession {
+	ngtcp2_conn *conn = nullptr;
+	SSL *ssl = nullptr;
+	ngtcp2_crypto_ossl_ctx *ossl_ctx = nullptr;
+	ngtcp2_crypto_conn_ref *conn_ref = nullptr;
+
+	int64_t app_stream_id = -1;
+	bool stream_open_sent = false;
+	bool handshake_completed = false;
+	bool peer_added_emitted = false;
+	bool draining = false;
+	bool timed_out = false;
+
+	// Inbound stream bytes
+	std::vector<uint8_t> rx_buffer;
+	size_t rx_head = 0;
+	// Outbound stream bytes
+	std::vector<uint8_t> tx_buffer;
+	size_t tx_head = 0;
+	std::deque<std::pair<u8, std::vector<uint8_t>>> rx_frames;
+
+	Address remote;
+	session_t peer_id = 0;
+
+	std::vector<uint8_t> scid;
+	bool destroyed = false;
+
+	~QuicSession();
+	void send_app_frame(u8 channel, bool reliable, const uint8_t *data, size_t len);
+
+	// Pointer to the unconsumed portion of tx_buffer
+	const uint8_t *tx_unread() const { return tx_buffer.data() + tx_head; }
+	size_t tx_unread_size() const { return tx_buffer.size() - tx_head; }
+	// Mark n bytes as consumed
+	void tx_advance(size_t n);
+};
+
+class QuicConnection final : public IConnection
+{
+public:
+	QuicConnection(float timeout, bool ipv6, PeerHandler *handler);
+	~QuicConnection() override;
+
+	void Serve(Address bind_addr) override;
+	void Connect(Address address) override;
+	bool Connected() override;
+	void Disconnect() override;
+	void DisconnectPeer(session_t peer_id) override;
+
+	bool ReceiveTimeoutMs(NetworkPacket *pkt, u32 timeout_ms) override;
+	void Send(session_t peer_id, u8 channelnum, NetworkPacket *pkt,
+		bool reliable) override;
+
+	session_t GetPeerID() const override { return m_local_peer_id; }
+	Address GetPeerAddress(session_t peer_id) override;
+	float getPeerStat(session_t, rtt_stat_type) override { return -1.0f; }
+	float getLocalStat(rate_stat_type) override { return -1.0f; }
+
+	void setServerCertificates(const std::string &cert_pem_path,
+		const std::string &key_pem_path);
+
+	// ngtcp2 callbacks must be reachable from extern "C" trampolines.
+	static int cb_recv_stream_data(ngtcp2_conn *conn, uint32_t flags,
+		int64_t stream_id, uint64_t offset, const uint8_t *data,
+		size_t datalen, void *user_data, void *stream_user_data);
+	static int cb_handshake_completed(ngtcp2_conn *conn, void *user_data);
+	static int cb_stream_open(ngtcp2_conn *conn, int64_t stream_id,
+		void *user_data);
+	static int cb_stream_close(ngtcp2_conn *conn, uint32_t flags,
+		int64_t stream_id, uint64_t app_error_code, void *user_data,
+		void *stream_user_data);
+	static int cb_acked_stream_data_offset(ngtcp2_conn *conn,
+		int64_t stream_id, uint64_t offset, uint64_t datalen,
+		void *user_data, void *stream_user_data);
+	static int cb_get_new_connection_id(ngtcp2_conn *conn, ngtcp2_cid *cid,
+		uint8_t *token, size_t cidlen, void *user_data);
+	static void cb_rand(uint8_t *dest, size_t destlen,
+		const ngtcp2_rand_ctx *rand_ctx);
+
+	static ngtcp2_conn *get_conn_from_ref(ngtcp2_crypto_conn_ref *ref);
+
+private:
+	struct PendingDelete {
+		session_t pid = 0;
+		Address remote;
+		bool timed_out = false;
+		bool emit_callback = false;
+		std::unique_ptr<QuicSession> session;
+	};
+
+	bool stepIO(int timeout_ms);
+	void drainSocket();
+	void flushAllSessions();
+	void handleAllExpiries();
+	std::vector<PendingDelete> reapDeadSessions();
+
+	QuicSession *getOrCreateServerSession(const Address &remote,
+		const uint8_t *pkt, size_t pktlen);
+	std::unique_ptr<QuicSession> makeServerSession(const Address &remote,
+		const uint8_t *initial_pkt, size_t initial_pktlen);
+	std::unique_ptr<QuicSession> makeClientSession(const Address &remote);
+
+	int handleIncomingPacket(QuicSession &s, const uint8_t *pkt, size_t pktlen);
+	void writeAndSendPackets(QuicSession &s);
+	void extractFrames(QuicSession &s);
+	void writeConnectionClose(QuicSession &s);
+	void cacheLocalSockaddr();
+
+	PeerHandler *m_handler;
+	float m_timeout;
+	bool m_ipv6;
+
+	int m_socket_fd = -1;
+	bool m_serving = false;
+	bool m_connecting = false;
+	Address m_bind_addr;
+	Address m_local_addr_observed;
+	// Cached form of the local address for ngtcp2_path and sendto
+	struct sockaddr_storage m_local_ss{};
+	socklen_t m_local_slen = 0;
+	session_t m_local_peer_id = 0;
+
+	std::unique_ptr<TlsClientContext> m_client_tls;
+	std::unique_ptr<TlsServerContext> m_server_tls;
+	std::string m_server_cert_pem;
+	std::string m_server_key_pem;
+
+	std::map<session_t, std::unique_ptr<QuicSession>> m_sessions;
+	session_t m_next_server_peer_id = 2;
+	std::mutex m_mutex;
+};
+
+IConnection *createQUIC(float timeout, bool ipv6, PeerHandler *handler);
+
+} // namespace con

--- a/src/network/quic_tls.cpp
+++ b/src/network/quic_tls.cpp
@@ -1,0 +1,379 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "network/quic_tls.h"
+
+#include <ngtcp2/ngtcp2_crypto_ossl.h>
+
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
+
+#include "util/base64.h"
+
+namespace con
+{
+
+std::string compute_cert_digest(X509 *cert)
+{
+	if (!cert)
+		return {};
+
+	// X509_digest computes the digest over the DER encoding directly
+	std::string out(SHA256_DIGEST_LENGTH, '\0');
+	unsigned int outlen = 0;
+	if (!X509_digest(cert, EVP_sha256(),
+			reinterpret_cast<unsigned char *>(out.data()), &outlen)) {
+		return {};
+	}
+	return out;
+}
+
+std::string hex_encode(const std::string &raw)
+{
+	static const char hex[] = "0123456789abcdef";
+	std::string out;
+	out.reserve(raw.size() * 2);
+	for (unsigned char b : raw) {
+		out.push_back(hex[b >> 4]);
+		out.push_back(hex[b & 0xf]);
+	}
+	return out;
+}
+
+namespace {
+
+// Stateless deleter functors for the OpenSSL objects
+template <auto F>
+struct OsslDel {
+	template <typename T> void operator()(T *p) const {
+		if (p) {
+			F(p);
+		}
+	}
+};
+
+using X509Ptr = std::unique_ptr<X509, OsslDel<X509_free>>;
+using EVPKEYPtr = std::unique_ptr<EVP_PKEY, OsslDel<EVP_PKEY_free>>;
+using BIOPtr = std::unique_ptr<BIO, OsslDel<BIO_free>>;
+
+bool is_numeric_host(const std::string &name)
+{
+	for (char c : name) {
+		if (!((c >= '0' && c <= '9') || c == '.' || c == ':'))
+			return false;
+	}
+	return !name.empty();
+}
+
+bool add_ext_by_nid(X509 *cert, int nid, const char *value)
+{
+	X509V3_CTX ctx;
+	X509V3_set_ctx_nodb(&ctx);
+	X509V3_set_ctx(&ctx, cert, cert, nullptr, nullptr, 0);
+	X509_EXTENSION *ext = X509V3_EXT_conf_nid(nullptr, &ctx, nid, value);
+	if (!ext)
+		return false;
+	X509_add_ext(cert, ext, -1);
+	X509_EXTENSION_free(ext);
+	return true;
+}
+
+} // namespace
+
+std::string compute_pem_fingerprint_b64(const std::string &cert_pem_path)
+{
+	BIOPtr bio(BIO_new_file(cert_pem_path.c_str(), "r"));
+	if (!bio)
+		return {};
+	X509Ptr cert(PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
+	if (!cert)
+		return {};
+	std::string raw = compute_cert_digest(cert.get());
+	if (raw.empty())
+		return {};
+	return base64_encode(raw);
+}
+
+// Generates a Ed25519 self-signed certificate valid for 10 years
+bool generate_self_signed_cert(const std::string &cert_pem_path,
+	const std::string &key_pem_path,
+	const std::string &bind_hostname)
+{
+	EVPKEYPtr pkey(EVP_PKEY_Q_keygen(nullptr, nullptr, "ED25519"));
+	if (!pkey)
+		return false;
+
+	X509Ptr cert(X509_new());
+	if (!cert)
+		return false;
+
+	// X509 version 3 (0x2)
+	X509_set_version(cert.get(), 2);
+
+	// This is a number that is unique per CA. Since it's self-signed, we just
+	// choose a random 64-bit positive number.
+	int64_t serial = 0;
+	if (RAND_bytes(reinterpret_cast<unsigned char *>(&serial), sizeof(serial)) != 1) {
+		return false;
+	}
+	if (serial < 0)
+		serial = -serial;
+	if (!ASN1_INTEGER_set_int64(X509_get_serialNumber(cert.get()), serial))
+		return false;
+
+	X509_gmtime_adj(X509_getm_notBefore(cert.get()), 0);
+	// Certificate expires 10 years from now
+	X509_gmtime_adj(X509_getm_notAfter(cert.get()), 10L * 365 * 24 * 3600);
+
+	if (X509_set_pubkey(cert.get(), pkey.get()) != 1)
+		return false;
+
+	X509_NAME *name = X509_get_subject_name(cert.get());
+	X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+		reinterpret_cast<const unsigned char *>("luanti-quic"), -1, -1, 0);
+	// This is just self-signed
+	X509_set_issuer_name(cert.get(), name);
+
+	// Set required basic extensions
+	add_ext_by_nid(cert.get(), NID_basic_constraints, "critical,CA:FALSE");
+	add_ext_by_nid(cert.get(), NID_key_usage, "critical,digitalSignature");
+	add_ext_by_nid(cert.get(), NID_ext_key_usage, "serverAuth");
+	add_ext_by_nid(cert.get(), NID_subject_key_identifier, "hash");
+
+	// Build a single SAN value with all entries
+	std::string san = "DNS:localhost,IP:127.0.0.1,IP:0:0:0:0:0:0:0:1";
+	if (!bind_hostname.empty()
+			&& bind_hostname != "localhost"
+			&& bind_hostname != "127.0.0.1"
+			&& bind_hostname != "0.0.0.0"
+			&& bind_hostname != "::1"
+			&& bind_hostname != "::"
+			&& bind_hostname != "::0") {
+		san += is_numeric_host(bind_hostname) ? ",IP:" : ",DNS:";
+		san += bind_hostname;
+	}
+	add_ext_by_nid(cert.get(), NID_subject_alt_name, san.c_str());
+
+	// Ed25519 uses EdDSA, which gets nullptr for the digest
+	if (X509_sign(cert.get(), pkey.get(), nullptr) == 0) {
+		ERR_print_errors_fp(stderr);
+		return false;
+	}
+
+	// Write the cert and private key to disk
+	{
+		BIOPtr bio(BIO_new_file(cert_pem_path.c_str(), "w"));
+		if (!bio || PEM_write_bio_X509(bio.get(), cert.get()) != 1)
+			return false;
+	}
+	{
+		BIOPtr bio(BIO_new_file(key_pem_path.c_str(), "w"));
+		if (!bio || PEM_write_bio_PKCS8PrivateKey(bio.get(), pkey.get(),
+				nullptr, nullptr, 0, nullptr, nullptr) != 1) {
+			return false;
+		}
+	}
+	return true;
+}
+
+namespace {
+
+// We attach a VerifyConfig to the SSL object using SSL_set_ex_data.
+// To do that, we need to register an index with OpenSSL.
+int g_verify_ex_index = -1;
+
+void verify_cfg_free(void *, void *ptr, CRYPTO_EX_DATA *, int, long, void *)
+{
+	delete static_cast<VerifyConfig *>(ptr);
+}
+
+int verify_callback(int preverify_ok, X509_STORE_CTX *store_ctx)
+{
+	SSL *ssl = static_cast<SSL *>(X509_STORE_CTX_get_ex_data(store_ctx,
+		SSL_get_ex_data_X509_STORE_CTX_idx()));
+	if (!ssl)
+		return 0;
+
+	auto *cfg = static_cast<VerifyConfig *>(SSL_get_ex_data(ssl, g_verify_ex_index));
+	if (!cfg)
+		return 0;
+
+	// Refuse numeric IP addresses that didn't supply a pinned certificate
+	// This is mostly so we can print a more friendly error message
+	if (cfg->numeric_no_pin) {
+		fprintf(stderr, "QUIC: Connecting to an IP address without a domain requires a "
+			"certificate fingerprint. You must add the +<base64 cert fingerprint> to "
+			"the address when connecting.\n");
+		return 0;
+	}
+
+	if (!cfg->pinned_sha256_raw.empty()) {
+		// Pinned fingerprint mode: we only have to check the leaf (depth 0)
+		if (X509_STORE_CTX_get_error_depth(store_ctx) != 0)
+			return 1;
+
+		X509 *leaf = X509_STORE_CTX_get_current_cert(store_ctx);
+		std::string actual = compute_cert_digest(leaf);
+		if (actual != cfg->pinned_sha256_raw) {
+			fprintf(stderr, "QUIC: pinned SHA-256 mismatch\n"
+				"  expected: %s\n"
+				"  got:      %s\n",
+				hex_encode(cfg->pinned_sha256_raw).c_str(),
+				hex_encode(actual).c_str());
+			return 0;
+		}
+		return 1;
+	}
+
+	// Web PKI mode: rely on the system trust store and hostname verification
+	return preverify_ok;
+}
+
+} // namespace
+
+TlsClientContext::TlsClientContext() = default;
+
+TlsClientContext::~TlsClientContext()
+{
+	if (m_ctx)
+		SSL_CTX_free(m_ctx);
+}
+
+bool TlsClientContext::init()
+{
+	if (g_verify_ex_index < 0) {
+		// Calls verify_cfg_free when the SSL object is freed
+		// We only need to register this index once throughout the application lifetime
+		g_verify_ex_index = SSL_get_ex_new_index(0, const_cast<char *>("luanti.verify"),
+			nullptr, nullptr, verify_cfg_free);
+		if (g_verify_ex_index < 0)
+			return false;
+	}
+
+	m_ctx = SSL_CTX_new(TLS_client_method());
+	if (!m_ctx)
+		return false;
+
+	SSL_CTX_set_min_proto_version(m_ctx, TLS1_3_VERSION);
+	SSL_CTX_set_max_proto_version(m_ctx, TLS1_3_VERSION);
+
+	// Load the system trust store for the Web PKI fallback path
+	if (!SSL_CTX_set_default_verify_paths(m_ctx)) {
+		// Not necessarily a fatal error, since pinned fingerprint mode doesn't need this
+		ERR_clear_error();
+	}
+
+	// We always request VERIFY_PEER and decide to accept or reject in our callback
+	SSL_CTX_set_verify(m_ctx, SSL_VERIFY_PEER, verify_callback);
+
+	return true;
+}
+
+bool TlsClientContext::configureSession(SSL *ssl, const VerifyConfig &config)
+{
+	// Allocate a heap copy which OpenSSL will free via verify_cfg_free when the
+	// SSL object is destroyed
+	auto cfg = std::make_unique<VerifyConfig>(config);
+	if (!SSL_set_ex_data(ssl, g_verify_ex_index, cfg.get()))
+		return false;
+	cfg.release();
+
+	if (SSL_set_alpn_protos(ssl, LUANTI_ALPN_WIRE, LUANTI_ALPN_WIRE_LEN) != 0)
+		return false;
+
+	// SNI and hostname for Web PKI verification (ignored when using a pinned cert)
+	if (!config.hostname.empty()) {
+		SSL_set_tlsext_host_name(ssl, config.hostname.c_str());
+		if (config.pinned_sha256_raw.empty() && !config.numeric_no_pin) {
+			SSL_set1_host(ssl, config.hostname.c_str());
+			SSL_set_hostflags(ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+		}
+	}
+
+	// SSL object must know it's a client before SSL_do_handshake() runs
+	SSL_set_connect_state(ssl);
+
+	// Hand control of the QUIC TLS record path to ngtcp2_crypto_ossl
+	return ngtcp2_crypto_ossl_configure_client_session(ssl) == 0;
+}
+
+TlsServerContext::TlsServerContext() = default;
+
+TlsServerContext::~TlsServerContext()
+{
+	if (m_ctx)
+		SSL_CTX_free(m_ctx);
+}
+
+namespace {
+
+// This is for selecting which protocol to use, via ALPN
+// We return the Luanti one if the client listed it, otherwise return error
+int alpn_select_cb(SSL *, const unsigned char **out, unsigned char *outlen,
+	const unsigned char *in, unsigned int inlen, void *)
+{
+	// The TLS wire format for ALPN is [length][protocol name...][length][protocol name...]
+	for (unsigned int i = 0; i + 1 < inlen;) {
+		// Read the protocol name length
+		unsigned char alen = in[i];
+		if (i + 1 + alen > inlen)
+			break;
+
+		// Check if this protocol name matches ours
+		if (alen == LUANTI_ALPN_LEN
+			&& memcmp(in + i + 1, LUANTI_ALPN, LUANTI_ALPN_LEN) == 0) {
+			*out = in + i + 1;
+			*outlen = alen;
+			return SSL_TLSEXT_ERR_OK;
+		}
+		i += 1 + alen;
+	}
+	return SSL_TLSEXT_ERR_ALERT_FATAL;
+}
+
+} // namespace
+
+bool TlsServerContext::init(const std::string &cert_pem_path, const std::string &key_pem_path)
+{
+	m_ctx = SSL_CTX_new(TLS_server_method());
+	if (!m_ctx)
+		return false;
+
+	SSL_CTX_set_min_proto_version(m_ctx, TLS1_3_VERSION);
+	SSL_CTX_set_max_proto_version(m_ctx, TLS1_3_VERSION);
+
+	if (SSL_CTX_use_certificate_chain_file(m_ctx, cert_pem_path.c_str()) != 1) {
+		ERR_print_errors_fp(stderr);
+		return false;
+	}
+	if (SSL_CTX_use_PrivateKey_file(m_ctx, key_pem_path.c_str(),
+			SSL_FILETYPE_PEM) != 1) {
+		ERR_print_errors_fp(stderr);
+		return false;
+	}
+	if (!SSL_CTX_check_private_key(m_ctx)) {
+		ERR_print_errors_fp(stderr);
+		return false;
+	}
+
+	SSL_CTX_set_alpn_select_cb(m_ctx, alpn_select_cb, nullptr);
+
+	return true;
+}
+
+} // namespace con

--- a/src/network/quic_tls.h
+++ b/src/network/quic_tls.h
@@ -1,0 +1,76 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+#include <memory>
+#include <string>
+
+namespace con
+{
+
+// Our own ALPN identifier
+constexpr const char *LUANTI_ALPN = "luanti";
+constexpr unsigned char LUANTI_ALPN_WIRE[] = {6, 'l', 'u', 'a', 'n', 't', 'i'};
+constexpr size_t LUANTI_ALPN_LEN = LUANTI_ALPN_WIRE[0];
+constexpr size_t LUANTI_ALPN_WIRE_LEN = sizeof(LUANTI_ALPN_WIRE);
+
+struct VerifyConfig {
+	// If non-empty, the certificate's SHA-256 fingerprint must equal this 32 byte raw hash
+	std::string pinned_sha256_raw;
+	// Hostname for SNI/Web PKI verification (when certificate pinning is not used)
+	std::string hostname;
+	// True when the address was a numeric IP but no certificate fingerprint was set
+	bool numeric_no_pin = false;
+};
+
+std::string compute_cert_digest(X509 *cert);
+std::string hex_encode(const std::string &raw);
+
+// Returns an empty string on failure
+std::string compute_pem_fingerprint_b64(const std::string &cert_pem_path);
+
+// Generate a new self-signed Ed25519 certificate and key pair, writing to
+// cert_pem_path and key_pem_path. The certificate has CN "luanti-quic"
+// and SubjectAltName entries for "localhost" and the bind hostname, if it's not empty.
+// Returns true on success.
+bool generate_self_signed_cert(const std::string &cert_pem_path,
+	const std::string &key_pem_path,
+	const std::string &bind_hostname = "");
+
+class TlsClientContext
+{
+public:
+	TlsClientContext();
+	~TlsClientContext();
+
+	// Returns true on success
+	bool init();
+
+	// Configure verification policy for a single connection
+	bool configureSession(SSL *ssl, const VerifyConfig &config);
+
+	SSL_CTX *get() const { return m_ctx; }
+
+private:
+	SSL_CTX *m_ctx = nullptr;
+};
+
+class TlsServerContext
+{
+public:
+	TlsServerContext();
+	~TlsServerContext();
+
+	// Loads a PEM-encoded certificate and private key
+	bool init(const std::string &cert_pem_path, const std::string &key_pem_path);
+
+	SSL_CTX *get() const { return m_ctx; }
+
+private:
+	SSL_CTX *m_ctx = nullptr;
+};
+
+} // namespace con

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -54,6 +54,10 @@
 
 // Network
 #include "network/connection.h"
+#ifdef USE_NGTCP2_QUIC
+#include "network/quic_connection.h"
+#include "network/quic_tls.h"
+#endif
 #include "network/networkexceptions.h"
 #include "network/networkpacket.h"
 #include "network/networkprotocol.h"
@@ -608,6 +612,11 @@ void Server::start()
 	// Stop thread if already running
 	m_thread->stop();
 
+#ifdef USE_NGTCP2_QUIC
+	// Set up the QUIC server certificate and private key
+	configureQuicServerCertificates();
+#endif
+
 	// Initialize connection
 	m_con->Serve(m_bind_addr);
 
@@ -638,6 +647,64 @@ void Server::start()
 	m_bind_addr.print(actionstream);
 	actionstream << "." << std::endl;
 }
+
+#ifdef USE_NGTCP2_QUIC
+void Server::configureQuicServerCertificates()
+{
+	auto *quic = dynamic_cast<con::QuicConnection *>(m_con.get());
+	if (!quic) {
+		warningstream << "QUIC build, but the connection is not a QuicConnection. "
+			"Skipping certificate configuration." << std::endl;
+		return;
+	}
+
+	// Use the cert/key file as defined in the settings. Otherwise, create or load
+	// from <world>/quic by default.
+	std::string cert_path = g_settings->get("quic_cert_file");
+	std::string key_path = g_settings->get("quic_key_file");
+
+	const std::string default_dir = m_path_world + DIR_DELIM + "quic";
+	const std::string default_cert = default_dir + DIR_DELIM + "server.cert.pem";
+	const std::string default_key = default_dir + DIR_DELIM + "server.key.pem";
+
+	if (cert_path.empty())
+		cert_path = default_cert;
+	if (key_path.empty())
+		key_path = default_key;
+
+	const bool have_cert = fs::PathExists(cert_path);
+	const bool have_key = fs::PathExists(key_path);
+
+	if (!have_cert || !have_key) {
+		if (g_settings->existsLocal("quic_cert_file")
+			|| g_settings->existsLocal("quic_key_file")) {
+			throw ServerError(std::string(
+				"QUIC server certificate or private key not found at the configured path. "
+				"Set quic_cert_file= and quic_key_file= correctly, or unset them to "
+				"generate a private key and certificate automatically."));
+		}
+		actionstream << "QUIC: no certificate found, generating a self-signed key pair at "
+			<< default_dir << std::endl;
+		if (!fs::CreateAllDirs(default_dir))
+			throw ServerError("Failed to create QUIC certificate directory: " + default_dir);
+		std::string bind_host = m_bind_addr.serializeString();
+		if (!con::generate_self_signed_cert(cert_path, key_path, bind_host)) {
+			throw ServerError("Failed to generate self-signed QUIC certificate");
+		}
+	}
+
+	quic->setServerCertificates(cert_path, key_path);
+
+	std::string fingerprint = con::compute_pem_fingerprint_b64(cert_path);
+	if (fingerprint.empty()) {
+		warningstream << "QUIC: could not read fingerprint from " << cert_path << std::endl;
+	} else {
+		actionstream << "QUIC: server certificate loaded from " << cert_path << std::endl;
+		actionstream << "QUIC: clients should connect using <host>:<port>+" << fingerprint
+			<< std::endl;
+	}
+}
+#endif
 
 void Server::stop()
 {

--- a/src/server.h
+++ b/src/server.h
@@ -195,6 +195,13 @@ public:
 
 	void start();
 	void stop();
+
+#ifdef USE_NGTCP2_QUIC
+	// Loads or auto-generates the server-side QUIC certificate and key,
+	// then hands them to the QUIC connection. Logs the public SHA-256
+	// fingerprint operators should publish as 'host:port+<base64>'.
+	void configureQuicServerCertificates();
+#endif
 	// Actual processing is done in another thread.
 	// This just checks if there was an error in that thread.
 	void step();

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -15,4 +15,14 @@ set(test_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/test_nodedef.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_serveractiveobjectmgr.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test_translations.cpp
-	PARENT_SCOPE)
+)
+
+if(USE_NGTCP2_QUIC)
+	list(APPEND test_SRCS
+		${CMAKE_CURRENT_SOURCE_DIR}/test_quic_address.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/test_quic_tls.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/test_quic_connection.cpp
+	)
+endif()
+
+set(test_SRCS ${test_SRCS} PARENT_SCOPE)

--- a/src/test/test_quic_address.cpp
+++ b/src/test/test_quic_address.cpp
@@ -1,0 +1,111 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "catch.h"
+
+#include "network/address.h"
+#include "network/networkexceptions.h"
+#include "settings.h"
+#include "util/base64.h"
+
+#include <string>
+
+namespace {
+
+const std::string pretend_cert_pin = "B0KLp0qT72HeQlIFywNg37sv8elgZTergaqpXKF+hJU=";
+
+// Ensure IPV6 is enabled for the parser
+void set_settings()
+{
+	if (!g_settings)
+		return;
+	if (!g_settings->exists("enable_ipv6"))
+		g_settings->setBool("enable_ipv6", true);
+}
+
+} // namespace
+
+TEST_CASE("Address::Resolve parses the QUIC cert pin/host/port", "[quic][address]")
+{
+	set_settings();
+
+	SECTION("plain numeric IP without pin")
+	{
+		Address a;
+		a.setPort(30000);
+		a.Resolve("127.0.0.1");
+		CHECK(a.getPort() == 30000);
+		CHECK(a.isNumericHostName());
+		CHECK_FALSE(a.hasPinnedCertSha256());
+		// With a numeric IP address we require the cert pin
+		CHECK(a.requiresPinnedCertSha256());
+	}
+
+	SECTION("host:port form")
+	{
+		Address a;
+		a.setPort(30001);
+		a.Resolve("127.0.0.1");
+		CHECK(a.getPort() == 30001);
+		CHECK(a.isNumericHostName());
+		CHECK_FALSE(a.hasPinnedCertSha256());
+	}
+
+	SECTION("host+pin form")
+	{
+		Address a;
+		a.Resolve(("127.0.0.1+" + pretend_cert_pin).c_str());
+		CHECK(a.hasPinnedCertSha256());
+		CHECK(a.getPinnedCertSha256Base64() == pretend_cert_pin);
+		// 32 raw bytes after decode
+		CHECK(base64_decode(a.getPinnedCertSha256Base64()).size() == 32);
+	}
+
+	SECTION("non-numeric hostname without pin")
+	{
+		// "localhost" is reliably resolvable
+		Address a;
+		a.setPort(30000);
+		try {
+			a.Resolve("localhost");
+		} catch (const ResolveError &) {
+			SKIP("localhost not resolvable in this environment");
+		}
+		CHECK(a.getPort() == 30000);
+		CHECK_FALSE(a.isNumericHostName());
+		CHECK_FALSE(a.hasPinnedCertSha256());
+		CHECK(a.shouldUseWebPki());
+	}
+
+	SECTION("IPv6 with certificate pin")
+	{
+		Address a;
+		a.Resolve(("::1+" + pretend_cert_pin).c_str());
+		CHECK(a.isIPv6());
+		CHECK(a.hasPinnedCertSha256());
+		CHECK(a.getPinnedCertSha256Base64() == pretend_cert_pin);
+	}
+}
+
+TEST_CASE("Address::Resolve rejects malformed compositions", "[quic][address]")
+{
+	set_settings();
+
+	SECTION("base64 that does not decode to 32 bytes")
+	{
+		Address a;
+		CHECK_THROWS_AS(a.Resolve("127.0.0.1+WRONG000"), ResolveError);
+	}
+
+	SECTION("invalid base64")
+	{
+		Address a;
+		CHECK_THROWS_AS(a.Resolve("127.0.0.1+not valid base64"), ResolveError);
+	}
+
+	SECTION("missing host before pin")
+	{
+		Address a;
+		CHECK_THROWS_AS(a.Resolve(("+" + pretend_cert_pin).c_str()), ResolveError);
+	}
+}

--- a/src/test/test_quic_connection.cpp
+++ b/src/test/test_quic_connection.cpp
@@ -1,0 +1,210 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "catch.h"
+
+#include "network/quic_connection.h"
+#include "network/quic_tls.h"
+#include "network/connection.h"
+#include "network/networkpacket.h"
+#include "network/peerhandler.h"
+#include "constants.h"
+#include "filesys.h"
+#include "porting.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace {
+
+constexpr u16 test_server_port = 30002;
+
+struct PeerCountHandler : public con::PeerHandler {
+	std::atomic<int> added{0};
+	std::atomic<int> deleted{0};
+	std::atomic<session_t> last_added_id{0};
+
+	void peerAdded(con::IPeer *peer) override
+	{
+		last_added_id = peer->id;
+		++added;
+	}
+	void deletingPeer(con::IPeer *, bool) override
+	{
+		++deleted;
+	}
+};
+
+struct ServerCert {
+	std::string dir;
+	std::string cert;
+	std::string key;
+
+	ServerCert()
+	{
+		dir = fs::TempPath() + DIR_DELIM "luanti-quic-test";
+		fs::CreateAllDirs(dir);
+		cert = dir + DIR_DELIM "server.cert.pem";
+		key = dir + DIR_DELIM "server.key.pem";
+		con::generate_self_signed_cert(cert, key, "localhost");
+	}
+	~ServerCert()
+	{
+		std::remove(cert.c_str());
+		std::remove(key.c_str());
+		fs::RecursiveDelete(dir);
+	}
+};
+
+} // namespace
+
+TEST_CASE("QUIC client and server connect and send packets", "[quic][connection]")
+{
+	ServerCert ck;
+	REQUIRE(fs::IsFile(ck.cert));
+	REQUIRE(fs::IsFile(ck.key));
+
+	const std::string pin_b64 = con::compute_pem_fingerprint_b64(ck.cert);
+	REQUIRE_FALSE(pin_b64.empty());
+
+	PeerCountHandler server_h;
+	std::unique_ptr<con::IConnection> server(con::createQUIC(30.0f, false, &server_h));
+
+	auto *quic_server = dynamic_cast<con::QuicConnection *>(server.get());
+	REQUIRE(quic_server != nullptr);
+	quic_server->setServerCertificates(ck.cert, ck.key);
+
+	Address bind_addr(127, 0, 0, 1, test_server_port);
+	try {
+		server->Serve(bind_addr);
+	} catch (const con::ConnectionBindFailed &e) {
+		SKIP(std::string("could not bind loopback test port: ") + e.what());
+	}
+
+	PeerCountHandler client_h;
+	std::unique_ptr<con::IConnection> client(con::createQUIC(30.0f, false, &client_h));
+
+	// Build the address with our base64 certificate digest suffix
+	Address remote;
+	remote.setPort(test_server_port);
+	remote.Resolve(("127.0.0.1+" + pin_b64).c_str());
+	client->Connect(remote);
+
+	// Let them keep receiving packets until the handshake is complete
+	const auto deadline =
+		std::chrono::steady_clock::now() + std::chrono::seconds(3);
+	while (std::chrono::steady_clock::now() < deadline) {
+		NetworkPacket sp, cp;
+		server->ReceiveTimeoutMs(&sp, 20);
+		client->ReceiveTimeoutMs(&cp, 20);
+		if (client->Connected() && server_h.added.load() > 0)
+			break;
+	}
+
+	REQUIRE(client->Connected());
+	REQUIRE(client_h.added.load() == 1);
+	REQUIRE(server_h.added.load() == 1);
+	const session_t client_pid_on_server = server_h.last_added_id.load();
+	REQUIRE(client_pid_on_server != 0);
+
+	// Send a packet from the client to the server
+	{
+		NetworkPacket pkt(0x4b, 0);
+		pkt.putRawString("Hello, server", 13);
+		client->Send(PEER_ID_SERVER, 0, &pkt, true);
+	}
+
+	NetworkPacket packet_from_client;
+	const bool got_client_packet = server->ReceiveTimeoutMs(&packet_from_client, 3000);
+	REQUIRE(got_client_packet);
+	CHECK(packet_from_client.getCommand() == 0x4b);
+	CHECK(packet_from_client.getPeerId() == client_pid_on_server);
+	CHECK(std::string(packet_from_client.getRemainingString(), 13) == "Hello, server");
+
+	// Let the client and server send some other packets
+	const auto deadline2 =
+		std::chrono::steady_clock::now() + std::chrono::milliseconds(100);
+	while (std::chrono::steady_clock::now() < deadline2) {
+		NetworkPacket sp, cp;
+		server->ReceiveTimeoutMs(&sp, 20);
+		client->ReceiveTimeoutMs(&cp, 20);
+	}
+
+	// Send a packet back to the client
+	{
+		NetworkPacket pkt(0x01, 14);
+		pkt.putRawString("Hello, client", 14);
+		server->Send(client_pid_on_server, 0, &pkt, true);
+	}
+
+	NetworkPacket packet_from_server;
+	const bool got_server_packet = client->ReceiveTimeoutMs(&packet_from_server, 3000);
+	REQUIRE(got_server_packet);
+	CHECK(packet_from_server.getCommand() == 0x01);
+	CHECK(packet_from_server.getPeerId() == PEER_ID_SERVER);
+	CHECK(packet_from_server.getSize() == 14);
+	CHECK(packet_from_server.getString(0) == std::string("Hello, client"));
+
+	client->Disconnect();
+	server->Disconnect();
+}
+
+TEST_CASE("QUIC client refuses raw IP without a cert pin", "[quic][connection]")
+{
+	PeerCountHandler client_h;
+	std::unique_ptr<con::IConnection> client(con::createQUIC(30.0f, false, &client_h));
+
+	Address remote;
+	remote.setPort(30000);
+	// No pinned certificate digest here
+	remote.Resolve("127.0.0.1");
+
+	CHECK_THROWS_AS(client->Connect(remote), con::ConnectionException);
+	CHECK(client_h.added.load() == 0);
+}
+
+TEST_CASE("QUIC client rejects a wrong cert fingerprint", "[quic][connection]")
+{
+	ServerCert ck;
+	REQUIRE(fs::IsFile(ck.cert));
+
+	PeerCountHandler server_h, client_h;
+	std::unique_ptr<con::IConnection> server(con::createQUIC(30.0f, false, &server_h));
+	auto *quic_server = dynamic_cast<con::QuicConnection *>(server.get());
+	REQUIRE(quic_server);
+	quic_server->setServerCertificates(ck.cert, ck.key);
+
+	Address bind_addr(127, 0, 0, 1, test_server_port + 1);
+	try {
+		server->Serve(bind_addr);
+	} catch (const con::ConnectionBindFailed &e) {
+		SKIP(std::string("Could not bind loopback test port: ") + e.what());
+	}
+
+	std::unique_ptr<con::IConnection> client(con::createQUIC(30.0f, false, &client_h));
+
+	const std::string bogus_pinned_cert = "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE=";
+	Address remote;
+	remote.setPort(test_server_port + 1);
+	remote.Resolve(("127.0.0.1+" + bogus_pinned_cert).c_str());
+	client->Connect(remote);
+
+	// Confirm the client never reaches the Connected() state
+	const auto deadline =
+		std::chrono::steady_clock::now() + std::chrono::seconds(2);
+	while (std::chrono::steady_clock::now() < deadline) {
+		NetworkPacket pkt;
+		server->ReceiveTimeoutMs(&pkt, 20);
+		client->ReceiveTimeoutMs(&pkt, 20);
+		if (client->Connected())
+			break;
+	}
+	CHECK_FALSE(client->Connected());
+
+	client->Disconnect();
+	server->Disconnect();
+}

--- a/src/test/test_quic_tls.cpp
+++ b/src/test/test_quic_tls.cpp
@@ -1,0 +1,67 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "catch.h"
+
+#include "network/quic_tls.h"
+#include "filesys.h"
+#include "util/base64.h"
+
+#include <openssl/bio.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+struct TempCertPaths {
+	std::string dir;
+	std::string cert;
+	std::string key;
+
+	explicit TempCertPaths(const std::string &tag)
+	{
+		dir = fs::TempPath() + DIR_DELIM "luanti-quic-test-" + tag;
+		fs::CreateAllDirs(dir);
+		cert = dir + DIR_DELIM "server.cert.pem";
+		key = dir + DIR_DELIM "server.key.pem";
+	}
+	~TempCertPaths()
+	{
+		std::remove(cert.c_str());
+		std::remove(key.c_str());
+		fs::RecursiveDelete(dir);
+	}
+};
+
+} // namespace
+
+TEST_CASE("generate_self_signed_cert produces usable cert and key pair", "[quic][tls]")
+{
+	TempCertPaths paths("gen");
+
+	REQUIRE(con::generate_self_signed_cert(paths.cert, paths.key, "localhost"));
+
+	CHECK(fs::IsFile(paths.cert));
+	CHECK(fs::IsFile(paths.key));
+
+	std::string cert_pem;
+	REQUIRE(fs::ReadFile(paths.cert, cert_pem));
+	CHECK(cert_pem.find("BEGIN CERTIFICATE") != std::string::npos);
+
+	const std::string fp_b64 = con::compute_pem_fingerprint_b64(paths.cert);
+	REQUIRE_FALSE(fp_b64.empty());
+	CHECK(base64_decode(fp_b64).size() == 32);
+}
+
+TEST_CASE("Generated cert can be loaded by TlsServerContext", "[quic][tls]")
+{
+	TempCertPaths paths("server-ctx");
+	REQUIRE(con::generate_self_signed_cert(paths.cert, paths.key, ""));
+
+	con::TlsServerContext server_ctx;
+	REQUIRE(server_ctx.init(paths.cert, paths.key));
+	CHECK(server_ctx.get() != nullptr);
+}


### PR DESCRIPTION
This is an implementation for QUIC support. Some notes (mostly from https://github.com/luanti-org/luanti/issues/15261#issuecomment-4368164615)

- Just as you guys intended, I am subclassing IConnection and the existing Luanti protocol basically gets passed through a QUIC stream as individual virtual frames. Nothing about the Luanti protocol (like game packet types) needs to be changed. For the ALPN that TLS/QUIC uses I just went with `luanti` for now as the name of the protocol.
- It supports both the web PKI (meaning you have to have a domain name and get a certificate from a certificate issuer) and local self-signed certificates (meaning you need to share a fingerprint of the certificate over a secure channel out of band, in other words, wherever you advertise your server, but you don't need to buy a domain name and don't need to look up anything from external servers).
- If the server uses a self-signed certificate, you have to add the fingerprint (essentially base64 of the SHA-256 hash of the certificate) to the "Address" parameter in the UI when connecting. Maybe we can add a separate field for this, but for now it's easy to copy and paste into the Address field. Actually in general I think it would be better to have a unified field for host, port, and now fingerprint hash too... But that's my personal opinion and a UI change for a different day.
  - By the way this will look like `192.168.1.68+Du1JozorVZhmsSB/eedmtpZ0XLN3dpb14GTr2XofIDI`
- I am using ngtcp2, and the reason is that it's by far the most buildable among QUIC libraries. It's a C library, so we have to be a little more careful with managing variables. But it's easy to build. You can build it in Ubuntu 26.04 and Debian "forky" without needing to manually compile any libraries. Since we already list OpenSSL as an optional dependency, I'm using that as the crypto backend (ngtcp2 supports multiple). You need `libngtcp2` and `libngtcp2-crypto-ossl`.
- You can set your server's private key and cert via `quic_cert_file` and `quic_key_file` in the config. By default it generates a self-signed certificate valid for 10 years.
- Everything is currently passed along a single bidirectional QUIC channel. I don't (yet) split the streams the way the original network implementation does.
- I did not add any advanced QUIC features yet. We can do this much later of course. So I did not do path migration (client wants to use a different IP address) or 0-RTT/retry tokens (honestly not really that useful for Luanti, more useful for HTTP).


### Dependencies:

I've only been running this on Ubuntu 26.04. I'd appreciate help with getting the CMake files right on other platforms.

Install the ngtcp2 and ngtcp2-crypto-ossl libraries. You might have to compile and install them manually on your platform, but on Ubuntu 26.04 you can install them from apt:
```
sudo apt install libngtcp2-16 libngtcp2-dev libngtcp2-crypto-ossl0 libngtcp2-crypto-ossl-dev
```

You also need OpenSSL 3.5 or later:
```
sudo apt install openssl libssl-dev
```

### Building:
I currently have QUIC support gated by a build flag, and for simplicity at the moment it is either all QUIC or no QUIC. Set `-DENABLE_EXPERIMENTAL_QUIC_TRANSPORT=ON` when building, e.g.

```
cmake . -DRUN_IN_PLACE=TRUE -DENABLE_EXPERIMENTAL_QUIC_TRANSPORT=ON -DBUILD_CLIENT=TRUE -DBUILD_SERVER=TRUE -DCMAKE_BUILD_TYPE=Debug
make -j$(nproc)
```

### Testing:
I included tests for parsing the address format with the cert fingerprint, generating certificates, actually connecting a client to a server and exchanging messages (like the unittest connection ones), and detecting incorrect certificate fingerprints. These are in the newer Catch2 format and get run with `./bin/luanti --run-tests`.

You can enable the ngtcp2 native debug logs with `LUANTI_QUIC_DEBUG=1`.

### Questions & known issues:
- **YES, as written it currently breaks backwards compatibility.** I am **already aware** that you will want to still be able to connect to unencrypted servers. I would appreciate pointers as to how we should handle this from the source code and from the interface (though I would even more appreciate someone else doing this...)
  1. How should the source code determine which connection type (unencrypted or QUIC) to use when connecting to a server?
  2. What does the interface need to look like?
  
- Singleplayer won't work right now, probably just needs a minor change
- Currently, if you don't have paths to your certificate and private key set in the config, it creates a new private key and self-signed certificate that is put in the world folder of the world you're currently hosting. (It will load a key and cert if they already exist there.) I just did this because the world folder was easily accessible in server.cpp, but to be clear there's nothing wrong with reusing the same certificate on multiple different servers or worlds running at the same time on the same machine. **Where should auto-generated certs go instead?** I think it makes the most sense to be in the .minetest folder, but I couldn't find which global variable that is under or how to access it.
- If there's a fingerprint mismatch, i.e. the pinned fingerprint does not match the one on the server, you get a log message explaining but in the interface are shown "Connection timed out" error after 10 seconds instead of the real reason. We need to show the error in the interface once it happens.
- Since we include the fingerprint as part of the address itself, on the registration page and other places in the interface there isn't enough room to show the whole thing
- Let me know if there are style issues in the code you would like me to fix. I tried to stick with the style guide although I on purpose broke the camel case rule when writing callbacks for the C libraries ngtcp2 and OpenSSL. Try not to groan at all my anonymous namespaces!
  - Also I don't know what the expectations are with copyright notices so I left them out. Everything I wrote can go to the public domain.

### Things that need to be tested
1. I don't own a domain and haven't tested using the web PKI for validating a certificate, but it's the default path in OpenSSL anyway so I expect it to work. I could probably test it by having my computer trust a custom development CA but I haven't done it yet.
2. I haven't done any performance testing whatsoever. I doubt QUIC will introduce substantial overhead, but if this introduces big performance issues I'm simply not aware. I only tested with a few clients connected.
3. I haven't built on other platforms and am not a CMake expert. Building libngtcp2 shouldn't be too bad because its only dependency is OpenSSL, but I have no access to macOS or Windows machines and don't know much about building on them.
4. More comprehensive/real-world memory testing would be good. I encountered and later fixed some segfaults during development using address sanitizer build flags, but it was just using the development test world with no other mods.

### TODO items:

- [ ] Fix comment and use UDPSocket
- [ ] Make singleplayer work again (and can use raw UDP)
  - Basically done already, didn't push it yet, need to test it some more first
- [ ] User interfaces
  - [ ] Trusting certificates on first use
  - [ ] Mismatched certificate errors
  - [ ] Viewing trusted certificate list
- [ ] `~/.minetest` is `porting::path_user` and put a client certs subdirectory there for the certs it collects from servers it trusted
- [ ] Change saved autogenerated server cert path to `porting::path_user` subfolder, like `/server/cert/`
- [ ] Clients retry with raw UDP fallback (not really a fan, definitely adds holes for old school MiTM attackers, but I know the community wants backwards compatibility...)

Prior to release:

- [ ] Split into different QUIC streams
- [ ] Core devs can apply for ALPN registration (whether it happens or not does not really affect us)
- [ ] Someone tests web PKI server connection
- [ ] Write instructions for how to generate non-self signed certs and sign with the "per domain" certificate