### PR TITLE
Add interpolation toggle to set_rotation

### DIFF
--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1540,6 +1540,7 @@ void GenericCAO::processMessage(const std::string &data)
 		bool do_interpolate = readU8(is);
 		bool is_end_position = readU8(is);
 		float update_interval = readF32(is);
+		bool do_interpolate_rotation = is.peek() != EOF ? readU8(is) : true;
 
 		if(getParent() != NULL) // Just in case
 			return;
@@ -1551,7 +1552,10 @@ void GenericCAO::processMessage(const std::string &data)
 		} else {
 			pos_translator.init(m_position);
 		}
-		rot_translator.update(m_rotation, false, update_interval);
+		if (do_interpolate_rotation)
+			rot_translator.update(m_rotation, false, update_interval);
+		else
+			rot_translator.init(m_rotation);
 		updateNodePos();
 	} else if (cmd == AO_CMD_SET_TEXTURE_MOD) {
 		std::string mod = deSerializeString16(is);

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -1673,6 +1673,7 @@ void GenericCAO::processMessage(const std::string &data)
 		bool do_interpolate = readU8(is);
 		bool is_end_position = readU8(is);
 		float update_interval = readF32(is);
+		bool do_interpolate_rotation = canRead(is) ? readU8(is) : true;
 
 		if(getParent() != NULL) // Just in case
 			return;
@@ -1684,7 +1685,10 @@ void GenericCAO::processMessage(const std::string &data)
 		} else {
 			pos_translator.init(m_position);
 		}
-		rot_translator.update(m_rotation, false, update_interval);
+		if (do_interpolate_rotation)
+			rot_translator.update(m_rotation, false, update_interval);
+		else
+			rot_translator.init(m_rotation);
 		updateNodePos();
 	} else if (cmd == AO_CMD_SET_TEXTURE_MOD) {
 		std::string mod = deSerializeString16(is);

--- a/src/network/networkprotocol.cpp
+++ b/src/network/networkprotocol.cpp
@@ -79,6 +79,7 @@
 		Type of TOCLIENT_HUDADD `size` changed from v2s32 to v2f
 		[scheduled bump for 5.16.0]
 	PROTOCOL VERSION 53
+		Added optional "do_interpolate_rotation" u8 to AO_CMD_UPDATE_POSITION
 		[scheduled bump for 5.17.0]
 */
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1155,7 +1155,7 @@ int ObjectRef::l_get_acceleration(lua_State *L)
 	return 1;
 }
 
-// set_rotation(self, rotation)
+// set_rotation(self, rotation, interpolate)
 int ObjectRef::l_set_rotation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1166,9 +1166,12 @@ int ObjectRef::l_set_rotation(lua_State *L)
 
 	v3f rotation = check_v3f(L, 2) * core::RADTODEG;
 
+	// Optional second parameter: interpolate (default true)
+	bool interpolate = lua_isboolean(L, 3) ? lua_toboolean(L, 3) : true;
+
 	// Note: These angles are inverted before being applied using setPitchYawRoll,
 	// hence we end up with a right-handed rotation
-	entitysao->setRotation(rotation);
+	entitysao->setRotation(rotation, interpolate);
 	return 0;
 }
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1301,7 +1301,7 @@ int ObjectRef::l_get_acceleration(lua_State *L)
 	return 1;
 }
 
-// set_rotation(self, rotation)
+// set_rotation(self, rotation, interpolate)
 int ObjectRef::l_set_rotation(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
@@ -1312,9 +1312,11 @@ int ObjectRef::l_set_rotation(lua_State *L)
 
 	v3f rotation = check_v3f(L, 2) * core::RADTODEG;
 
+	bool interpolate = lua_isboolean(L, 3) ? lua_toboolean(L, 3) : true;
+
 	// Note: These angles are inverted before being applied using setPitchYawRoll,
 	// hence we end up with a right-handed rotation
-	entitysao->setRotation(rotation);
+	entitysao->setRotation(rotation, interpolate);
 	return 0;
 }
 

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -545,8 +545,11 @@ void LuaEntitySAO::sendPosition(bool do_interpolate, bool is_movement_end)
 		m_rotation,
 		do_interpolate,
 		is_movement_end,
-		update_interval
+		update_interval,
+		m_rotation_interpolate
 	);
+	// Reset per-update rotation interpolation flag to default
+	m_rotation_interpolate = true;
 	// create message and add to list
 	m_messages_out.emplace(getId(), false, str);
 }

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -550,8 +550,11 @@ void LuaEntitySAO::sendPosition(bool do_interpolate, bool is_movement_end)
 		m_rotation,
 		do_interpolate,
 		is_movement_end,
-		update_interval
+		update_interval,
+		m_rotation_interpolate
 	);
