### PR TITLE
Add `listimages[]` element to allow styling inventory slots with textures

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3242,6 +3242,20 @@ Elements
 * Sets default background color of tooltips
 * Sets default font color of tooltips
 
+### `listimages[<slot_bgimg_normal>;<slot_bgimg_hover>]`
+
+* Works like `listcolors[]`, but uses images rather than solid colors.
+* `slot_bgimg_normal` Sets background image of slots.
+* `slot_bgimg_hover` Sets background image of slots when hovered.
+
+### `listimages[<slot_bgimg_normal>;<slot_bgimg_hover>;<tooltip_bgcolor>;<tooltip_fontcolor>]`
+
+* Works like `listcolors[]`, but uses images rather than solid colors.
+* `slot_bgimg_normal` Sets background image of slots.
+* `slot_bgimg_hover` Sets background image of slots when hovered.
+* Sets background color of tooltips for inventory slots.
+* Sets font color of tooltips for inventory slots.
+
 ### `tooltip[<gui_element_name>;<tooltip_text>;<bgcolor>;<fontcolor>]`
 
 * Adds tooltip for an element

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3245,8 +3245,13 @@ Elements
 ### `listimages[<slot_bgimg_normal>;<slot_bgimg_hover>]`
 
 * Works like `listcolors[]`, but uses images rather than solid colors.
-* `slot_bgimg_normal` (optional): Sets background image of slots.
-* `slot_bgimg_hover` (optional): Sets background image of slots when hovered.
+* `slot_bgimg_normal` Sets background image of slots. May be empty.
+* `slot_bgimg_hover` Sets background image of slots when hovered. May be empty.
+* When a field is empty, that texture is not set (slots keep the color from `listcolors[]` for that state).
+* Examples:
+    * `listimages[slot.png;slot_hover.png]`
+    * `listimages[slot.png;]`
+    * `listimages[;slot_hover.png]`
 
 ### `tooltip[<gui_element_name>;<tooltip_text>;<bgcolor>;<fontcolor>]`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3245,8 +3245,8 @@ Elements
 ### `listimages[<slot_bgimg_normal>;<slot_bgimg_hover>]`
 
 * Works like `listcolors[]`, but uses images rather than solid colors.
-* `slot_bgimg_normal` Sets background image of slots. May be empty.
-* `slot_bgimg_hover` Sets background image of slots when hovered. May be empty.
+* `slot_bgimg_normal`: Sets background image of slots. May be empty.
+* `slot_bgimg_hover`: Sets background image of slots when hovered. May be empty.
 * When a field is empty, that texture is not set (slots keep the color from `listcolors[]` for that state).
 * Examples:
     * `listimages[slot.png;slot_hover.png]`

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3245,16 +3245,8 @@ Elements
 ### `listimages[<slot_bgimg_normal>;<slot_bgimg_hover>]`
 
 * Works like `listcolors[]`, but uses images rather than solid colors.
-* `slot_bgimg_normal` Sets background image of slots.
-* `slot_bgimg_hover` Sets background image of slots when hovered.
-
-### `listimages[<slot_bgimg_normal>;<slot_bgimg_hover>;<tooltip_bgcolor>;<tooltip_fontcolor>]`
-
-* Works like `listcolors[]`, but uses images rather than solid colors.
-* `slot_bgimg_normal` Sets background image of slots.
-* `slot_bgimg_hover` Sets background image of slots when hovered.
-* Sets background color of tooltips for inventory slots.
-* Sets font color of tooltips for inventory slots.
+* `slot_bgimg_normal` (optional): Sets background image of slots.
+* `slot_bgimg_hover` (optional): Sets background image of slots when hovered.
 
 ### `tooltip[<gui_element_name>;<tooltip_text>;<bgcolor>;<fontcolor>]`
 

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -762,6 +762,19 @@ mouse control = true]
 		]]..
 		tooltip_fs,
 
