### PR TITLE
Fix documentation of .gltf multi-track

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -401,7 +401,8 @@ depends on by supplying a file with an equal name.
 Only a subset of model file format features is supported:
 
 Simple textured meshes (with multiple textures), optionally with normals.
-The .x, .b3d and .gltf formats additionally support (a single) animation.
+.x and .b3d support a single animation.
+.gltf support multiple animation tracks.
 
 #### glTF
 


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
    Improved documentation.
- How does the PR work?
    Improves the documentation
- Does it resolve any reported issue?
    Not that I am aware of.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
    Nope
- If not a bug fix, why is this PR needed? What usecases does it solve?
    It's a documentation bug fix.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
    I used the search feature in my IDE to locate the affected sections faster. Everything was by hand after that.

## To do

This PR is a Ready for Review.

- [x] Remove .gltf from list of model formats limited to a single animation.

## How to test

Read the documentation on unsupported model format features. (Lines 401-404 in current `lua_api.md`)
