### PR TITLE
Improved inventory interactions

### DIFF
--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -245,7 +245,7 @@ void GameFormSpec::showFormSpec(const std::string &formspec, const std::string &
 	// Replace the currently open formspec
 	GUIFormSpecMenu::create(m_formspec, m_client, m_rendering_engine->get_gui_env(),
 		&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
-		m_client->getSoundManager());
+		m_client->getSoundManager(), m_input);
 	m_formspec->setName(formname);
 }
 
@@ -260,7 +260,7 @@ void GameFormSpec::showCSMFormSpec(const std::string &formspec, const std::strin
 
 	GUIFormSpecMenu::create(m_formspec, m_client, m_rendering_engine->get_gui_env(),
 			&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
-			m_client->getSoundManager());
+			m_client->getSoundManager(), m_input);
 	m_formspec->setName(formname);
 }
 
@@ -284,7 +284,7 @@ void GameFormSpec::showPauseMenuFormSpec(const std::string &formspec, const std:
 	GUIFormSpecMenu::create(fs, m_client, m_rendering_engine->get_gui_env(),
 			// Ignore formspec prepend.
 			&m_input->joystick, fs_src, txt_dst, "",
-			m_client->getSoundManager());
+			m_client->getSoundManager(), m_input);
 
 	fs->setName(formname);
 	fs->doPause = true;
@@ -304,7 +304,7 @@ void GameFormSpec::showNodeFormspec(const std::string &formspec, const v3s16 &no
 
 	GUIFormSpecMenu::create(m_formspec, m_client, m_rendering_engine->get_gui_env(),
 		&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
-		m_client->getSoundManager());
+		m_client->getSoundManager(), m_input);
 
 	m_formspec->setFormSpec(formspec, inventoryloc);
 }
@@ -347,7 +347,7 @@ void GameFormSpec::showPlayerInventory(const std::string *fs_override)
 
 	GUIFormSpecMenu::create(m_formspec, m_client, m_rendering_engine->get_gui_env(),
 		&m_input->joystick, fs_src.get(), txt_dst, m_client->getFormspecPrepend(),
-		m_client->getSoundManager());
+		m_client->getSoundManager(), m_input);
 
 	m_formspec->setFormSpec(fs_src->getForm(), inventoryloc);
 	fs_src.release(); // owned by GUIFormSpecMenu
@@ -461,7 +461,7 @@ void GameFormSpec::showPauseMenu()
 
 	GUIFormSpecMenu::create(m_formspec, m_client, m_rendering_engine->get_gui_env(),
 			&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
-			m_client->getSoundManager());
+			m_client->getSoundManager(), m_input);
 	m_formspec->setFocus("btn_continue");
 	// game will be paused in next step, if in singleplayer (see Game::m_is_paused)
 	m_formspec->doPause = true;
@@ -485,7 +485,7 @@ void GameFormSpec::showDeathFormspecLegacy()
 
 	GUIFormSpecMenu::create(m_formspec, m_client, m_rendering_engine->get_gui_env(),
 		&m_input->joystick, fs_src, txt_dst, m_client->getFormspecPrepend(),
-		m_client->getSoundManager());
+		m_client->getSoundManager(), m_input);
 	m_formspec->setFocus("btn_respawn");
 }
 

--- a/src/client/inputhandler.h
+++ b/src/client/inputhandler.h
@@ -87,6 +87,15 @@ public:
 
 	PointerType getLastPointerType() { return last_pointer_type; }
 
+	// Returns the GameKeyType action bound to this key, or INTERNAL_ENUM_COUNT if unbound
+	GameKeyType getActionFromKey(KeyPress key) const
+	{
+		auto it = keysListenedFor.find(key);
+		if (it != keysListenedFor.end())
+			return it->second;
+		return GameKeyType::INTERNAL_ENUM_COUNT;
+	}
+
 private:
 	void listenForKey(KeyPress keyCode, GameKeyType action)
 	{
@@ -157,6 +166,9 @@ public:
 	virtual bool wasKeyReleased(GameKeyType k) = 0;
 	virtual bool cancelPressed() = 0;
 
+	// Returns the GameKeyType action bound to this key, or INTERNAL_ENUM_COUNT if unbound
+	virtual GameKeyType getActionFromKey(KeyPress key) { return GameKeyType::INTERNAL_ENUM_COUNT; }
+
 	virtual float getJoystickSpeed() = 0;
 	virtual float getJoystickDirection() = 0;
 
@@ -225,6 +237,11 @@ public:
 	virtual bool cancelPressed()
 	{
 		return wasKeyDown(KeyType::ESC);
+	}
+
+	virtual GameKeyType getActionFromKey(KeyPress key)
+	{
+		return m_receiver->getActionFromKey(key);
 	}
 
 	virtual void clearWasKeyPressed()

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -175,6 +175,7 @@ GUIEngine::GUIEngine(JoystickController *joystick,
 			formspecgui.release(),
 			buttonhandler.release(),
 			"",
+			nullptr,
 			false);
 
 	m_menu->defaultAllowClose(false);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -11,6 +11,7 @@
 #include "EGUIElementTypes.h"
 #include "itemdef.h"
 #include "gamedef.h"
+#include "hud_element.h"
 #include "client/keycode.h"
 #include "gui/guiTable.h"
 #include <IGUIButton.h>
@@ -91,7 +92,7 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 		gui::IGUIElement *parent, s32 id, IMenuManager *menumgr,
 		Client *client, gui::IGUIEnvironment *guienv, ISimpleTextureSource *tsrc,
 		ISoundManager *sound_manager, IFormSource *fsrc, TextDest *tdst,
-		const std::string &formspecPrepend, bool remap_dbl_click):
+		const std::string &formspecPrepend, InputHandler *input, bool remap_dbl_click):
 	GUIModalMenu(guienv, parent, id, menumgr, remap_dbl_click),
 	m_invmgr(client),
 	m_tsrc(tsrc),
