### PR TITLE
Improve volumetric lighting performance

### DIFF
--- a/client/shaders/volumetric_light/opengl_fragment.glsl
+++ b/client/shaders/volumetric_light/opengl_fragment.glsl
@@ -32,9 +32,18 @@ float noise(vec3 uvd) {
 
 float sampleVolumetricLight(vec2 uv, vec3 lightVec, float rawDepth)
 {
+	// We use the depth map to approximate the effect of depth on the light intensity.
+	// The exponent was chosen based on aesthetic preference.
+	float depthFactor = pow(rawDepth, 128.0);
+	// depthFactor only collapses below 1e-4 for geometry within about 1.5
+	// nodes of the camera (with the default 0.1 node near plane), where the
+	// result is zeroed anyway and the raymarch can be skipped.
+	if (depthFactor < 1e-4)
+		return 0.;
+
 	lightVec = 0.5 * lightVec / lightVec.z + 0.5;
 	const float samples = 30.;
-	float result = texture2D(depthmap, uv).r < 1. ? 0.0 : 1.0;
+	float result = rawDepth < 1. ? 0.0 : 1.0;
 	float bias = noise(vec3(uv, rawDepth));
 	vec2 samplepos;
 	for (float i = 1.; i < samples; i++) {
@@ -42,9 +51,7 @@ float sampleVolumetricLight(vec2 uv, vec3 lightVec, float rawDepth)
 		if (min(samplepos.x, samplepos.y) > 0. && max(samplepos.x, samplepos.y) < 1.)
 			result += texture2D(depthmap, samplepos).r < 1. ? 0.0 : 1.0;
 	}
-	// We use the depth map to approximate the effect of depth on the light intensity.
-	// The exponent was chosen based on aesthetic preference.
-	return result / samples * pow(texture2D(depthmap, uv).r, 128.0);
+	return result / samples * depthFactor;
 }
 
 vec3 getDirectLightScatteringAtGround(vec3 v_LightDirection)
@@ -78,13 +85,17 @@ vec3 applyVolumetricLight(vec3 color, vec2 uv, float rawDepth)
 		sourcePosition = moonPositionScreen;
 	}
 
-	float cameraDirectionFactor = pow(clamp(dot(sourcePosition, vec3(0., 0., 1.)), 0.0, 0.7), 2.5);
-	float viewAngleFactor = pow(max(0., dot(sourcePosition, lookDirection)), 8.);
+	// No visible light source (sun/moon below horizon or behind the camera):
+	// lightFactor would be 0, so the raymarch can be skipped entirely.
+	if (brightness > 0.) {
+		float cameraDirectionFactor = pow(clamp(dot(sourcePosition, vec3(0., 0., 1.)), 0.0, 0.7), 2.5);
+		float viewAngleFactor = pow(max(0., dot(sourcePosition, lookDirection)), 8.);
 
-	float lightFactor = brightness * sampleVolumetricLight(uv, sourcePosition, rawDepth) *
-			(0.05 * cameraDirectionFactor + 0.95 * viewAngleFactor);
+		float lightFactor = brightness * sampleVolumetricLight(uv, sourcePosition, rawDepth) *
+				(0.05 * cameraDirectionFactor + 0.95 * viewAngleFactor);
 
-	color = mix(color, boost * getDirectLightScatteringAtGround(v_LightDirection) * dayLight, lightFactor);
+		color = mix(color, boost * getDirectLightScatteringAtGround(v_LightDirection) * dayLight, lightFactor);
+	}
 
 	// a factor of 5 tested well
 	color *= volumetricLightStrength * 5.0;

--- a/src/client/render/secondstage.cpp
+++ b/src/client/render/secondstage.cpp
@@ -215,19 +215,36 @@ RenderStep *addPostProcessing(RenderPipeline *pipeline, RenderStep *previousStep
 			source = TEXTURE_BLOOM;
 		}
 
+		u8 downsample_start = 0;
 		if (enable_volumetric_light) {
-			buffer->setTexture(TEXTURE_VOLUME, scale, "volume", bloom_format);
+			// The volumetric pass is expensive (a raymarch per target pixel)
+			// and its output only reaches the screen through the blur of the
+			// bloom chain, whose first target is half resolution anyway. So
+			// with performance_tradeoffs enabled, render it directly into the
+			// first downsample target and skip the then-redundant first
+			// bloom_downsample step.
+			const bool half_res = g_settings->getFlag("performance_tradeoffs");
 
 			shader_id = client->getShaderSource()->getShaderRaw("volumetric_light");
 			auto volume = pipeline->addStep<PostProcessingStep>(shader_id, std::vector<u8> { source, TEXTURE_DEPTH });
 			volume->setRenderSource(buffer);
-			volume->setRenderTarget(pipeline->createOwned<TextureBufferOutput>(buffer, TEXTURE_VOLUME));
-			source = TEXTURE_VOLUME;
+			if (half_res) {
+				// Only the color input is minified; depth stays unfiltered
+				// because the shader does exact comparisons against 1.0.
+				volume->setBilinearFilter(0, true);
+				volume->setRenderTarget(pipeline->createOwned<TextureBufferOutput>(buffer, TEXTURE_SCALE_DOWN));
+				source = TEXTURE_SCALE_DOWN;
+				downsample_start = 1;
+			} else {
+				buffer->setTexture(TEXTURE_VOLUME, scale, "volume", bloom_format);
+				volume->setRenderTarget(pipeline->createOwned<TextureBufferOutput>(buffer, TEXTURE_VOLUME));
+				source = TEXTURE_VOLUME;
+			}
 		}
 
 		// downsample
 		shader_id = client->getShaderSource()->getShaderRaw("bloom_downsample");