+	--listimages
+		[[
+			formspec_version[11]
+			size[12,13]
+			list[current_player;main;1,1;8,1;0]
+
+			listimages[testformspec_node.png;testformspec_hovered.png]
+			list[current_player;main;1,3;8,2;8]
+
+			listimages[;testformspec_hovered.png^\[brighten]
+			list[current_player;main;1,6;8,1;24]
+		]],
+
 	-- Text alignment
 		"size[12,13]real_coordinates[true]" ..
 		"container[0.5,0.5]" .. text_alignment_fs .. "container_end[]",
@@ -774,7 +787,7 @@ local function show_test_formspec(pname)
 		page = page()
 	end
 
-	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Table,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Autoscroll,Sound,Background,Unsized,Tooltip,Tooltip+Listcolors,Text Alignment;" .. page_id .. ";false;false]"
+	local fs = page .. "tabheader[0,0;11,0.65;maintabs;Real Coord,Styles,Noclip,Table,Hypertext,Tabs,Invs,Window,Anim,Model,ScrollC,Autoscroll,Sound,Background,Unsized,Tooltip,Tooltip+Listcolors,Listimages,Text Alignment;" .. page_id .. ";false;false]"
 
 	core.show_formspec(pname, "testformspec:formspec", fs)
 end

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -551,7 +551,7 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 	GUIInventoryList *e = new GUIInventoryList(Environment, data->current_parent,
 			spec.fid, rect, m_invmgr, loc, listname, geom, start_i,
 			v2s32(slot_size.X, slot_size.Y), slot_spacing, this,
-			data->inventorylist_options, m_font);
+			data->inventorylist_options, m_font, m_tsrc);
 
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 
@@ -2544,6 +2544,40 @@ void GUIFormSpecMenu::parseListColors(parserData* data, const std::string &eleme
 	}
 }
 