+	// Reset per-update rotation interpolation flag to default
+	m_rotation_interpolate = true;
 	// create message and add to list
 	m_messages_out.emplace(getId(), false, str);
 }

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -359,7 +359,8 @@ std::string UnitSAO::generateUpdateArmorGroupsCommand() const
 
 std::string UnitSAO::generateUpdatePositionCommand(const v3f &position,
 		const v3f &velocity, const v3f &acceleration, const v3f &rotation,
-		bool do_interpolate, bool is_movement_end, f32 update_interval)
+		bool do_interpolate, bool is_movement_end, f32 update_interval,
+		bool do_interpolate_rotation)
 {
 	std::ostringstream os(std::ios::binary);
 	// command
@@ -378,6 +379,8 @@ std::string UnitSAO::generateUpdatePositionCommand(const v3f &position,
 	writeU8(os, is_movement_end);
 	// update_interval (for interpolation)
 	writeF32(os, update_interval);
+	// do_interpolate_rotation
+	writeU8(os, do_interpolate_rotation);
 	return os.str();
 }
 

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -438,7 +438,8 @@ std::string UnitSAO::generateUpdateArmorGroupsCommand() const
 
 std::string UnitSAO::generateUpdatePositionCommand(const v3f &position,
 		const v3f &velocity, const v3f &acceleration, const v3f &rotation,
-		bool do_interpolate, bool is_movement_end, f32 update_interval)
+		bool do_interpolate, bool is_movement_end, f32 update_interval,
+		bool do_interpolate_rotation)
 {
 	std::ostringstream os(std::ios::binary);
 	// command
@@ -457,6 +458,8 @@ std::string UnitSAO::generateUpdatePositionCommand(const v3f &position,
 	writeU8(os, is_movement_end);
 	// update_interval (for interpolation)
 	writeF32(os, update_interval);
+	// do_interpolate_rotation
+	writeU8(os, do_interpolate_rotation);
 	return os.str();
 }
 

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -22,6 +22,10 @@ public:
 
 	// Rotation
 	void setRotation(v3f rotation) { m_rotation = rotation; }
+	void setRotation(v3f rotation, bool interpolate) {
+		m_rotation = rotation;
+		m_rotation_interpolate = interpolate;
+	}
 	const v3f &getRotation() const { return m_rotation; }
 	const v3f getTotalRotation() const {
 		// This replicates what happens clientside serverside
@@ -87,7 +91,8 @@ public:
 	std::string generateUpdateArmorGroupsCommand() const;
 	static std::string generateUpdatePositionCommand(const v3f &position,
 			const v3f &velocity, const v3f &acceleration, const v3f &rotation,
-			bool do_interpolate, bool is_movement_end, f32 update_interval);
+			bool do_interpolate, bool is_movement_end, f32 update_interval,
+			bool do_interpolate_rotation = true);
 	std::string generateSetPropertiesCommand(const ObjectProperties &prop) const;
 	static std::string generateUpdateBoneOverrideCommand(
 			const std::string &bone, const BoneOverride &props);
@@ -98,6 +103,7 @@ protected:
 
 	v3f m_rotation;
 	f32 m_rotation_add_yaw = 0;
+	bool m_rotation_interpolate = true; // per-update flag for rotation interpolation
 
 	ItemGroupList m_armor_groups;
 

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -39,6 +39,10 @@ public:
 
 	// Rotation
 	void setRotation(v3f rotation) { m_rotation = rotation; }
+	void setRotation(v3f rotation, bool interpolate) {
+		m_rotation = rotation;
+		m_rotation_interpolate = interpolate;
+	}
 	const v3f &getRotation() const { return m_rotation; }
 	core::quaternion getTotalRotation() const;
 	v3f getRadRotation() { return m_rotation * core::DEGTORAD; }
@@ -97,7 +101,8 @@ public:
 	std::string generateUpdateArmorGroupsCommand() const;
 	static std::string generateUpdatePositionCommand(const v3f &position,
 			const v3f &velocity, const v3f &acceleration, const v3f &rotation,
-			bool do_interpolate, bool is_movement_end, f32 update_interval);
+			bool do_interpolate, bool is_movement_end, f32 update_interval,
+			bool do_interpolate_rotation = true);
 	std::string generateSetPropertiesCommand(const ObjectProperties &prop) const;
 	static std::string generateUpdateBoneOverrideCommand(
 			const std::string &bone, const BoneOverride &props);
@@ -108,6 +113,7 @@ protected:
 
 	v3f m_rotation;
 	f32 m_rotation_add_yaw = 0;
+	bool m_rotation_interpolate = true; // per-update flag for rotation interpolation
 
 	ItemGroupList m_armor_groups;
 


### PR DESCRIPTION
Fixes: #16745
Related: https://github.com/luanti-org/minetest_game/pull/3255

Add compact, short information about your PR for easier understanding:

- Goal of the PR
- How does the PR work?
- Does it resolve any reported issue?
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
- If not a bug fix, why is this PR needed? What usecases does it solve?
- If you have used an LLM/AI to help with code or assets, you must disclose this.

Adds optional interpolate parameter to set_rotation(rotation, interpolate). When false, rotation snaps instantly on the client instead of blending over ~100ms. Default true preserves existing behavior.

Needed to fix [minetest_game#2950 and #2948 as the cart mod needs precise rotation timing that the engine's built-in interpolation prevents.](https://github.com/luanti-org/minetest_game/issues/2950)

Kiro was used to assist with code writing of the laid out tasks plan, after investigating.

## To do

This PR is a Ready for Review.

- [X] Property added, serialized, Lua-bound, client-side respected, backward compatibility sorted
- [X] Flag sent with AO_CMD_UPDATE_POSITION, backward compatible (extra byte, old clients ignore)
- [X] Client reads flag and uses rot_translator.init() vs .update()

## How to test

```
-- Snaps instantly (no client blending)
self.object:set_rotation(vector.new(math.pi/4, 0, 0), false)

-- Smooth interpolation (default, same as before)
self.object:set_rotation(vector.new(math.pi/4, 0, 0))
```