@@ -100,7 +101,8 @@ GUIFormSpecMenu::GUIFormSpecMenu(JoystickController *joystick,
 	m_formspec_prepend(formspecPrepend),
 	m_form_src(fsrc),
 	m_text_dst(tdst),
-	m_joystick(joystick)
+	m_joystick(joystick),
+	m_input(input)
 {
 	current_keys_pending.key_down = false;
 	current_keys_pending.key_up = false;
@@ -120,7 +122,9 @@ GUIFormSpecMenu::~GUIFormSpecMenu()
 
 void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
 	gui::IGUIEnvironment *guienv, JoystickController *joystick, IFormSource *fs_src,
-	TextDest *txt_dest, const std::string &formspecPrepend, ISoundManager *sound_manager)
+	TextDest *txt_dest, const std::string &formspecPrepend, ISoundManager *sound_manager,
+	InputHandler *input)
+
 {
 	if (cur_formspec && cur_formspec->getReferenceCount() == 1) {
 		/*
@@ -138,7 +142,7 @@ void GUIFormSpecMenu::create(GUIFormSpecMenu *&cur_formspec, Client *client,
 	if (cur_formspec == nullptr) {
 		cur_formspec = new GUIFormSpecMenu(joystick, guiroot, -1, &g_menumgr,
 			client, guienv, client->getTextureSource(), sound_manager, fs_src,
-			txt_dest, formspecPrepend);
+			txt_dest, formspecPrepend, input);
 
 		/*
 			Caution: do not call (*cur_formspec)->drop() here --
@@ -4262,6 +4266,49 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 		if (event.KeyInput.PressedDown && keySettingHasMatch("keymap_toggle_debug", kp)) {
 			if (!m_client || m_client->checkPrivilege("debug"))
 				m_show_debug = !m_show_debug;
+		}
+
+		// Handle slot keys for item swapping
+		if (event.KeyInput.PressedDown && m_input) {
+			GameKeyType action = m_input->getActionFromKey(kp);
+			if (action >= KeyType::SLOT_1 && action < KeyType::SLOT_1 + HUD_HOTBAR_ITEMCOUNT_MAX) {
+				u16 i = action - KeyType::SLOT_1;
+
+				// Try to swap the hovered item with hotbar slot i
+				if (const GUIInventoryList::ItemSpec hovered = getHoveredItem(); hovered.isValid()) {
+					auto *a = new IMoveAction();
+					a->count = 0;
+
+					// IMoveAction doesn't attempt to swap from an empty slot into a full slot,
+					// So to get this behaviour, we need to check which slot is occupied and swap ourselves
+					const Inventory *inv = m_invmgr->getInventory(hovered.inventoryloc);
+					const InventoryList *list = inv ? inv->getList(hovered.listname) : nullptr;
+					bool hovered_empty = !list || list->getItem(hovered.i).empty();
+
+					if (hovered_empty) {
+						// Pull from hotbar slot to empty slot
+						a->from_inv.setCurrentPlayer();
+						a->from_list = "main";
+						a->from_i = i;
+						a->to_inv = hovered.inventoryloc;
+						a->to_list = hovered.listname;
+						a->to_i = hovered.i;
+					} else {
+						// Push hovered item to hotbar slot
+						a->from_inv = hovered.inventoryloc;
+						a->from_list = hovered.listname;
+						a->from_i = hovered.i;
+						a->to_inv.setCurrentPlayer();
+						a->to_list = "main";
+						a->to_i = i;
+					}
+
+					m_client->inventoryAction(a);
+				}
+
+				// Consume event to prevent switching active hotbar slot
+				return true;
+			}
 		}
 
 		if (event.KeyInput.PressedDown &&

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -4268,6 +4268,17 @@ bool GUIFormSpecMenu::OnEvent(const SEvent& event)
 				m_show_debug = !m_show_debug;
 		}
 
+		if (event.KeyInput.PressedDown && m_client && keySettingHasMatch("keymap_drop", kp)) {
+			if (const GUIInventoryList::ItemSpec hovered = getHoveredItem(); hovered.isValid()) {
+				auto *a = new IDropAction();
+				a->count = event.KeyInput.Shift ? 1 : 0;
+				a->from_inv = hovered.inventoryloc;
+				a->from_list = hovered.listname;
+				a->from_i = hovered.i;
+				m_client->inventoryAction(a);
+			}
+		}
+
 		// Handle slot keys for item swapping
 		if (event.KeyInput.PressedDown && m_input) {
 			GameKeyType action = m_input->getActionFromKey(kp);

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -28,6 +28,7 @@ class Client;
 class GUIScrollContainer;
 class ISoundManager;
 class JoystickController;
+class InputHandler;
 
 enum FormspecFieldType {
 	f_Button,
@@ -160,6 +161,7 @@ public:
 			IFormSource* fs_src,
 			TextDest* txt_dst,
 			const std::string &formspecPrepend,
+			InputHandler *input,
 			bool remap_dbl_click = true);
 
 	~GUIFormSpecMenu();
@@ -167,7 +169,7 @@ public:
 	static void create(GUIFormSpecMenu *&cur_formspec, Client *client,
 		gui::IGUIEnvironment *guienv, JoystickController *joystick, IFormSource *fs_src,
 		TextDest *txt_dest, const std::string &formspecPrepend,
-		ISoundManager *sound_manager);
+		ISoundManager *sound_manager, InputHandler *input);
 
 	void setFormSpec(const std::string &formspec_string,
 			const InventoryLocation &current_inventory_location)
@@ -242,6 +244,11 @@ public:
 	u16 getSelectedAmount() const
 	{
 		return m_selected_amount;
+	}
+
+	GUIInventoryList::ItemSpec getHoveredItem() const
+	{
+		return getItemAtPos(m_pointer);
 	}
 
 	bool doTooltipAppendItemname() const
@@ -388,6 +395,7 @@ private:
 	u16                        m_formspec_version = 1;
 	std::optional<std::string> m_focused_element = std::nullopt;
 	JoystickController        *m_joystick;
+	InputHandler              *m_input = nullptr;
 	bool                       m_show_debug = false;
 	bool                       m_show_focus = false;
 	gui::IGUIElement          *m_last_focused = nullptr;


### PR DESCRIPTION
This PR aims to improve inventory interactions.
Currently the inventory system can feel a bit clunky. A friend encouraged me to write a PR to fix some of those issues.

## Current features

At the time of writing this PR adds:
- Fast swapping with hotbar keys:
  This is something found in minecraft, and it enables the user to swap/move inventory items with hotbar item by hovering over slots and pressing the corresponding number key. This works in any formspec.
  - If no item is present in the hotbar slot, it will move the hovered item.
  - If an item is present in the hotbar slot but its of a different kind, the two will swap.
  - If an item is present in the hotbar slot but its of the same kind, we will try to fill the target up to the stack limit by taking from the source.
  - If the hovered slot is an empty slot, the item in the hotbar slot will be moved into the hovered slot.

- Dropping from the inventory:
  Hovering over a slot and pressing 'Q' drops a stack of items, and pressing modifier+'Q' (by default 'shift'+'Q') drops only one item. This is the same behaviour as dropping items outside of the inventory.

## To do

This PR is a work in progress, and I hope to make this somewhat of a 'living' PR.
I'd like to add other features to improve the inventory system, but I would like some input on what are wanted features first.

Here are some ideas that came to mind:
- 'Fixing' shift+clicking items creating new stacks rather than adding to existing ones if in the same inventory (this might have been intended as a feature?).
- Allowing middle mouse drag, and duplicating item in creative mode (currently middle mouse drag only works in creative mode, and dosent duplicate items there).
- Splitting into 1/3 + 2/3 via middle mouse button (or maybe 1/4 + 3/4 is more useful?).
- Walking while in the inventory (Could have a large effect on gameplay. In minecraft this feature is often added by cheat clients, so an argument could be made that making it accessible to all players would help level the field).
- Option or default to invert stack-dropping behaviour.

## Testing
Hop into a game, try the features listed earlier.
I have found no issues so far, and it doesn't seem to break anything else.
However I didn't extensively test if this PR breaks any mods.


Disclosure: AI was used in helping to understand the lunati codebase. No code, no commits and no part of this PR was written by AI.