### PR TITLE
Add .b3d to breakages.md

### DIFF
--- a/doc/breakages.md
+++ b/doc/breakages.md
@@ -3,7 +3,7 @@
 This document contains a list of breaking changes to be made in the next major version.
 This list is largely advisory and items may be reevaluated once the time comes.
 
-* remove support for the `.x` model file format
+* remove support for the `.x` and `.b3d` model file formats
   * see https://github.com/luanti-org/luanti/issues/15619 for discussion
 * remove attachment space multiplier (*10)
 * remove space multiplier for models (*10)


### PR DESCRIPTION
Adds `.b3d` to `breakages.md`, see #15619 for discussion. closes #15619