### PR TITLE
GameFormSpec: Rewrite builtin formspecs with real coordinates

### DIFF
--- a/builtin/game/death_screen.lua
+++ b/builtin/game/death_screen.lua
@@ -3,11 +3,12 @@ local S = core.get_translator("__builtin")
 
 function core.show_death_screen(player, _reason)
 	local fs = {
-		"formspec_version[1]",
-		"size[11,5.5,true]",
+		"formspec_version[2]",
+		"size[14.25,7.275,true]",
 		"bgcolor[#320000b4;true]",
-		"label[4.85,1.35;", F(S("You died")), "]",
-		"button_exit[4,3;3,0.5;btn_respawn;", F(S("Respawn")), "]",
+		"style_type[label;halign=center;valign=center]",
+		"label[5.375,1.85;3.5,0.8;", F(S("You died")), "]",
+		"button_exit[5.375,3.725;3.5,0.8;btn_respawn;", F(S("Respawn")), "]",
 	}
 	core.show_formspec(player:get_player_name(), "__builtin:death", table.concat(fs, ""))
 end

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -353,7 +353,7 @@ void GameFormSpec::showPlayerInventory(const std::string *fs_override)
 	fs_src.release(); // owned by GUIFormSpecMenu
 }
 
-#define SIZE_TAG "size[11,5.5,true]" // Fixed size (ignored in touchscreen mode)
+#define SIZE_TAG "size[14.25,7.275,true]" // Fixed size (ignored in touchscreen mode)
 
 void GameFormSpec::showPauseMenu()
 {
@@ -377,46 +377,56 @@ void GameFormSpec::showPauseMenu()
 
 	auto simple_singleplayer_mode = m_client->m_simple_singleplayer_mode;
 
-	float ypos = simple_singleplayer_mode ? 0.7f : 0.1f;
+	const float button_height = 0.8f;
+	const float spacing = 0.38f;
+	float ypos = simple_singleplayer_mode ? 1.05f : 0.325f;
 	std::ostringstream os;
 
-	os << "formspec_version[1]" << SIZE_TAG
-		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_continue;"
+	os << "formspec_version[2]" << SIZE_TAG;
+
+	if (simple_singleplayer_mode) {
+		os << "style_type[label;halign=center;valign=center]";
+		os << "label[5.375,0;3.5," << ypos << ";" << strgettext("Game paused") << "]";
+	}
+
+	os << "container[5.375,0]";
+	os << "button_exit[0," << ypos << ";3.5," << button_height << ";btn_continue;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short
 		<< strgettext("Continue") << "]";
 
 	if (!simple_singleplayer_mode) {
-		os << "button[4," << (ypos++) << ";3,0.5;btn_change_password;"
+		os << "button[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_change_password;"
 			// TRANSLATORS: Pause menu button, try to keep the translation short
 			<< strgettext("Change Password") << "]";
-	} else {
-		os << "field[4.95,0;5,1.5;;" << strgettext("Game paused") << ";]";
 	}
 
-	os	<< "button[4," << (ypos++) << ";3,0.5;btn_settings;"
+	os << "button[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_settings;"
 		// TRANSLATORS: Try to keep the translation short
 		<< strgettext("Settings") << "]";
 
 #ifndef __ANDROID__
 #if USE_SOUND
-	os << "button[4," << (ypos++) << ";3,0.5;btn_sound;"
+	os << "button[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_sound;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short
 		<< strgettext("Sound Volume") << "]";
 #endif
 #endif
 
-	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_menu;"
+	os << "button_exit[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_exit_menu;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short
 		<< strgettext("Exit to Menu") << "]";
-	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_os;"
+
+	os << "button_exit[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_exit_os;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short (OS = Operating System)
-		<< strgettext("Exit to OS")   << "]";
+		<< strgettext("Exit to OS") << "]";
+
+	os << "container_end[]";
 	if (!control_text.empty()) {
-	os		<< "textarea[7.5,0.25;3.9,6.25;;" << control_text << ";]";
+		os << "textarea[9.25,0.8;4.625,6.1;;" << control_text << ";]";
 	}
-	os		<< "textarea[0.4,0.25;3.9,6.25;;" << PROJECT_NAME_C " " VERSION_STRING "\n"
-		<< "\n"
-		<<  strgettext("Game info:") << "\n";
+	os << "textarea[0.375,0.8;4.625,6.075;;" << PROJECT_NAME_C " " VERSION_STRING "\n"
+		<< "\n" <<  strgettext("Game info:") << "\n";
+
 	const std::string &address = m_client->getAddressName();
 	// TRANSLATORS: Game mode (server or singleplayer)
 	os << strgettext("- Mode: ");

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -480,11 +480,12 @@ void GameFormSpec::showPauseMenu()
 void GameFormSpec::showDeathFormspecLegacy()
 {
 	static std::string formspec_str =
-		std::string("formspec_version[1]") +
+		std::string("formspec_version[2]") +
 		SIZE_TAG
 		"bgcolor[#320000b4;true]"
-		"label[4.85,1.35;" + gettext("You died") + "]"
-		"button_exit[4,3;3,0.5;btn_respawn;" + gettext("Respawn") + "]"
+		"style_type[label;halign=center;valign=center]"
+		"label[5.375,1.85;3.5,0.8;" + gettext("You died") + "]"
+		"button_exit[5.375,3.725;3.5,0.8;btn_respawn;" + gettext("Respawn") + "]"
 		;
 
 	/* Create menu */

--- a/src/client/game_formspec.cpp
+++ b/src/client/game_formspec.cpp
@@ -353,7 +353,7 @@ void GameFormSpec::showPlayerInventory(const std::string *fs_override)
 	fs_src.release(); // owned by GUIFormSpecMenu
 }
 
-#define SIZE_TAG "size[11,5.5,true]" // Fixed size (ignored in touchscreen mode)
+#define SIZE_TAG "size[14.25,7.275,true]" // Fixed size (ignored in touchscreen mode)
 
 void GameFormSpec::showPauseMenu()
 {
@@ -377,46 +377,56 @@ void GameFormSpec::showPauseMenu()
 
 	auto simple_singleplayer_mode = m_client->m_simple_singleplayer_mode;
 
-	float ypos = simple_singleplayer_mode ? 0.7f : 0.1f;
+	const float button_height = 0.8f;
+	const float spacing = 0.38f;
+	float ypos = simple_singleplayer_mode ? 1.05f : 0.325f;
 	std::ostringstream os;
 
-	os << "formspec_version[1]" << SIZE_TAG
-		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_continue;"
+	os << "formspec_version[2]" << SIZE_TAG;
+
+	if (simple_singleplayer_mode) {
+		os << "style_type[label;halign=center;valign=center]";
+		os << "label[5.375,0;3.5," << ypos << ";" << strgettext("Game paused") << "]";
+	}
+
+	os << "container[5.375,0]";
+	os << "button_exit[0," << ypos << ";3.5," << button_height << ";btn_continue;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short
 		<< strgettext("Continue") << "]";
 
 	if (!simple_singleplayer_mode) {
-		os << "button[4," << (ypos++) << ";3,0.5;btn_change_password;"
+		os << "button[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_change_password;"
 			// TRANSLATORS: Pause menu button, try to keep the translation short
 			<< strgettext("Change Password") << "]";
-	} else {
-		os << "field[4.95,0;5,1.5;;" << strgettext("Game paused") << ";]";
 	}
 
-	os	<< "button[4," << (ypos++) << ";3,0.5;btn_settings;"
+	os << "button[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_settings;"
 		// TRANSLATORS: Try to keep the translation short
 		<< strgettext("Settings") << "]";
 
 #ifndef __ANDROID__
 #if USE_SOUND
-	os << "button[4," << (ypos++) << ";3,0.5;btn_sound;"
+	os << "button[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_sound;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short
 		<< strgettext("Sound Volume") << "]";
 #endif
 #endif
 
-	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_menu;"
+	os << "button_exit[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_exit_menu;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short
 		<< strgettext("Exit to Menu") << "]";
-	os		<< "button_exit[4," << (ypos++) << ";3,0.5;btn_exit_os;"
+
+	os << "button_exit[0," << (ypos += button_height + spacing) << ";3.5," << button_height << ";btn_exit_os;"
 		// TRANSLATORS: Pause menu button, try to keep the translation short (OS = Operating System)
-		<< strgettext("Exit to OS")   << "]";
+		<< strgettext("Exit to OS") << "]";
+
+	os << "container_end[]";
 	if (!control_text.empty()) {
-	os		<< "textarea[7.5,0.25;3.9,6.25;;" << control_text << ";]";
+		os << "textarea[9.275,0.8;4.7,6.1;;" << control_text << ";]";
 	}
-	os		<< "textarea[0.4,0.25;3.9,6.25;;" << PROJECT_NAME_C " " VERSION_STRING "\n"
-		<< "\n"
-		<<  strgettext("Game info:") << "\n";
+	os << "textarea[0.4,0.8;4.7,6.075;;" << PROJECT_NAME_C " " VERSION_STRING "\n"
+		<< "\n" <<  strgettext("Game info:") << "\n";
+
 	const std::string &address = m_client->getAddressName();
 	// TRANSLATORS: Game mode (server or singleplayer)
 	os << strgettext("- Mode: ");


### PR DESCRIPTION
Fixes #17364 

- **Goal of the PR**
  Use `formspec_version[2]` in pause menu and death screen to allow centering of text

- **Does it resolve any reported issue?**
  #17364

- **Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?**
  [UI Improvements](https://github.com/luanti-org/luanti/blob/master/doc/direction.md#23-ui-improvements)

- **If not a bug fix, why is this PR needed? What usecases does it solve?**
  It makes the "Game paused" text on the pause menu actually centered rather than using a read-only `field[]` hack :P 

- **If you have used an LLM/AI to help with code or assets, you must disclose this.**
  Nope.

## To do

This PR is Ready for Review.

- [x] Fix up the death screen too

## How to test

1. Set `font_size` to something large like 24
2. Observe that the "Game paused" text in the pause menu is now centered properly
3. Also observe that there is really no noticeable difference between the pause menu in this PR vs the latest master
4. Also test how the pause menu looks while not in singleplayer (on a server) and notice there is no noticeable difference with that too
5. Observe the same with the death screen

<img width="620" height="344" alt="pause_menu" src="https://github.com/user-attachments/assets/653ad340-651d-454c-a665-8b6e385535b6" />

<img width="620" height="350" alt="death_screen" src="https://github.com/user-attachments/assets/e0d26f2c-31a5-4fda-afd1-38ee78d32e0c" />


