### PR TITLE
Formspec: move all primary actions in dialogs to the right

### DIFF
--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -47,8 +47,8 @@ function ui.get_message_formspec(title, message, btn_id)
 		"set_focus[", btn_id, ";true]",
 		"box[0.5,1.2;13,5;#000]",
 		("textarea[0.5,1.2;13,5;;%s;%s]"):format(title, message),
-		"button[2,6.6;4,1;", btn_id, ";" .. fgettext("OK") .. "]",
-		"button[8,6.6;4,1;btn_error_copy;" .. fgettext("Copy to clipboard") .. "]"
+		"button[8,6.6;4,1;", btn_id, ";" .. fgettext("OK") .. "]",
+		"button[2,6.6;4,1;btn_error_copy;" .. fgettext("Copy to clipboard") .. "]"
 	})
 end
 

--- a/builtin/fstk/ui.lua
+++ b/builtin/fstk/ui.lua
@@ -47,8 +47,8 @@ function ui.get_message_formspec(title, message, btn_id)
 		"set_focus[", btn_id, ";true]",
 		"box[0.5,1.2;13,5;#000]",
 		("textarea[0.5,1.2;13,5;;%s;%s]"):format(title, message),
-		"button[8,6.6;4,1;", btn_id, ";" .. fgettext("OK") .. "]",
-		"button[2,6.6;4,1;btn_error_copy;" .. fgettext("Copy to clipboard") .. "]"
+		"button[2,6.6;4,1;btn_error_copy;" .. fgettext("Copy to clipboard") .. "]",
+		"button[8,6.6;4,1;", btn_id, ";" .. fgettext("OK") .. "]"
 	})
 end
 

--- a/builtin/mainmenu/common.lua
+++ b/builtin/mainmenu/common.lua
@@ -269,10 +269,10 @@ function menu_worldmt_legacy(selected)
 	end
 end
 
-function confirmation_formspec(message, confirm_id, confirm_label, cancel_id, cancel_label)
+function confirmation_formspec(message, cancel_id, cancel_label, confirm_id, confirm_label)
 	return "size[10,2.5,true]" ..
 			"label[0.5,0.5;" .. message .. "]" ..
 			"style[" .. confirm_id .. ";bgcolor=red]" ..
-			"button[0.5,1.5;2.5,0.5;" .. confirm_id .. ";" .. confirm_label .. "]" ..
-			"button[7.0,1.5;2.5,0.5;" .. cancel_id .. ";" .. cancel_label .. "]"
+			"button[0.5,1.5;2.5,0.5;" .. cancel_id .. ";" .. cancel_label .. "]" ..
+			"button[7.0,1.5;2.5,0.5;" .. confirm_id .. ";" .. confirm_label .. "]"
 end

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -195,10 +195,10 @@ local function get_formspec(data)
 	end
 
 	retval = retval ..
-		"button[3.25,7;2.5,0.5;btn_config_world_save;" ..
-		fgettext("Save") .. "]" ..
-		"button[5.75,7;2.5,0.5;btn_config_world_cancel;" ..
+		"button[3.25,7;2.5,0.5;btn_config_world_cancel;" ..
 		fgettext("Cancel") .. "]" ..
+		"button[5.75,7;2.5,0.5;btn_config_world_save;" ..
+		fgettext("Save") .. "]" ..
 		"button[9,7;2.5,0.5;btn_config_world_cdb;" ..
 		fgettext("Find More Mods") .. "]"
 

--- a/builtin/mainmenu/dlg_create_world.lua
+++ b/builtin/mainmenu/dlg_create_world.lua
@@ -316,8 +316,8 @@ local function create_world_formspec(dialogdata)
 
 		-- Menu buttons
 		"container[0,6.9]"..
-		"button[3.25,0;3,0.5;world_create_confirm;" .. fgettext("Create") .. "]" ..
-		"button[6.25,0;3,0.5;world_create_cancel;" .. fgettext("Cancel") .. "]" ..
+		"button[3.25,0;3,0.5;world_create_cancel;" .. fgettext("Cancel") .. "]" ..
+		"button[6.25,0;3,0.5;world_create_confirm;" .. fgettext("Create") .. "]" ..
 		"container_end[]"
 
 	return retval

