### PR TITLE
Add can_place definition to the engine

### DIFF
--- a/builtin/game/item.lua
+++ b/builtin/game/item.lua
@@ -182,6 +182,11 @@ function core.item_place_node(itemstack, placer, pointed_thing, param2,
 		place_to = vector.copy(under)
 	end
 
+	-- If defined, allow node defined can_place to do an early escape.
+	if type(def.can_place) == "function" and not def.can_place(place_to, placer) then
+		return itemstack, nil
+	end
+
 	if core.is_protected(place_to, playername) then
 		log("action", playername
 				.. " tried to place " .. def.name

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -11090,6 +11090,11 @@ Used by `core.register_node`.
     -- Returns true if node can be dug, or false if not.
     -- default: nil
 
+    can_place = function(pos, [player]),
+    -- Returns true if node can be placed, or false if not.
+    -- It is recommended to set node_placement_prediction to "" so the node does not flicker.
+    -- default: nil
+
     on_punch = function(pos, node, puncher, pointed_thing),
     -- default: core.node_punch
     -- Called when puncher (an ObjectRef) punches the node at pos.

--- a/games/devtest/mods/testnodes/properties.lua
+++ b/games/devtest/mods/testnodes/properties.lua
@@ -680,6 +680,20 @@ local function register_pointable_test_node(name, description, pointable)
 	})
 end
 
+-- Placeability
+
+core.register_node("testnodes:can_place", {
+	tiles = {"default_jungletree_top.png", "default_jungletree_top.png", "default_jungletree.png"},
+	groups = {oddly_breakable_by_hand=1, dig_immediate=3},
+	description = S("This node can only be placed on basenodes:dirt_with_grass"),
+	node_placement_prediction = "",
+	can_place = function(pos, placer)
+		if core.get_node(vector.subtract(pos, vector.new(0,1,0))).name == "basenodes:dirt_with_grass" then
+			return true
+		end
+	end
+})
+
 register_pointable_test_node("pointable", "Pointable Node", true)
 register_pointable_test_node("not_pointable", "Not Pointable Node", false)
 register_pointable_test_node("blocking_pointable", "Blocking Pointable Node", "blocking")


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
To add the yin to the can_dig's yang.
- How does the PR work?
It runs your function to check if it can place the node.
- Does it resolve any reported issue?
#17381
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
Not sure
- If not a bug fix, why is this PR needed? What usecases does it solve?
Makes mods simpler to implement.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
Nope

But @cx384 wrote the original code in #17381. :D

## To do

This PR is a Ready for Review.

- [x] Have
- [x] A nice
- [x] Day

## How to test

I dunno you can run random checks when someone's placing a node on specific nodes. There's a built in test node that can only be placed on devtest dirt_with_grass.
