### PR TITLE
GUIChatConsole: Fix (smooth) scrolling by arrows

### DIFF
--- a/irr/src/CGUIScrollBar.cpp
+++ b/irr/src/CGUIScrollBar.cpp
@@ -502,24 +502,34 @@ void CGUIScrollBar::refreshControls()
 	DownButton->setVisible(visible);
 }
 
-static inline s32 interpolate_scroll(s32 from, s32 to, f32 amount)
+static inline s32 interpolate_scroll(s32 from, s32 to, u32 deltaMs)
 {
-	s32 step = core::round32((to - from) * core::clamp(amount, 0.001f, 1.0f));
-	if (step == 0)
+	const s32 diff = to - from;
+	if (diff == 0)
 		return to;
+
+	// Adjust to match 60 FPS. This also means that interpolation is
+	// effectively disabled at <= 30 FPS.
+	s32 step = core::round32(diff * 0.5f * (deltaMs / 16.667f));
+	// Step at least by 1. Relevant for low ranges.
+	if (step == 0)
+		step = (diff > 0) * 2 - 1; // { 0, 1 } -> { -1, 1 }
+
+	// Note: This is clamped later by `setPosRaw`.
 	return from + step;
 }
 
 void CGUIScrollBar::interpolatePos(u32 deltaMs)
 {
-	if (TargetPos.has_value()) {
-		// Adjust to match 60 FPS. This also means that interpolation is
-		// effectively disabled at <= 30 FPS.
-		f32 amount = 0.5f * (deltaMs / 16.667f);
-		setPosRaw(interpolate_scroll(Pos, *TargetPos, amount));
-		if (Pos == TargetPos)
-			TargetPos = std::nullopt;
+	if (!TargetPos.has_value())
+		return;
 
+	const s32 oldPos = Pos;
+	setPosRaw(interpolate_scroll(Pos, *TargetPos, deltaMs));
+	if (Pos == TargetPos)
+		TargetPos = std::nullopt;
+
+	if (Pos != oldPos) {
 		SEvent e;
 		e.EventType = EET_GUI_EVENT;
 		e.GUIEvent.Caller = this;

--- a/irr/src/CGUIScrollBar.cpp
+++ b/irr/src/CGUIScrollBar.cpp
@@ -510,7 +510,8 @@ static inline s32 interpolate_scroll(s32 from, s32 to, u32 deltaMs)
 
 	// Adjust to match 60 FPS. This also means that interpolation is
 	// effectively disabled at <= 30 FPS.
-	s32 step = core::round32(diff * 0.5f * (deltaMs / 16.667f));
+	f32 factor = std::min(0.5f * (deltaMs / 16.667f), 1.0f);
+	s32 step = core::round32(diff * factor);
 	// Step at least by 1. Relevant for low ranges.
 	if (step == 0)
 		step = (diff > 0) * 2 - 1; // { 0, 1 } -> { -1, 1 }

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -200,11 +200,7 @@ void ChatBuffer::scrollAbsolute(s32 scroll)
 	s32 top = getTopScrollPos();
 	s32 bottom = getBottomScrollPos();
 
-	m_scroll = scroll;
-	if (m_scroll < top)
-		m_scroll = top;
-	if (m_scroll > bottom)
-		m_scroll = bottom;
+	m_scroll = std::clamp(scroll, top, bottom); // Note: bottom > top
 }
 
 void ChatBuffer::scrollBottom()

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -19,6 +19,11 @@
 #include <IVideoDriver.h>
 #include <string>
 
+/// Scrollbars use integers, hence give enough room to interpolate for smooth scrolling.
+static constexpr s32 SCROLLBAR_SCALE = 128;
+static constexpr s32 SCROLL_SMALL_STEP = 3;
+
+
 inline u32 clamp_u8(s32 value)
 {
 	return (u32) MYMIN(MYMAX(value, 0), 255);
@@ -89,8 +94,9 @@ GUIChatConsole::GUIChatConsole(
 
 	m_scrollbar.reset(new GUIScrollBar(env, this, -1, core::rect<s32>(0, 0, 30, m_height), false, tsrc));
 	m_scrollbar->setSubElement(true);
-	m_scrollbar->setLargeStep(1);
-	m_scrollbar->setSmallStep(1);
+	// Steps = Amount of chat lines
+	m_scrollbar->setLargeStep(SCROLLBAR_SCALE * 5);
+	m_scrollbar->setSmallStep(SCROLLBAR_SCALE * SCROLL_SMALL_STEP);
 }
 
 void GUIChatConsole::openConsole(f32 scale)
@@ -353,7 +359,7 @@ void GUIChatConsole::drawText()
 		}
 	}
 
-	updateScrollbar();
+	updateScrollbar(false);
 }
 
 void GUIChatConsole::drawPrompt()
