### PR TITLE
Fix AbsolutePath returning non identical strings on semantically identical paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ AppDir
 !/clientmods/preview/
 /client/mod_storage/
 /mod_data
+/build-unit
 
 ## Configuration/log files
 minetest.conf

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ AppDir
 !/clientmods/preview/
 /client/mod_storage/
 /mod_data
-/build-unit
 
 ## Configuration/log files
 minetest.conf

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -5,6 +5,7 @@
 #include "filesys.h"
 #include "util/string.h"
 #include <iostream>
+#include <filesystem>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -841,8 +842,25 @@ std::string AbsolutePath(const std::string &path)
 #endif
 	if (!abs_path)
 		return "";
-	std::string abs_path_str(abs_path);
+	std::filesystem::path absolute_path(abs_path);
 	free(abs_path);
+
+	//remove any trailing delim before return
+	std::filesystem::path root_path = absolute_path.root_path();
+	if (absolute_path == root_path) {
+		std::string abs_path_str = absolute_path.string();
+		return abs_path_str;
+	}
+	std::string path_string = absolute_path.string();
+	std::string root_string = root_path.string();
+	while (path_string.length() > root_string.length()) {
+		if (IsDirDelimiter(path_string.back())) {
+			path_string.pop_back();
+		} else {
+		break;
+		}
+	}
+	std::string abs_path_str = path_string;
 	return abs_path_str;
 }
 

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -845,22 +845,11 @@ std::string AbsolutePath(const std::string &path)
 	std::filesystem::path absolute_path(abs_path);
 	free(abs_path);
 
-	//remove any trailing delim before return
-	std::filesystem::path root_path = absolute_path.root_path();
-	if (absolute_path == root_path) {
-		std::string abs_path_str = absolute_path.string();
-		return abs_path_str;
-	}
-	std::string path_string = absolute_path.string();
-	std::string root_string = root_path.string();
-	while (path_string.length() > root_string.length()) {
-		if (IsDirDelimiter(path_string.back())) {
-			path_string.pop_back();
-		} else {
-		break;
-		}
-	}
-	std::string abs_path_str = path_string;
+	// remove any trailing delim before return
+	std::string abs_path_str = absolute_path.string();
+	std::string root_string = absolute_path.root_path().string();
+	while (abs_path_str.length() > root_string.length() && IsDirDelimiter(abs_path_str.back()))
+		abs_path_str.pop_back();
 	return abs_path_str;
 }
 

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -842,7 +842,7 @@ std::string AbsolutePath(const std::string &path)
 #endif
 	if (!abs_path)
 		return "";
-	std::filesystem::path absolute_path(abs_path);
+	std::filesystem::path absolute_path(abs_path, std::filesystem::path::format::native_format);
 	free(abs_path);
 
 	// remove any trailing delim before return

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -6,6 +6,7 @@
 
 #include <sstream>
 #include <algorithm>
+#include <filesystem>
 
 #include "log.h"
 #include "serialization.h"
@@ -338,7 +339,13 @@ void TestFileSys::testAbsolutePath()
 		const auto dir_path2 = getTestTempFile();
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2), ""); // doesn't exist
 		fs::CreateDir(dir_path2);
-		UASSERTCMP(auto, !=, fs::AbsolutePath(dir_path2), ""); // now it does
+		const auto absolute_dir_path = fs::AbsolutePath(dir_path2);
+		UASSERTCMP(auto, !=, absolute_dir_path, "");// now it does
+		const std::filesystem::path absolute_path(absolute_dir_path);
+		const std::string root_path = absolute_path.root_path().string();
+		UASSERTEQ(auto, fs::AbsolutePath(root_path), root_path);
+		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + DIR_DELIM), absolute_dir_path);
+		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + DIR_DELIM + DIR_DELIM), absolute_dir_path);
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + DIR_DELIM ".."), fs::AbsolutePath(dir_path));
 		// excess . and / are removed
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + p("//..")), fs::AbsolutePath(dir_path));

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -341,7 +341,8 @@ void TestFileSys::testAbsolutePath()
 		fs::CreateDir(dir_path2);
 		const auto absolute_dir_path = fs::AbsolutePath(dir_path2);
 		UASSERTCMP(auto, !=, absolute_dir_path, "");// now it does
-		const std::filesystem::path absolute_path(absolute_dir_path);
+		const std::filesystem::path absolute_path(absolute_dir_path,
+				std::filesystem::path::format::native_format);
 		const std::string root_path = absolute_path.root_path().string();
 		UASSERTEQ(auto, fs::AbsolutePath(root_path), root_path);
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + DIR_DELIM), absolute_dir_path);


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

AbsolutePath should return identical strings for semantically identical strings but previously could return: C:/Test/Path and C:/Test/Path/ depending on what the function was called on. This lead to failing tests because other functions expected identical outputs. The invalid string position would wrongfully assume that one path had a delimiter and then move to the other side of the delimiter to attempt comparison but since they were the same path it was an out of bounds index.

Part of #17354 
## To do

This PR is Ready for Review.

I added unit tests that ensure AbsolutePath returns as expected. I also tested master branch for non ASCII character handling(it doesn't) to ensure my fix didn't break previous functionality