### PR TITLE
Craftrecipe Item Wear Feature

### DIFF
--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -333,13 +333,10 @@ core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
 		local is_tool = can_wear > 0 and core.registered_tools[item_name]
 
 		if is_tool then
-			local current_stack = craft_inv:get_stack("craft", index)
-			-- add wear only if tool is returned as a replacement
-			if current_stack:get_name() == item_name then
-				local new_wear = item:get_wear() + (65535 / can_wear + 1)
-				-- tool broken, remove and play sound
-				if new_wear > 65535 then
-					current_stack:clear()
+			local item_replacement = craft_inv:get_stack("craft", index):get_name()
+			if item_replacement == item_name then
+				item:add_wear_by_uses(can_wear)
+				if item:is_empty() then
 					local pos = player:get_pos()
 					if pos then
 						local sound = is_tool.sound and is_tool.sound.breaks or
@@ -347,10 +344,8 @@ core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
 						core.sound_play(sound,
 								{pos = pos, gain = 0.3, max_hear_distance = 1}, true)
 					end
-				else
-					current_stack:set_wear(new_wear)
 				end
-				craft_inv:set_stack("craft", index, current_stack)
+				craft_inv:set_stack("craft", index, item)
 			end
 		end
 	end

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -329,19 +329,17 @@ end
 core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
 	for index, item in ipairs(old_craft_grid) do
 		local item_name = item:get_name()
-		local can_wear = core.get_item_group(item_name, "craft_wear")
-		local is_tool = can_wear > 0 and core.registered_tools[item_name]
+		local can_wear = core.get_item_group(item_name, "craft_uses")
+		local tool = can_wear > 0 and core.registered_tools[item_name]
 
-		if is_tool then
+		if tool then
 			local item_replacement = craft_inv:get_stack("craft", index):get_name()
 			if item_replacement == item_name then
 				item:add_wear_by_uses(can_wear)
 				if item:is_empty() then
 					local pos = player:get_pos()
 					if pos then
-						local sound = is_tool.sound and is_tool.sound.breaks or
-								"default_tool_breaks"
-						core.sound_play(sound,
+						core.sound_play(tool.sound and tool.sound.breaks,
 								{pos = pos, gain = 0.3, max_hear_distance = 1}, true)
 					end
 				end

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -323,7 +323,7 @@ function core.run_lbm(id, pos_list, dtime_s)
 end
 
 --
--- Tool wear inside craftrecipe, uses {craft_wear = [uses]} group
+-- Tool wear inside craftrecipe, uses {craft_uses = [uses]} group
 --
 
 core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -337,10 +337,10 @@ core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
 			if item_replacement == item_name then
 				item:add_wear_by_uses(wear)
 				if item:is_empty() then
-					local pos = player:get_pos()
-					if pos then
+					local name = player:get_player_name()
+					if name then
 						core.sound_play(tool.sound and tool.sound.breaks,
-								{pos = pos, gain = 0.3, max_hear_distance = 1}, true)
+								{to_player = name, gain = 0.5}, true)
 					end
 				end
 				craft_inv:set_stack("craft", index, item)

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -321,3 +321,37 @@ function core.run_lbm(id, pos_list, dtime_s)
 		end
 	end
 end
+
+--
+-- Tool wear inside craftrecipe, uses {craft_wear = [uses]} group
+--
+
+core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
+	for index, item in ipairs(old_craft_grid) do
+		local item_name = item:get_name()
+		local can_wear = core.get_item_group(item_name, "craft_wear")
+		local is_tool = core.registered_tools[item_name]
+
+		if is_tool and can_wear > 0 then
+			local current_stack = craft_inv:get_stack("craft", index)
+			-- add wear only if tool is returned as a replacement
+			if current_stack:get_name() == item_name then
+				local new_wear = item:get_wear() + (65535 / can_wear + 1)
+				-- tool broken, remove and play sound
+				if new_wear > 65535 then
+					craft_inv:set_stack("craft", index, ItemStack(""))
+					local pos = player:get_pos()
+					if pos then
+						local sound = is_tool.sound and is_tool.sound.breaks or
+								"default_tool_breaks"
+						core.sound_play(sound,
+								{pos = pos, gain = 0.3, max_hear_distance = 1}, true)
+					end
+				else
+					current_stack:set_wear(new_wear)
+					craft_inv:set_stack("craft", index, current_stack)
+				end
+			end
+		end
+	end
+end)

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -330,16 +330,16 @@ core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
 	for index, item in ipairs(old_craft_grid) do
 		local item_name = item:get_name()
 		local can_wear = core.get_item_group(item_name, "craft_wear")
