### PR TITLE
Main menu: Mod sorting and display improvements

### DIFF
--- a/builtin/common/filterlist.lua
+++ b/builtin/common/filterlist.lua
@@ -268,39 +268,3 @@ function sort_worlds_alphabetic(self)
 		return a.name:lower() < b.name:lower()
 	end)
 end
-
---------------------------------------------------------------------------------
-function sort_mod_list(self)
-
-	table.sort(self.m_processed_list, function(a, b)
-		-- Show game mods at bottom
-		if a.type ~= b.type or a.loc ~= b.loc then
-			if b.type == "game" then
-				return a.loc ~= "game"
-			end
-			return b.loc == "game"
-		end
-		-- If in same or no modpack, sort by name
-		if a.modpack == b.modpack then
-			if a.name:lower() == b.name:lower() then
-				return a.name < b.name
-			end
-			return a.name:lower() < b.name:lower()
-		-- Else compare name to modpack name
-		else
-			-- Always show modpack pseudo-mod on top of modpack mod list
-			if a.name == b.modpack then
-				return true
-			elseif b.name == a.modpack then
-				return false
-			end
-
-			local name_a = a.modpack or a.name
-			local name_b = b.modpack or b.name
-			if name_a:lower() == name_b:lower() then
-				return  name_a < name_b
-			end
-			return name_a:lower() < name_b:lower()
-		end
-	end)
-end

--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -743,8 +743,6 @@ function pkgmgr.reload_global_mods()
 	end
 	pkgmgr.global_mods = filterlist.create(pkgmgr.preparemodlist,
 			pkgmgr.comparemod, is_equal, nil, {})
-	pkgmgr.global_mods:add_sort_mechanism("alphabetic", sort_mod_list)
-	pkgmgr.global_mods:set_sortmode("alphabetic")
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -11,6 +11,8 @@ local function modname_valid(name)
 end
 
 local function init_data(data)