+void GUIFormSpecMenu::parseListImages(parserData* data, const std::string &element)
+{
+	std::vector<std::string> parts;
+	// Supports:
+	// listimages[<normal>;<hover>]
+	// listimages[<normal>;<hover>;<tooltip_bgcolor>;<tooltip_fontcolor>]
+	if (!precheckElement("listimages", element, 2, 4, parts))
+		return;
+
+	std::string normal_str = unescape_string(parts[0]);
+	std::string hover_str  = unescape_string(parts[1]);
+
+	video::ITexture *normal_tex = m_tsrc->getTexture(normal_str);
+	video::ITexture *hover_tex  = m_tsrc->getTexture(hover_str);
+
+	data->inventorylist_options.slotbgimg_n = normal_tex;
+	data->inventorylist_options.slotbgimg_h = hover_tex;
+
+	// also update tooltip colors if provided
+	if (parts.size() >= 4) {
+		video::SColor tmp;
+
+		if (parseColorString(parts[2], tmp, false))
+			m_default_tooltip_bgcolor = tmp;
+		if (parseColorString(parts[3], tmp, false))
+			m_default_tooltip_color = tmp;
+	}
+
+	// update all already parsed inventorylists
+	for (GUIInventoryList *e : m_inventorylists) {
+		e->setSlotBGImages(normal_tex, hover_tex);
+	}
+}
+
 void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)
 {
 	std::vector<std::string> parts;
@@ -3113,6 +3147,7 @@ const std::unordered_map<std::string, std::function<void(GUIFormSpecMenu*, GUIFo
 		{"box",                    &GUIFormSpecMenu::parseBox},
 		{"bgcolor",                &GUIFormSpecMenu::parseBackgroundColor},
 		{"listcolors",             &GUIFormSpecMenu::parseListColors},
+		{"listimages",             &GUIFormSpecMenu::parseListImages},
 		{"tooltip",                &GUIFormSpecMenu::parseTooltip},
 		{"hypertip",               &GUIFormSpecMenu::parseHyperTip},
 		{"scrollbar",              &GUIFormSpecMenu::parseScrollBar},

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2562,11 +2562,6 @@ void GUIFormSpecMenu::parseListImages(parserData* data, const std::string &eleme
 
 	data->inventorylist_options.slotbgimg_n = normal_tex;
 	data->inventorylist_options.slotbgimg_h = hover_tex;
-
-	// update all already parsed inventorylists
-	for (GUIInventoryList *e : m_inventorylists) {
-		e->setSlotBGImages(normal_tex, hover_tex);
-	}
 }
 
 void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2552,16 +2552,13 @@ void GUIFormSpecMenu::parseListImages(parserData* data, const std::string &eleme
 	if (!precheckElement("listimages", element, 2, 2, parts))
 		return;
 
-	video::ITexture *normal_tex = !parts[0].empty()
+	data->inventorylist_options.slotbgimg_n.grab(!parts[0].empty()
 			? m_tsrc->getTexture(unescape_string(parts[0]))
-			: nullptr;
+			: nullptr);
 
-	video::ITexture *hover_tex = !parts[1].empty()
+	data->inventorylist_options.slotbgimg_h.grab(!parts[1].empty()
 			? m_tsrc->getTexture(unescape_string(parts[1]))
-			: nullptr;
-
-	data->inventorylist_options.slotbgimg_n.grab(normal_tex);
-	data->inventorylist_options.slotbgimg_h.grab(hover_tex);
+			: nullptr);
 }
 
 void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -551,7 +551,7 @@ void GUIFormSpecMenu::parseList(parserData *data, const std::string &element)
 	GUIInventoryList *e = new GUIInventoryList(Environment, data->current_parent,
 			spec.fid, rect, m_invmgr, loc, listname, geom, start_i,
 			v2s32(slot_size.X, slot_size.Y), slot_spacing, this,
-			data->inventorylist_options, m_font, m_tsrc);
+			data->inventorylist_options, m_font);
 
 	e->setNotClipped(style.getBool(StyleSpec::NOCLIP, false));
 
@@ -2549,28 +2549,19 @@ void GUIFormSpecMenu::parseListImages(parserData* data, const std::string &eleme
 	std::vector<std::string> parts;
 	// Supports:
 	// listimages[<normal>;<hover>]
-	// listimages[<normal>;<hover>;<tooltip_bgcolor>;<tooltip_fontcolor>]
-	if (!precheckElement("listimages", element, 2, 4, parts))
+	if (!precheckElement("listimages", element, 1, 2, parts))
 		return;
 
-	std::string normal_str = unescape_string(parts[0]);
-	std::string hover_str  = unescape_string(parts[1]);
+	video::ITexture *normal_tex = !parts[0].empty()
+			? m_tsrc->getTexture(unescape_string(parts[0]))
+			: nullptr;
 
-	video::ITexture *normal_tex = m_tsrc->getTexture(normal_str);
-	video::ITexture *hover_tex  = m_tsrc->getTexture(hover_str);
+	video::ITexture *hover_tex = (parts.size() >= 2 && !parts[1].empty())
+			? m_tsrc->getTexture(unescape_string(parts[1]))
+			: nullptr;
 
 	data->inventorylist_options.slotbgimg_n = normal_tex;
 	data->inventorylist_options.slotbgimg_h = hover_tex;
-
-	// also update tooltip colors if provided
-	if (parts.size() >= 4) {
-		video::SColor tmp;
-
-		if (parseColorString(parts[2], tmp, false))
-			m_default_tooltip_bgcolor = tmp;
-		if (parseColorString(parts[3], tmp, false))
-			m_default_tooltip_color = tmp;
-	}
 
 	// update all already parsed inventorylists
 	for (GUIInventoryList *e : m_inventorylists) {

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2549,14 +2549,14 @@ void GUIFormSpecMenu::parseListImages(parserData* data, const std::string &eleme
 	std::vector<std::string> parts;
 	// Supports:
 	// listimages[<normal>;<hover>]
-	if (!precheckElement("listimages", element, 1, 2, parts))
+	if (!precheckElement("listimages", element, 2, 2, parts))
 		return;
 
 	video::ITexture *normal_tex = !parts[0].empty()
 			? m_tsrc->getTexture(unescape_string(parts[0]))
 			: nullptr;
 
-	video::ITexture *hover_tex = (parts.size() >= 2 && !parts[1].empty())
+	video::ITexture *hover_tex = !parts[1].empty()
 			? m_tsrc->getTexture(unescape_string(parts[1]))
 			: nullptr;
 

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2560,8 +2560,8 @@ void GUIFormSpecMenu::parseListImages(parserData* data, const std::string &eleme
 			? m_tsrc->getTexture(unescape_string(parts[1]))
 			: nullptr;
 
-	data->inventorylist_options.slotbgimg_n = normal_tex;
-	data->inventorylist_options.slotbgimg_h = hover_tex;
+	data->inventorylist_options.slotbgimg_n.grab(normal_tex);
+	data->inventorylist_options.slotbgimg_h.grab(hover_tex);
 }
 
 void GUIFormSpecMenu::parseTooltip(parserData* data, const std::string &element)

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -510,6 +510,7 @@ private:
 	void parseBox(parserData* data, const std::string &element);
 	void parseBackgroundColor(parserData* data, const std::string &element);
 	void parseListColors(parserData* data, const std::string &element);
+	void parseListImages(parserData* data, const std::string &element);
 	void parseTooltip(parserData* data, const std::string &element);
 	bool parseVersionDirect(const std::string &data);
 	bool parseSizeDirect(parserData* data, const std::string &element);

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -106,9 +106,9 @@ void GUIInventoryList::draw()
 		const auto min = rect.UpperLeftCorner;
 		const auto max = rect.LowerRightCorner;
 		vertices.emplace_back(min.X, min.Y - 1, 4, 0,0,0, color, 0,0);
-		vertices.emplace_back(max.X, min.Y - 1, 4, 0,0,0, color, 0,0);
-		vertices.emplace_back(max.X, max.Y - 0, 4, 0,0,0, color, 0,0);
-		vertices.emplace_back(min.X, max.Y - 0, 4, 0,0,0, color, 0,0);
+		vertices.emplace_back(max.X, min.Y - 1, 4, 0,0,0, color, 1,0);
+		vertices.emplace_back(max.X, max.Y - 0, 4, 0,0,0, color, 1,1);
+		vertices.emplace_back(min.X, max.Y - 0, 4, 0,0,0, color, 0,1);
 	};
 
 	const s32 list_size = (s32)ilist->getSize();
@@ -143,32 +143,19 @@ void GUIInventoryList::draw()
 		bool hovering = item_i == m_hovered_i;
 
 		if (m_options.slotbgimg_n != nullptr) {
-			video::ITexture *tex = hovering && m_options.slotbgimg_h
-					? m_options.slotbgimg_h
-					: m_options.slotbgimg_n;
+			if (hovering) {
+				// the hovered slot
+				video::ITexture *tex = m_options.slotbgimg_h
+						? m_options.slotbgimg_h
+						: m_options.slotbgimg_n;
 
-			if (tex) {
-				std::vector<video::S3DVertex> verts;
-				std::vector<u16> indices = {0, 1, 2, 0, 2, 3};
-
-				const auto min = rect_clip.UpperLeftCorner;
-				const auto max = rect_clip.LowerRightCorner;
-				video::SColor white(255, 255, 255, 255);
-
-				verts.emplace_back(min.X, min.Y, 4, 0,0,0, white, 0,0);
-				verts.emplace_back(max.X, min.Y, 4, 0,0,0, white, 1,0);
-				verts.emplace_back(max.X, max.Y, 4, 0,0,0, white, 1,1);
-				verts.emplace_back(min.X, max.Y, 4, 0,0,0, white, 0,1);
-
-				video::SMaterial mat = driver->getMaterial2D();
-				mat.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-				mat.setTexture(0, tex);
-				driver->setMaterial(mat);
-
-				driver->draw2DVertexPrimitiveList(
-					verts.data(), verts.size(),
-					indices.data(), indices.size() / 3,
-					video::EVT_STANDARD, scene::EPT_TRIANGLES, video::EIT_16BIT);
+				if (tex) {
+					core::rect<s32> src(0, 0, tex->getOriginalSize().Width, tex->getOriginalSize().Height);
+					driver->draw2DImage(tex, rect_clip, src, &AbsoluteClippingRect, nullptr, true);
+				}
+			} else {
+				// all other non-hovered slots
+				add_rectangle(true, video::SColor(255, 255, 255, 255), rect_clip);
 			}
 		} else {
 			add_rectangle(true, hovering ? m_options.slotbg_h : m_options.slotbg_n, rect_clip);
@@ -219,7 +206,15 @@ void GUIInventoryList::draw()
 	}
 
 	video::SMaterial mat = driver->getMaterial2D();
-	mat.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
+
+	if (m_options.slotbgimg_n) {
+		mat.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+		mat.setTexture(0, m_options.slotbgimg_n);
+	} else {
+		mat.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
+		mat.setTexture(0, nullptr);
+	}
+
 	driver->setMaterial(mat);
 
 	driver->draw2DVertexPrimitiveList(
@@ -227,6 +222,11 @@ void GUIInventoryList::draw()
 		indices_3.data(), indices_3.size() / 3,
 		video::EVT_STANDARD, scene::EPT_TRIANGLES, video::EIT_16BIT
 	);
+
+	mat.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
+	mat.setTexture(0, nullptr);
+	driver->setMaterial(mat);
+
 	driver->draw2DVertexPrimitiveList(
 		vertices.data(), vertices.size(),
 		indices_2.data(), indices_2.size() / 2,

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -22,8 +22,7 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	const v2f32 &slot_spacing,
 	GUIFormSpecMenu *fs_menu,
 	const Options &options,
-	gui::IGUIFont *font,
-	ISimpleTextureSource *tsrc) :
+	gui::IGUIFont *font) :
 	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
 	m_invmgr(invmgr),
 	m_inventoryloc(inventoryloc),
@@ -35,7 +34,6 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	m_fs_menu(fs_menu),
 	m_options(options),
 	m_font(font),
-	m_tsrc(tsrc),
 	m_hovered_i(-1),
 	m_already_warned(false)
 {
@@ -142,21 +140,16 @@ void GUIInventoryList::draw()
 		bool selected = item_i == selected_index;
 		bool hovering = item_i == m_hovered_i;
 
-		if (m_options.slotbgimg_n != nullptr) {
-			if (hovering) {
-				// the hovered slot
-				video::ITexture *tex = m_options.slotbgimg_h
-						? m_options.slotbgimg_h
-						: m_options.slotbgimg_n;
+		if (hovering && m_options.slotbgimg_h) {
+			// the hovered slot
+			video::ITexture *tex = m_options.slotbgimg_h;
+			core::rect<s32> src(0, 0, tex->getOriginalSize().Width, tex->getOriginalSize().Height);
+			driver->draw2DImage(tex, rect_clip, src, &AbsoluteClippingRect, nullptr, true);
 
-				if (tex) {
-					core::rect<s32> src(0, 0, tex->getOriginalSize().Width, tex->getOriginalSize().Height);
-					driver->draw2DImage(tex, rect_clip, src, &AbsoluteClippingRect, nullptr, true);
-				}
-			} else {
-				// all other non-hovered slots
-				add_rectangle(true, video::SColor(255, 255, 255, 255), rect_clip);
-			}
+		} else if (m_options.slotbgimg_n) {
+			// all other non-hovered slots
+			add_rectangle(true, video::SColor(255, 255, 255, 255), rect_clip);
+
 		} else {
 			add_rectangle(true, hovering ? m_options.slotbg_h : m_options.slotbg_n, rect_clip);
 		}

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -142,8 +142,8 @@ void GUIInventoryList::draw()
 
 		if (hovering && m_options.slotbgimg_h) {
 			// the hovered slot
-			video::ITexture *tex = m_options.slotbgimg_h;
-			core::rect<s32> src(0, 0, tex->getOriginalSize().Width, tex->getOriginalSize().Height);
+			video::ITexture *tex = m_options.slotbgimg_h.get();
+			core::rect<s32> src(v2s32(), tex->getOriginalSize());
 			driver->draw2DImage(tex, rect_clip, src, &AbsoluteClippingRect, nullptr, true);
 
 		} else if (m_options.slotbgimg_n) {
@@ -202,7 +202,7 @@ void GUIInventoryList::draw()
 
 	if (m_options.slotbgimg_n) {
 		mat.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
-		mat.setTexture(0, m_options.slotbgimg_n);
+		mat.setTexture(0, m_options.slotbgimg_n.get());
 	} else {
 		mat.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 		mat.setTexture(0, nullptr);

--- a/src/gui/guiInventoryList.cpp
+++ b/src/gui/guiInventoryList.cpp
@@ -22,7 +22,8 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	const v2f32 &slot_spacing,
 	GUIFormSpecMenu *fs_menu,
 	const Options &options,
-	gui::IGUIFont *font) :
+	gui::IGUIFont *font,
+	ISimpleTextureSource *tsrc) :
 	gui::IGUIElement(gui::EGUIET_ELEMENT, env, parent, id, rectangle),
 	m_invmgr(invmgr),
 	m_inventoryloc(inventoryloc),
@@ -34,6 +35,7 @@ GUIInventoryList::GUIInventoryList(gui::IGUIEnvironment *env,
 	m_fs_menu(fs_menu),
 	m_options(options),
 	m_font(font),
+	m_tsrc(tsrc),
 	m_hovered_i(-1),
 	m_already_warned(false)
 {
@@ -67,6 +69,8 @@ void GUIInventoryList::draw()
 		return;
 	}
 	m_already_warned = false;
+
+	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	Client *client = m_fs_menu->getClient();
 	const ItemSpec *selected_item = m_fs_menu->getSelectedItem();
@@ -138,7 +142,37 @@ void GUIInventoryList::draw()
 		bool selected = item_i == selected_index;
 		bool hovering = item_i == m_hovered_i;
 
-		add_rectangle(true, hovering ? m_options.slotbg_h : m_options.slotbg_n, rect_clip);
+		if (m_options.slotbgimg_n != nullptr) {
+			video::ITexture *tex = hovering && m_options.slotbgimg_h
+					? m_options.slotbgimg_h
+					: m_options.slotbgimg_n;
+
+			if (tex) {
+				std::vector<video::S3DVertex> verts;
+				std::vector<u16> indices = {0, 1, 2, 0, 2, 3};
+
+				const auto min = rect_clip.UpperLeftCorner;
+				const auto max = rect_clip.LowerRightCorner;
+				video::SColor white(255, 255, 255, 255);
+
+				verts.emplace_back(min.X, min.Y, 4, 0,0,0, white, 0,0);
+				verts.emplace_back(max.X, min.Y, 4, 0,0,0, white, 1,0);
+				verts.emplace_back(max.X, max.Y, 4, 0,0,0, white, 1,1);
+				verts.emplace_back(min.X, max.Y, 4, 0,0,0, white, 0,1);
+
+				video::SMaterial mat = driver->getMaterial2D();
+				mat.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
+				mat.setTexture(0, tex);
+				driver->setMaterial(mat);
+
+				driver->draw2DVertexPrimitiveList(
+					verts.data(), verts.size(),
+					indices.data(), indices.size() / 3,
+					video::EVT_STANDARD, scene::EPT_TRIANGLES, video::EIT_16BIT);
+			}
+		} else {
+			add_rectangle(true, hovering ? m_options.slotbg_h : m_options.slotbg_n, rect_clip);
+		}
 
 		// Draw inv slot borders
 		if (m_options.slotborder) {
@@ -183,8 +217,6 @@ void GUIInventoryList::draw()
 			m_fs_menu->addHoveredItemTooltip(tooltip);
 		}
 	}
-
-	video::IVideoDriver *driver = Environment->getVideoDriver();
 
 	video::SMaterial mat = driver->getMaterial2D();
 	mat.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "client/texturesource.h"
 #include "inventorymanager.h"
 #include <IGUIElement.h>
 #include <IGUIEnvironment.h>
@@ -70,8 +69,7 @@ public:
 		const v2f32 &slot_spacing,
 		GUIFormSpecMenu *fs_menu,
 		const Options &options,
-		gui::IGUIFont *font,
-		ISimpleTextureSource *tsrc);
+		gui::IGUIFont *font);
 
 	void draw() override;
 
@@ -139,10 +137,6 @@ private:
 
 	// the font
 	gui::IGUIFont *m_font;
-
-	ISimpleTextureSource *m_tsrc;
-
-	ISimpleTextureSource *getTextureSource() { return m_tsrc; }
 
 	// the index of the hovered item; -1 if no item is hovered
 	s32 m_hovered_i;

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -97,12 +97,6 @@ public:
 		m_options.slotbg_h = slotbg_h;
 	}
 
-	void setSlotBGImages(video::ITexture *normal, video::ITexture *hover)
-	{
-		m_options.slotbgimg_n.grab(normal);
-		m_options.slotbgimg_h.grab(hover);
-	}
-
 	void setSlotBorders(bool slotborder, const video::SColor &slotbordercolor)
 	{
 		m_options.slotborder = slotborder;

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -8,6 +8,8 @@
 #include <IGUIElement.h>
 #include <IGUIEnvironment.h>
 #include "irr_v2d.h"
+#include "irr_ptr.h"
+#include "ITexture.h"
 
 
 class GUIFormSpecMenu;
@@ -52,8 +54,8 @@ public:
 		// colors for normal and highlighted slot background
 		video::SColor slotbg_n = video::SColor(255, 128, 128, 128);
 		video::SColor slotbg_h = video::SColor(255, 192, 192, 192);
-		video::ITexture *slotbgimg_n = nullptr;
-		video::ITexture *slotbgimg_h = nullptr;
+		irr_ptr<video::ITexture> slotbgimg_n;
+		irr_ptr<video::ITexture> slotbgimg_h;
 	};
 
 	GUIInventoryList(gui::IGUIEnvironment *env,
@@ -97,8 +99,8 @@ public:
 
 	void setSlotBGImages(video::ITexture *normal, video::ITexture *hover)
 	{
-		m_options.slotbgimg_n = normal;
-		m_options.slotbgimg_h = hover;
+		m_options.slotbgimg_n.grab(normal);
+		m_options.slotbgimg_h.grab(hover);
 	}
 
 	void setSlotBorders(bool slotborder, const video::SColor &slotbordercolor)

--- a/src/gui/guiInventoryList.h
+++ b/src/gui/guiInventoryList.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "client/texturesource.h"
 #include "inventorymanager.h"
 #include <IGUIElement.h>
 #include <IGUIEnvironment.h>
@@ -52,6 +53,8 @@ public:
 		// colors for normal and highlighted slot background
 		video::SColor slotbg_n = video::SColor(255, 128, 128, 128);
 		video::SColor slotbg_h = video::SColor(255, 192, 192, 192);
+		video::ITexture *slotbgimg_n = nullptr;
+		video::ITexture *slotbgimg_h = nullptr;
 	};
 
 	GUIInventoryList(gui::IGUIEnvironment *env,
@@ -67,7 +70,8 @@ public:
 		const v2f32 &slot_spacing,
 		GUIFormSpecMenu *fs_menu,
 		const Options &options,
-		gui::IGUIFont *font);
+		gui::IGUIFont *font,
+		ISimpleTextureSource *tsrc);
 
 	void draw() override;
 
@@ -91,6 +95,12 @@ public:
 	{
 		m_options.slotbg_n = slotbg_n;
 		m_options.slotbg_h = slotbg_h;
+	}
+
+	void setSlotBGImages(video::ITexture *normal, video::ITexture *hover)
+	{
+		m_options.slotbgimg_n = normal;
+		m_options.slotbgimg_h = hover;
 	}
 
 	void setSlotBorders(bool slotborder, const video::SColor &slotbordercolor)
@@ -129,6 +139,10 @@ private:
 
 	// the font
 	gui::IGUIFont *m_font;
+
+	ISimpleTextureSource *m_tsrc;
+
+	ISimpleTextureSource *getTextureSource() { return m_tsrc; }
 
 	// the index of the hovered item; -1 if no item is hovered
 	s32 m_hovered_i;


### PR DESCRIPTION
Closes #14870 

- **Goal of the PR**
  To allow styling inventory slots with textures.

- **How does the PR work?**
  It adds a new `listimages[]` formspec element

- **Does it resolve any reported issue?**
  Yes, #14870.

- **Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?**
  [UI Improvements](https://github.com/luanti-org/luanti/blob/master/doc/direction.md#23-ui-improvements)

- **If you have used an LLM/AI to help with code or assets, you must disclose this.**
  While I did use AI for guidance, not a single line of code was written by AI.

## To do

This PR is Ready for Review.

- [x] Add documentation to `lua_api.md`
- [x] Add examples to devtest in `/test_formspec`?

## How to test

<!-- Example code or instructions -->

1. Open Devtest and go to the "Listimages" tab in `/test_formspec`

<img width="1248" height="702" alt="output" src="https://github.com/user-attachments/assets/be4b6ca3-1f12-4d4f-9c2b-2bce0c656e22" />



