### PR TITLE
Clarify palette pixel repetition

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1144,9 +1144,11 @@ You can register one node/item, which can have up to 256 colors.
 
 When using palettes, you always provide a pixel index for the given
 node or `ItemStack`. The palette is read from left to right and from
-top to bottom. If the palette has less than 256 pixels, then it is
-stretched to contain exactly 256 pixels (after arranging the pixels
-to one line). Palette colors are indexed in range [0, 255].
+top to bottom. If the palette has fewer than 256 pixels, its pixels are
+repeated rather than interpolated after arranging them into one line.
+Use a power-of-two number of pixels so each color occupies an equal
+number of the 256 palette indices. Palette colors are indexed in range
+[0, 255].
 
 Examples:
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -1144,10 +1144,17 @@ You can register one node/item, which can have up to 256 colors.
 
 When using palettes, you always provide a pixel index for the given
 node or `ItemStack`. The palette is read from left to right and from
-top to bottom. If the palette has fewer than 256 pixels, its pixels are
-repeated rather than interpolated after arranging them into one line.
-Use a power-of-two number of pixels so each color occupies an equal
-number of the 256 palette indices. Palette colors are indexed in range
+top to bottom. Use textures with power-of-two dimensions (4x8, 16x4,
+16x16, ...), with at most 256 pixels. Smaller palettes are expanded to
+256 entries by repeating each source pixel without interpolation. For a
+palette with `area` pixels, the source color is selected using integer
+division:
+
+    color = palette[index / (256 / area)]
+
+Where `index` is the palette index, `area` is the texture pixel count,
+and `palette` contains the source texture colors. A node's `paramtype2`
+may reduce the usable index range. Palette colors are indexed in range
 [0, 255].
 
 Examples:
@@ -1157,8 +1164,8 @@ Examples:
 * 16x16 palette, index = 16: the pixel below the top left corner
 * 16x16 palette, index = 255: the bottom right corner
 * 2 (width) x 4 (height) palette, index = 31: the top left corner.
-  The palette has 8 pixels, so each pixel is stretched to 32 pixels,
-  to ensure the total 256 pixels.
+  The palette has 8 pixels, so each pixel is repeated across 32 indices,
+  to ensure the total 256 entries.
 * 2x4 palette, index = 32: the top right corner
 * 2x4 palette, index = 63: the top right corner
 * 2x4 palette, index = 64: the pixel below the top left corner


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR: Replace the ambiguous statement that small palettes are "stretched" with the actual index behavior: source pixels are repeated, not interpolated.
- How does the PR work? `TextureSource::getPalette()` computes `step = 256 / area`, appends each source pixel `step` times, and fills any remaining indices with white. The documentation now describes that behavior and recommends a power-of-two pixel count so every source color receives an equal share of the 256 indices.
- Does it resolve any reported issue? Closes #11927.
- Does this relate to a goal in the roadmap? No; this corrects existing API documentation.
- Why is this useful? A 16-pixel palette gives each color 16 consecutive indices, so a game can use the low 4 bits for color while retaining the high 4 bits for other state without manually expanding the image to 256 pixels.
- AI disclosure: OpenAI Codex assisted with repository-policy review, implementation, duplicate checking, and validation.

## To do

Ready for Review.

- [x] Verify the wording against the current palette expansion implementation.
- [x] Build the rendered Lua API documentation.

## How to test

Compare the updated paragraph with [`TextureSource::getPalette()`](https://github.com/luanti-org/luanti/blob/9438b4ef4bb6c5ee791ffd5269d7fbc8077071a8/src/client/texturesource.cpp#L495-L512):

- lines 495–498 warn when the pixel count does not divide 256;
- lines 501–507 repeat each source pixel `256 / area` times;
- lines 510–512 fill any leftover indices with white.

The repository-pinned MkDocs build completed successfully, and the generated textures page contains the corrected paragraph.