@@ -668,7 +674,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 	{
 		if (event.MouseInput.Event == EMIE_MOUSE_WHEEL)
 		{
-			s32 rows = myround(-3.0 * event.MouseInput.Wheel);
+			s32 rows = myround(-SCROLL_SMALL_STEP * event.MouseInput.Wheel);
 			m_chat_backend->scroll(rows);
 		}
 		// Middle click or ctrl-click opens weblink, if enabled in config
@@ -703,7 +709,11 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 	else if (event.EventType == EET_GUI_EVENT && event.GUIEvent.EventType == EGET_SCROLL_BAR_CHANGED &&
 			(void*) event.GUIEvent.Caller == (void*) m_scrollbar.get())
 	{
-		m_chat_backend->getConsoleBuffer().scrollAbsolute(m_scrollbar->getPos());
+		ChatBuffer &buf = m_chat_backend->getConsoleBuffer();
+		buf.scrollAbsolute(
+			(m_scrollbar->getPos() + (SCROLLBAR_SCALE / 2)) / SCROLLBAR_SCALE
+		);
+		m_pos_scrolled_by_scrollbar = buf.getScrollPosition();
 	}
 
 	return Parent ? Parent->OnEvent(event) : false;
@@ -793,10 +803,12 @@ void GUIChatConsole::updatePrimarySelection()
 void GUIChatConsole::updateScrollbar(bool update_size)
 {
 	ChatBuffer &buf = m_chat_backend->getConsoleBuffer();
-	m_scrollbar->setMin(buf.getTopScrollPos());
-	m_scrollbar->setMax(buf.getBottomScrollPos());
-	m_scrollbar->setPos(buf.getScrollPosition());
+	m_scrollbar->setMin(SCROLLBAR_SCALE * buf.getTopScrollPos());
+	m_scrollbar->setMax(SCROLLBAR_SCALE * buf.getBottomScrollPos());
 	m_scrollbar->setPageSize(m_fontsize.Y * buf.getLineCount());
+	if (buf.getScrollPosition() != m_pos_scrolled_by_scrollbar)
+		m_scrollbar->setPos(SCROLLBAR_SCALE * buf.getScrollPosition());
+
 	m_scrollbar->setVisible(m_scrollbar->getMin() != m_scrollbar->getMax());
 
 	if (update_size) {

--- a/src/gui/guiChatConsole.h
+++ b/src/gui/guiChatConsole.h
@@ -76,13 +76,16 @@ private:
 	// If the selected text changed, we need to update the (X11) primary selection.
 	void updatePrimarySelection();
 
-	void updateScrollbar(bool update_size = false);
+	void updateScrollbar(bool update_size);
 
 private:
 	ChatBackend* m_chat_backend;
 	Client* m_client;
 	IMenuManager* m_menumgr;
 	irr_ptr<GUIScrollBar> m_scrollbar;
+	/// Tells apart whether the chat was scrolled by the scrollbar or
+	/// directly (new messages, Page Up/Down or Wheel)
+	s32 m_pos_scrolled_by_scrollbar = -1;
 
 	// current screen size
 	v2u32 m_screensize;


### PR DESCRIPTION
Fixes #17342

1. Scaling factor to actually have a smooth animated scrollbar (when scrolling with it, and with `smooth_scrolling = true`)
2. Variable `m_pos_scrolled_by_scrollbar` to tell apart whether the chat was scrolled (e.g. new messages) or whether the scrollbar was used. This is important to not revert the scrollbar position while it's still animating.
3. Make it such that scrolling always increments by 3 lines (new constant). Previously, this was different between scrollbar and the chat lines "part".

In the long run I would recommend to forward all key/wheel inputs to the scrollbar, such that scollbar fully controls the scroll position of the chat dialog. However, forwarding them is tricky because `CGUIScrollBar` forwards them to the parent again, i.e. recursion.

## To do

This PR is Ready for Review.

## How to test

1. Use the setting `smooth_scrolling = true`
2. Scrollbars must continue to work (e.g. sound volume settings, or `/test_formspec`)
3. Chat console scrollbar must work as intended (small and large size). It must be animated.
4. When scrolling in the chat console directly, the scrollbar position must update accordingly.
5. Use the setting `smooth_scrolling = false`
6. Test stuff