-		for (u8 i = 0; i < MIPMAP_LEVELS; i++) {
+		for (u8 i = downsample_start; i < MIPMAP_LEVELS; i++) {
 			auto step = pipeline->addStep<PostProcessingStep>(shader_id, std::vector<u8> { source });
 			step->setRenderSource(buffer);
 			step->setBilinearFilter(0, true);


### PR DESCRIPTION
- **Goal of the PR:** Cut the GPU cost of volumetric lighting ("godrays"), which is currently one of the more expensive effect toggles, without visible quality loss.

- **How does the PR work?** Two commits.

  **1. Skip the raymarch when it cannot contribute.** Two early exits, neither changes the visible output:
  - The first exit fires when the sun or moon is behind the camera. Not merely off-screen, but actually behind you: the shader checks the sign of the light's position in camera space (`sunPositionScreen.z > 0`), which covers the whole hemisphere in front. A sun just past the edge of the screen still counts as in front and still costs full price.
  - The second exit is per pixel, not per frame. Any pixel showing geometry closer than about 1.5 nodes skips its own raymarch, because `pow(depth, 128.0)` has already collapsed to nothing there. In practice that means a wall right in front of your face, rather than terrain or being underground in general. This one is more "cheap insurance" than anything, and is not bit-exact. It discards a contribution below `1e-4`.

  I tested with a wider hemisphere pan by panning away from the sun in a fixed spot. The cost stays at full price after the sun has left the screen, then falls off gradually, then hits a flat floor once the sun is behind you (> 90 degrees to either side). Measured in a sealed box at /permatime 06:00 (external mod) with half res off. I saw 95 ms facing the sun, still 95 ms panned northeast far enough to put it off screen, then tapering to a flat 54 ms that holds across the whole rear half from north through west to south. 
  
  My understanding is that the taper is not the exit fading in, but rather the existing upstream loop skipping samples that land outside the screen as the sun's projected position runs off toward infinity. Rays behave the same way (still visible with the sun off-screen), because the march walks toward the sun's projected position and its path still crosses on-screen sky. Cutting the pass when the sun leaves the frustum would delete godrays that are genuinely visible.

  For the same reason this is a direction test and not an occlusion test. With the sun in front of the camera but hidden behind a ridge, the pass still runs at full cost, which is correct: that is exactly the view the shafts around the ridge come from.

  We also reuse the already fetched `rawDepth` instead of sampling the depth map twice more at the same UV.

  **2. Render the pass at half resolution when `performance_tradeoffs` is enabled.** The volumetric output only reaches the screen through the bloom downsample/upsample blur chain. That chain's first target is already half resolution. Full res computes 4x the raymarch work to produce detail the first downsample immediately discards. With tradeoffs enabled, the pass renders straight into the first bloom downsample, skipping the then-redundant full to half `bloom_downsample` step. The color input gets bilinear filtering for the minification and the depth input stays nearest as the shader does exact `< 1.0` comparisons.

  To be clear about where the win comes from: it is the 4x reduction in marched pixels. Skipping the first `bloom_downsample` measured perf-neutral on its own, since it is a 13-tap blur on a half-size target either way. That step is dropped because it has become redundant, not because it was costing frames.

  No new setting per sfan5: this reuses the existing `performance_tradeoffs`, so it's off by default on desktop and on by default on Android.

- **Measured** — M1 MacBook Air, legacy GL, 880x510, worst-case noon sun, 30 samples, frame time in ms:

  | build | facing the sun | facing away |
  |---|---|---|
  | master | 83 | 98 |
  | + early exits | 81 | 48.5 |
  | + half res (`performance_tradeoffs`) | 49.5 | 42.9 |

  The early exits are the whole win when you are not looking at the sun and half res is the whole win when you are.

- **Does it resolve any reported issue?** No.

- **Does this relate to a goal in the roadmap?** No. This is client rendering performance, so it needs a concept approval.

- **If not a bug fix, why is this PR needed? What usecases does it solve?** Volumetric lighting is expensive enough that weaker GPUs (integrated graphics, older laptops, Android) effectively cannot leave it on. Commit 1 removes cost that buys nothing at all while commit 2 gives an extra boost to those already using tradeoffs and allows them to enjoy the aesthetics of Volumetric Lighting.

- **If you have used an LLM/AI to help with code or assets, you must disclose this.** Yes, assisted by Claude. All measurements are mine on real hardware, and I have reviewed and tested every change personally on a local build of this branch.

## To do

This PR is Ready for Review.

## How to test

### Early exits
1. Enable bloom + volumetric lighting (Settings -> Graphics -> Effects), `/time 6:00` or noon, and look toward the sun.
2. Compare FPS and godray appearance against master in the same world and position. Rays should look the same. FPS should be noticeably higher on GPU-bound systems.
3. Turn to face away from the sun (at night, away from the moon). The pass should now cost close to nothing. Note that facing a ridge that hides the sun is *not* this case and still costs full price.
4. For the second exit, stand flush against a wall so it is under ~1.5 nodes away and fills the view. Draw time should drop even while facing the sun. In a 3x3x3 box, standing in the middle is about 1.5 nodes from the wall and sits right on the threshold, so move up against it.

### Half resolution
1. Enable "Tradeoffs for performance", bloom and volumetric lighting. Rejoin the world and observe the god rays from a fixed position at a fixed time. 
2. Leave and disable Tradeoffs, then join and compare again from the same position/time. They should exhibit no visual quality loss. FPS should be higher and draw time lower.
3. As a regression test (this path is untouched), turn off VL and verify bloom-only performs the same as `master` branch.
