### PR TITLE
GUIHyperText: Disable delay hack for non-hypertip hypertext

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1761,7 +1761,8 @@ void GUIFormSpecMenu::parseHyperText(parserData *data, const std::string &elemen
 	GUIHyperText *e = new GUIHyperText(spec.flabel.c_str(), Environment,
 			data->current_parent, spec.fid, rect, m_client, m_tsrc,
 			video::SColor(0,0,0,0),
-			video::SColor(255,255,255,255));
+			video::SColor(255,255,255,255),
+			false);
 	e->drop();
 
 	m_fields.push_back(spec);
@@ -1861,7 +1862,8 @@ void GUIFormSpecMenu::parseHyperTip(parserData *data, const std::string &element
 		GUIHyperText *e = new GUIHyperText(spec.flabel.c_str(), Environment,
 				data->current_parent, spec.fid, rect, m_client, m_tsrc,
 				m_default_tooltip_bgcolor,
-				m_default_tooltip_color);
+				m_default_tooltip_color,
+				true);
 
 		auto style = getStyleForElement("hypertip", spec.fname);
 		e->setStyles(style);
@@ -3794,7 +3796,8 @@ void GUIFormSpecMenu::drawMenu()
 									parent_element->getParent(), field.fid,
 									spec.hover_rect, m_client, m_tsrc,
 									m_default_tooltip_bgcolor,
-									m_default_tooltip_color);
+									m_default_tooltip_color,
+									false);
 
 							auto style = getStyleForElement("hypertip", spec.name);
 							e->setStyles(style);

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -1065,13 +1065,15 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 		IGUIElement *parent, s32 id, const core::rect<s32> &rectangle,
 		Client *client, ISimpleTextureSource *tsrc,
 		video::SColor default_background_color,
-		video::SColor default_color) :
+		video::SColor default_color,
+		bool is_hypertip) :
 		IGUIElement(EGUIET_ELEMENT, environment, parent, id, rectangle),
 		m_tsrc(tsrc), m_vscrollbar(nullptr),
 		m_drawer(text, client, environment, tsrc, default_background_color, default_color),
 		m_text_scrollpos(0, 0),
 		m_default_background_color(default_background_color),
-		m_default_color(default_color)
+		m_default_color(default_color),
+		m_draw_state(is_hypertip ? 0 : 2) // disable delay hack for non-hypertip hypertext
 {
 
 	IGUISkin *skin = nullptr;

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -199,7 +199,8 @@ public:
 			const core::rect<s32> &rectangle, Client *client,
 			ISimpleTextureSource *tsrc,
 			video::SColor default_background_color,
-			video::SColor default_color);
+			video::SColor default_color,
+			bool is_hypertip = false);
 
 	//! destructor
 	virtual ~GUIHyperText();


### PR DESCRIPTION
Fixes #17313 

## To do

This PR is Ready for Review.

## How to test

Easiest way is to go to the ContentDB menu and select some big game with lots of screenshots and make sure there is no "flickering" due to the hypertext disappearing for the first frame every time the formspec updates.