--- a/builtin/mainmenu/dlg_delete_content.lua
+++ b/builtin/mainmenu/dlg_delete_content.lua
@@ -7,8 +7,8 @@
 local function delete_content_formspec(dialogdata)
 	return confirmation_formspec(
 		fgettext("Are you sure you want to delete \"$1\"?", dialogdata.content.name),
-		'dlg_delete_content_confirm', fgettext("Delete"),
-		'dlg_delete_content_cancel', fgettext("Cancel"))
+		'dlg_delete_content_cancel', fgettext("Cancel"),
+		'dlg_delete_content_confirm', fgettext("Delete"))
 end
 
 --------------------------------------------------------------------------------

--- a/builtin/mainmenu/dlg_delete_world.lua
+++ b/builtin/mainmenu/dlg_delete_world.lua
@@ -6,8 +6,8 @@
 local function delete_world_formspec(dialogdata)
 	return confirmation_formspec(
 		fgettext("Delete World \"$1\"?", dialogdata.delete_name),
-		'world_delete_confirm', fgettext("Delete"),
-		'world_delete_cancel', fgettext("Cancel"))
+		'world_delete_cancel', fgettext("Cancel"),
+		'world_delete_confirm', fgettext("Delete"))
 end
 
 local function delete_world_buttonhandler(this, fields)

--- a/builtin/mainmenu/dlg_register.lua
+++ b/builtin/mainmenu/dlg_register.lua
@@ -32,8 +32,8 @@ local function register_formspec(dialogdata)
 
 	table.insert_all(retval, {
 		"container[0.375,", tostring(buttons_y), "]",
-		"button[0,0;2.5,0.8;dlg_register_confirm;", fgettext("Register"), "]",
-		"button[4.75,0;2.5,0.8;dlg_register_cancel;", fgettext("Cancel"), "]",
+		"button[0,0;2.5,0.8;dlg_register_cancel;", fgettext("Cancel"), "]",
+		"button[4.75,0;2.5,0.8;dlg_register_confirm;", fgettext("Register"), "]",
 		"container_end[]",
 	})
 

--- a/builtin/mainmenu/dlg_rename_modpack.lua
+++ b/builtin/mainmenu/dlg_rename_modpack.lua
@@ -7,10 +7,10 @@
 local function rename_modpack_formspec(dialogdata)
 	local retval =
 		"size[11.5,4.5,true]" ..
-		"button[3.25,3.5;2.5,0.5;dlg_rename_modpack_confirm;"..
-				fgettext("Accept") .. "]" ..
-		"button[5.75,3.5;2.5,0.5;dlg_rename_modpack_cancel;"..
-				fgettext("Cancel") .. "]"
+		"button[3.25,3.5;2.5,0.5;dlg_rename_modpack_cancel;"..
+				fgettext("Cancel") .. "]" ..
+		"button[5.75,3.5;2.5,0.5;dlg_rename_modpack_confirm;"..
+				fgettext("Accept") .. "]"
 
 	local input_y = 2
 	if dialogdata.mod.is_name_explicit then

--- a/src/gui/guiOpenURL.cpp
+++ b/src/gui/guiOpenURL.cpp
@@ -140,14 +140,14 @@ void GUIOpenURLMenu::regenerateGui(v2u32 screensize)
 	ypos += 80 * s;
 	if (ok) {
 		core::rect<s32> rect(0, 0, 100 * s, 40 * s);
-		rect = rect + v2s32(size.X / 2 - 150 * s, ypos);
+		rect = rect + v2s32(size.X / 2 + 50 * s, ypos);
 		auto *e = GUIButton::addButton(Environment, rect, m_tsrc, this, ID_open,
 				wstrgettext("Open").c_str());
 		e->setStyles(styles);
 	}
 	{
 		core::rect<s32> rect(0, 0, 100 * s, 40 * s);
-		rect = rect + v2s32(size.X / 2 + 50 * s, ypos);
+		rect = rect + v2s32(size.X / 2 - 150 * s, ypos);
 		auto *e = GUIButton::addButton(Environment, rect, m_tsrc, this, ID_cancel,
 				wstrgettext("Cancel").c_str());
 		e->setStyles(styles);


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:
See https://irc.luanti.org/luanti-dev/2026-07-29

Before:
<img width="953" height="574" alt="image" src="https://github.com/user-attachments/assets/9bf9357f-6f0f-45bd-a9ea-c7dba1276d47" />

After:
<img width="953" height="574" alt="image" src="https://github.com/user-attachments/assets/70f48ab5-dc01-415a-8b05-19b21a412527" />
