### PR TITLE
Chat: Add setting to control space after autocomplete

### DIFF
--- a/builtin/common/settings/dlg_settings.lua
+++ b/builtin/common/settings/dlg_settings.lua
@@ -125,6 +125,7 @@ local function load()
 			"console_height",
 			"console_alpha",
 			"console_color",
+			"chat_autocomplete_append",
 			{ heading = fgettext_ne("Controls") },
 			"autojump",
 			"safe_dig_and_place",

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -961,6 +961,9 @@ chat_weblink_color (Weblink color) string #8888FF
 #    Value 0 will use the default font size.
 chat_font_size (Chat font size) int 0 0 72
 
+#    Append space character after autocompleting a player name.
+#    This is triggered by using the Tab key.
+chat_autocomplete_append_space (Autocomplete append space) bool true
 
 [**Content Repository]
 

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -961,9 +961,10 @@ chat_weblink_color (Weblink color) string #8888FF
 #    Value 0 will use the default font size.
 chat_font_size (Chat font size) int 0 0 72
 
-#    Append space character after autocompleting a player name.
+#    Append characters after autocompleting a player name.
 #    This is triggered by using the Tab key.
-chat_autocomplete_append_space (Autocomplete append space) bool true
+#    The string must be surrounded with quotation marks (").
+chat_autocomplete_append (Autocomplete append string) string " "
 
 [**Content Repository]
 

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -638,8 +638,17 @@ void ChatPrompt::nickCompletion(const std::set<std::string> &names)
 		if (prefix.size() == line.size()) {
 			shortest.append(L": ");
 		} else if (prefix_end == line.size()) {
-			if (g_settings->getBool("chat_autocomplete_append_space"))
-				shortest.append(L" ");
+			bool is_valid = false;
+			auto what = trim(g_settings->get("chat_autocomplete_append"));
+			if (what.size() >= 2) {
+				if (what[0] == '"' && what[what.size() - 1] == '"') {
+					what.remove_prefix(1);
+					what.remove_suffix(1);
+					is_valid = true;
+				}
+			}
+
+			shortest.append(is_valid ? utf8_to_wide(what) : L" ");
 		}
 	}
 

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -635,10 +635,12 @@ void ChatPrompt::nickCompletion(const std::set<std::string> &names)
 	}
 
 	if (completions.size() == 1) {
-		if (prefix.size() == line.size())
+		if (prefix.size() == line.size()) {
 			shortest.append(L": ");
-		else if (prefix_end == line.size())
-			shortest.append(L" ");
+		} else if (prefix_end == line.size()) {
+			if (g_settings->getBool("chat_autocomplete_append_space"))
+				shortest.append(L" ");
+		}
 	}
 
 	makeLineRef().replace(prefix_start, prefix_end - prefix_start, shortest);

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -129,7 +129,7 @@ void set_default_settings()
 	settings->setDefault("occlusion_culler", "bfs");
 	settings->setDefault("enable_raytraced_culling", "true");
 	settings->setDefault("chat_weblink_color", "#8888FF");
-	settings->setDefault("chat_autocomplete_append_space", "true");
+	settings->setDefault("chat_autocomplete_append", "\" \"");
 
 	// Keymap
 	settings->setDefault("keymap_forward", "SYSTEM_SCANCODE_26|GAMEPAD_AXIS_MINUS_1"); // KEY_KEY_W|Left Joystick

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -129,6 +129,7 @@ void set_default_settings()
 	settings->setDefault("occlusion_culler", "bfs");
 	settings->setDefault("enable_raytraced_culling", "true");
 	settings->setDefault("chat_weblink_color", "#8888FF");
+	settings->setDefault("chat_autocomplete_append_space", "true");
 
 	// Keymap
 	settings->setDefault("keymap_forward", "SYSTEM_SCANCODE_26|GAMEPAD_AXIS_MINUS_1"); // KEY_KEY_W|Left Joystick


### PR DESCRIPTION
Requested here https://irc.luanti.org/luanti-dev/2026-07-25#i_6333876

* set to `true` (default)
   * "hello singleplayer "
   * "singleplayer: "
* set to `false`
   * "hello singleplayer" (no tailing space)
   * "singleplayer: " (no change)

Useful to add punctuation after the player name. I am however used to have a space character inserted after autocomplete, thus introduced new setting.

## To do

This PR is Ready for Review.


## How to test

1. Join a world (or use the ncurses terminal)
2. Autocomplete
3. Compare
4. ???
5. Profit