-		local is_tool = core.registered_tools[item_name]
+		local is_tool = can_wear > 0 and core.registered_tools[item_name]
 
-		if is_tool and can_wear > 0 then
+		if is_tool then
 			local current_stack = craft_inv:get_stack("craft", index)
 			-- add wear only if tool is returned as a replacement
 			if current_stack:get_name() == item_name then
 				local new_wear = item:get_wear() + (65535 / can_wear + 1)
 				-- tool broken, remove and play sound
 				if new_wear > 65535 then
-					craft_inv:set_stack("craft", index, ItemStack(""))
+					current_stack:clear()
 					local pos = player:get_pos()
 					if pos then
 						local sound = is_tool.sound and is_tool.sound.breaks or
@@ -349,8 +349,8 @@ core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
 					end
 				else
 					current_stack:set_wear(new_wear)
-					craft_inv:set_stack("craft", index, current_stack)
 				end
+				craft_inv:set_stack("craft", index, current_stack)
 			end
 		end
 	end

--- a/builtin/game/misc.lua
+++ b/builtin/game/misc.lua
@@ -323,19 +323,19 @@ function core.run_lbm(id, pos_list, dtime_s)
 end
 
 --
--- Tool wear inside craftrecipe, uses {craft_uses = [uses]} group
+-- Tool wear inside craftrecipe using {craft_uses = [uses]} group
 --
 
 core.register_on_craft(function (crafted, player, old_craft_grid, craft_inv)
 	for index, item in ipairs(old_craft_grid) do
 		local item_name = item:get_name()
-		local can_wear = core.get_item_group(item_name, "craft_uses")
-		local tool = can_wear > 0 and core.registered_tools[item_name]
+		local wear = core.get_item_group(item_name, "craft_uses")
+		local tool = wear > 0 and core.registered_tools[item_name]
 
 		if tool then
 			local item_replacement = craft_inv:get_stack("craft", index):get_name()
 			if item_replacement == item_name then
-				item:add_wear_by_uses(can_wear)
+				item:add_wear_by_uses(wear)
 				if item:is_empty() then
 					local pos = player:get_pos()
 					if pos then

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1479,10 +1479,10 @@ Examples:
 }
 ```
 
-Special sound-
+Special sound-groups
 --------------------
 
-These sound- are played back by the engine if provided.
+These sound-groups are played back by the engine if provided.
 
  * `player_damage`: Played when the local player takes damage (gain = 0.5)
  * `player_falling_damage`: Played when the local player takes

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1479,10 +1479,10 @@ Examples:
 }
 ```
 
-Special sound-groups
+Special sound-
 --------------------
 
-These sound-groups are played back by the engine if provided.
+These sound- are played back by the engine if provided.
 
  * `player_damage`: Played when the local player takes damage (gain = 0.5)
  * `player_falling_damage`: Played when the local player takes
@@ -2594,6 +2594,9 @@ to games.
 
 * `disable_repair`: If set to 1 for a tool, it cannot be repaired using the
   `"toolrepair"` crafting recipe
+* `craft_uses`: Contains the number of uses a tool can be used inside a
+  crafting recipe, but only when the tool itself is returned by using the
+  replacements table.
 
 
 ### `ObjectRef` armor groups


### PR DESCRIPTION
Adds a new group { craft_uses = [total uses] } to a tool item, which adds wear to that item when returned via replacements table inside a craft recipe.  Once [total uses] has been reached the tool breaks and can play a sound when removed from the crafting grid.

## How to test

<!-- Example code or instructions -->

```
core.register_tool("mymod:cooking_orb", {
	description = "Cooking Orb",
	inventory_image = "mymod_cooking_orb.png",
	groups = {craft_uses = 20},
	sound = {breaks = "default_tool_breaks"},
})

core.register_craft({
	output = "farming:bread",
	recipe = {
		{"farming:flour", "mymod:cooking_orb"}
	},
	replacements = {
		{"mymod:cooking_orb", "mymod:cooking_orb"},
	}
})
```