+	-- Note: `pkgmgr.global_mods` is similar, but without the world + gameid filter.
+
 	data.list = filterlist.create(
 		pkgmgr.preparemodlist,
 		pkgmgr.comparemod,

--- a/src/content/mod_configuration.cpp
+++ b/src/content/mod_configuration.cpp
@@ -39,7 +39,7 @@ void ModConfiguration::addModsInPath(const std::string &path, const std::string 
 {
 	verbosestream << "Adding mods from path " << path << " virtual=\""
 		<< virtual_path << "\"" << std::endl;
-	addMods(flattenMods(getModsInPath(path, virtual_path)));
+	addMods(flattenMods(getModsInPath(path, virtual_path), true));
 }
 
 void ModConfiguration::addMods(const std::vector<ModSpec> &new_mods)
@@ -147,7 +147,9 @@ void ModConfiguration::addModsFromConfig(
 	 * and used in an error message later.
 	 */
 	for (const auto &modPath : modPaths) {
-		std::vector<ModSpec> addon_mods_in_path = flattenMods(getModsInPath(modPath.second, modPath.first));
+		std::vector<ModSpec> addon_mods_in_path =
+			flattenMods(getModsInPath(modPath.second, modPath.first), true);
+
 		for (const auto &mod : addon_mods_in_path) {
 			const auto &pair = load_mod_names.find(mod.name);
 			if (pair != load_mod_names.end()) {

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -4,15 +4,20 @@
 
 #include <cctype>
 #include <fstream>
-#include <json/json.h>
 #include <algorithm>
 #include "content/mods.h"
 #include "database/database.h"
 #include "filesys.h"
 #include "log.h"
+#include "porting.h" // strcasecmp
 #include "settings.h"
 #include "script/common/c_internal.h"
 #include "exceptions.h"
+
+bool ModSpecSorter::operator()(const ModSpec &a, const ModSpec &b) const
+{
+	return strcasecmp(a.name.c_str(), b.name.c_str()) < 0;
+}
 
 void ModSpec::checkAndLog() const
 {
@@ -159,12 +164,12 @@ bool parseModContents(ModSpec &spec)
 	return true;
 }
 
-std::map<std::string, ModSpec> getModsInPath(
+ModSpecList getModsInPath(
 		const std::string &path, const std::string &virtual_path, int modpack_depth)
 {
 	// NOTE: this function works in mutual recursion with parseModContents
 
-	std::map<std::string, ModSpec> result;
+	ModSpecList result;
 	std::vector<fs::DirListNode> dirlist = fs::GetDirListing(path);
 	std::string mod_path;
 	std::string mod_virtual_path;
@@ -189,18 +194,16 @@ std::map<std::string, ModSpec> getModsInPath(
 
 		ModSpec spec(modname, mod_path, modpack_depth, mod_virtual_path);
 		if (parseModContents(spec)) {
-			result[modname] = std::move(spec);
+			result.emplace(std::move(spec));
 		}
 	}
 	return result;
 }
 
-std::vector<ModSpec> flattenMods(const std::map<std::string, ModSpec> &mods,
-		bool discard_modpacks)
+std::vector<ModSpec> flattenMods(const ModSpecList &mods, bool discard_modpacks)
 {
 	std::vector<ModSpec> result;
-	for (const auto &it : mods) {
-		const ModSpec &mod = it.second;
+	for (const ModSpec &mod : mods) {
 		if (!mod.is_modpack || !discard_modpacks) {
 			result.push_back(mod);
 		}
@@ -210,6 +213,9 @@ std::vector<ModSpec> flattenMods(const std::map<std::string, ModSpec> &mods,
 			result.insert(result.end(), content.begin(), content.end());
 		}
 	}
+
+	if (discard_modpacks)
+		std::sort(result.begin(), result.end(), ModSpecSorter());
 	return result;
 }
 

--- a/src/content/mods.cpp
+++ b/src/content/mods.cpp
@@ -14,7 +14,7 @@
 #include "script/common/c_internal.h"
 #include "exceptions.h"
 
-bool ModSpecSorter::operator()(const ModSpec &a, const ModSpec &b) const
+bool ModSpecCompare::operator()(const ModSpec &a, const ModSpec &b) const
 {
 	return strcasecmp(a.name.c_str(), b.name.c_str()) < 0;
 }
@@ -200,25 +200,27 @@ ModSpecList getModsInPath(
 	return result;
 }
 
+static void flatten_recursive(std::vector<ModSpec> &result, const ModSpecList &mods,
+		bool discard_modpacks)
+{
+	for (const ModSpec &mod : mods) {
+		if (!mod.is_modpack || !discard_modpacks)
+			result.push_back(mod);
+
+		if (mod.is_modpack)
+			flatten_recursive(result, mod.modpack_content, discard_modpacks);
+	}
+}
+
 std::vector<ModSpec> flattenMods(const ModSpecList &mods, bool discard_modpacks)
 {
 	std::vector<ModSpec> result;
-	for (const ModSpec &mod : mods) {
-		if (!mod.is_modpack || !discard_modpacks) {
-			result.push_back(mod);
-		}
-		if (mod.is_modpack) {
-			std::vector<ModSpec> content = flattenMods(mod.modpack_content, discard_modpacks);
-			result.reserve(result.size() + content.size());
-			result.insert(result.end(), content.begin(), content.end());
-		}
-	}
+	flatten_recursive(result, mods, discard_modpacks);
 
 	if (discard_modpacks)
-		std::sort(result.begin(), result.end(), ModSpecSorter());
+		std::sort(result.begin(), result.end(), ModSpecCompare());
 	return result;
 }
-
 
 ModStorage::ModStorage(const std::string &mod_name, ModStorageDatabase *database):
 	m_mod_name(mod_name), m_database(database)

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -6,13 +6,19 @@
 
 #include <vector>
 #include <string>
-#include <map>
+#include <set>
 #include <unordered_set>
 #include "metadata.h"
 
 class ModStorageDatabase;
+struct ModSpec;
 
 #define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_"
+
+struct ModSpecSorter {
+	bool operator()(const ModSpec &a, const ModSpec &b) const;
+};
+using ModSpecList = std::set<ModSpec, ModSpecSorter>;
 
 struct ModSpec
 {
@@ -53,7 +59,7 @@ struct ModSpec
 	std::vector<const char *> deprecation_msgs;
 
 	// if modpack:
-	std::map<std::string, ModSpec> modpack_content;
+	ModSpecList modpack_content;
 
 	ModSpec()
 	{
@@ -80,14 +86,14 @@ struct ModSpec
  * @param Path to search, should be absolute
  * @param modpack_depth If > 0: Is this searching within a modpack
  * @param virtual_path Virtual path for this directory, see comment in ModSpec
- * @returns map of mods
+ * @returns list of mods, sorted by name
  */
-std::map<std::string, ModSpec> getModsInPath(const std::string &path,
+ModSpecList getModsInPath(const std::string &path,
 		const std::string &virtual_path, int modpack_depth = 0);
 
 // replaces modpack Modspecs with their content
-std::vector<ModSpec> flattenMods(const std::map<std::string, ModSpec> &mods,
-		bool discard_modpacks = true);
+std::vector<ModSpec> flattenMods(const ModSpecList &mods,
+		bool discard_modpacks);
 
 
 class ModStorage : public IMetadata

--- a/src/content/mods.h
+++ b/src/content/mods.h
@@ -15,10 +15,10 @@ struct ModSpec;
 
 #define MODNAME_ALLOWED_CHARS "abcdefghijklmnopqrstuvwxyz0123456789_"
 
-struct ModSpecSorter {
+struct ModSpecCompare {
 	bool operator()(const ModSpec &a, const ModSpec &b) const;
 };
-using ModSpecList = std::set<ModSpec, ModSpecSorter>;
+using ModSpecList = std::set<ModSpec, ModSpecCompare>;
 
 struct ModSpec
 {

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -238,7 +238,7 @@ std::string findLocaleFileWithExtension(const std::string &path)
 /******************************************************************************/
 std::string findLocaleFileInMods(const std::string &path, const std::string &filename_no_ext)
 {
-	std::vector<ModSpec> mods = flattenMods(getModsInPath(path, "root", 0));
+	std::vector<ModSpec> mods = flattenMods(getModsInPath(path, "root", 0), true);
 
 	for (const auto &mod : mods) {
 		std::string ret = findLocaleFileWithExtension(


### PR DESCRIPTION
Commit 1: Fixes the mod sorting at the root, in C++.
~~Commit 2: Appends the technical name for reference e.g. in dependencies or when looking them up externally.~~  removed.

<img width="798" height="514" alt="comparison" src="https://github.com/user-attachments/assets/8abfa1e2-0eb2-477c-8c8a-8db094eeb18d" />


## To do

This PR is Ready for Review.

## How to test

1. Have a few modpacks
2. All modpacks must be displayed correctly, and mods must not suddenly turn into modpacks (which unfortunately happened with the `sort_mod_list` Lua sorting function)
3. The mods must all be sorted correctly