### PR TITLE
Decompress block-data without locking

### DIFF
--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -575,7 +575,7 @@ EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 		}
 		// 2). Second invocation, we have the data
 		if (!from_db->empty()) {
-			*block = m_map->loadBlock(*is_ptr.get(), pos, false, version);
+			*block = m_map->loadBlock(*is_ptr.get(), pos, version);
 			if (block_ok(*block))
 				return EMERGE_FROM_DISK;
 		}

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -553,15 +553,16 @@ EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 	if (from_db && !from_db->empty()) {
 		is_ptr = std::make_unique<std::istringstream>(*from_db, std::ios_base::binary);
 		version = readU8(*is_ptr);
+		if (!ser_ver_supported_read(version))
+			throw VersionMismatchException("ERROR: MapBlock format not supported");
 		if (is_ptr->good() && version >= 29) {
 			// we can uncompress right here
 			ScopeProfiler sp(g_profiler, "EmergeThread: deCompress block", SPT_AVG, PRECISION_MICRO);
 			auto in_raw = std::make_unique<std::stringstream>(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
 			decompress(*is_ptr, *in_raw, version);
+			// use the decompressed stream
 			is_ptr = std::move(in_raw);
-		}
-		else
-		{
+		} else {
 			// reset the stream
 			is_ptr->seekg(0);
 			version = 0;

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -547,23 +547,8 @@ bool EmergeThread::popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata)
 EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 	 const std::string *from_db, MapBlock **block, BlockMakeData *bmdata)
 {
-	// attempt to uncompress the block data without holding the lock
-	std::unique_ptr<std::istream> is_ptr;
-	u8 version = 0;
-	if (from_db && !from_db->empty()) {
-		is_ptr = std::make_unique<std::istringstream>(*from_db, std::ios_base::binary);
-		version = readU8(*is_ptr);
-		if (!ser_ver_supported_read(version))
-			throw VersionMismatchException("ERROR: MapBlock format not supported");
-		if (is_ptr->good() && version >= 29) {
-			// we can uncompress right here
-			ScopeProfiler sp(g_profiler, "EmergeThread: deCompress block", SPT_AVG, PRECISION_MICRO);
-			auto in_raw = std::make_unique<std::stringstream>(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
-			decompress(*is_ptr, *in_raw, version);
-			// use the decompressed stream
-			is_ptr = std::move(in_raw);
-		}
-	}
+	// create block stream without holding the lock
+	auto [is_ptr, version] = m_map->createBlockIStream(from_db);
 
 	//TimeTaker tt("", nullptr, PRECISION_MICRO);
 	Server::EnvAutoLock envlock(m_server);

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -26,6 +26,8 @@
 #include "scripting_emerge.h"
 #include "script/common/c_types.h" // LuaError
 #include "server.h"
+#include "serialization.h"
+#include "util/serialize.h"
 #include "settings.h"
 #include "voxel.h"
 
@@ -543,7 +545,7 @@ bool EmergeThread::popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata)
 
 
 EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
-	 const std::string *from_db, MapBlock **block, BlockMakeData *bmdata)
+        std::istream *from_db, MapBlock **block, BlockMakeData *bmdata, u8 version)
 {
 	//TimeTaker tt("", nullptr, PRECISION_MICRO);
 	Server::EnvAutoLock envlock(m_server);
@@ -569,11 +571,9 @@ EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 			return EMERGE_FROM_DISK;
 		}
 		// 2). Second invocation, we have the data
-		if (!from_db->empty()) {
-			*block = m_map->loadBlock(*from_db, pos);
-			if (block_ok(*block))
-				return EMERGE_FROM_DISK;
-		}
+		*block = m_map->loadBlock(*from_db, pos, false, version);
+		if (block_ok(*block))
+			return EMERGE_FROM_DISK;
 	}
 
 	// 3). Attempt to start generation
@@ -708,7 +708,7 @@ void *EmergeThread::run()
 		bool allow_gen = bedata.flags & BLOCK_EMERGE_ALLOW_GEN;
 		EMERGE_DBG_OUT("pos=" << pos << " allow_gen=" << allow_gen);
 
-		action = getBlockOrStartGen(pos, allow_gen, nullptr, &block, &bmdata);
+		action = getBlockOrStartGen(pos, allow_gen, nullptr, &block, &bmdata, 0);
 
 		/* Try to load it */
 		if (action == EMERGE_FROM_DISK) {
@@ -720,8 +720,24 @@ void *EmergeThread::run()
 				// a good, safe way to handle it.
 				m_db.loadBlock(pos, databuf);
 			}
+
+			// decompress if possible, then
 			// actually load it, then decide again
-			action = getBlockOrStartGen(pos, allow_gen, &databuf, &block, &bmdata);
+			std::istringstream is(databuf, std::ios_base::binary);
+			u8 version = readU8(is);
+			if (is.good() && version >= 29) {
+				std::stringstream in_raw(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
+				{
+				ScopeProfiler sp(g_profiler, "EmergeThread: deCompress block", SPT_AVG, PRECISION_MICRO);
+				decompress(is, in_raw, version);
+				}
+				action = getBlockOrStartGen(pos, allow_gen, &in_raw, &block, &bmdata, version);
+			} else {
+				// unread the version
+				is.seekg(0);
+				action = getBlockOrStartGen(pos, allow_gen, &is, &block, &bmdata, 0);
+			}
+
 			databuf.clear();
 		}
 

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -562,10 +562,6 @@ EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 			decompress(*is_ptr, *in_raw, version);
 			// use the decompressed stream
 			is_ptr = std::move(in_raw);
-		} else {
-			// reset the stream
-			is_ptr->seekg(0);
-			version = 0;
 		}
 	}
 

--- a/src/emerge.cpp
+++ b/src/emerge.cpp
@@ -545,8 +545,29 @@ bool EmergeThread::popBlockEmerge(v3s16 *pos, BlockEmergeData *bedata)
 
 
 EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
-        std::istream *from_db, MapBlock **block, BlockMakeData *bmdata, u8 version)
+	 const std::string *from_db, MapBlock **block, BlockMakeData *bmdata)
 {
+	// attempt to uncompress the block data without holding the lock
+	std::unique_ptr<std::istream> is_ptr;
+	u8 version = 0;
+	if (from_db && !from_db->empty()) {
+		is_ptr = std::make_unique<std::istringstream>(*from_db, std::ios_base::binary);
+		version = readU8(*is_ptr);
+		if (is_ptr->good() && version >= 29) {
+			// we can uncompress right here
+			ScopeProfiler sp(g_profiler, "EmergeThread: deCompress block", SPT_AVG, PRECISION_MICRO);
+			auto in_raw = std::make_unique<std::stringstream>(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
+			decompress(*is_ptr, *in_raw, version);
+			is_ptr = std::move(in_raw);
+		}
+		else
+		{
+			// reset the stream
+			is_ptr->seekg(0);
+			version = 0;
+		}
+	}
+
 	//TimeTaker tt("", nullptr, PRECISION_MICRO);
 	Server::EnvAutoLock envlock(m_server);
 	//g_profiler->avg("EmergeThread: lock wait time [us]", tt.stop());
@@ -571,9 +592,11 @@ EmergeAction EmergeThread::getBlockOrStartGen(const v3s16 pos, bool allow_gen,
 			return EMERGE_FROM_DISK;
 		}
 		// 2). Second invocation, we have the data
-		*block = m_map->loadBlock(*from_db, pos, false, version);
-		if (block_ok(*block))
-			return EMERGE_FROM_DISK;
+		if (!from_db->empty()) {
+			*block = m_map->loadBlock(*is_ptr.get(), pos, false, version);
+			if (block_ok(*block))
+				return EMERGE_FROM_DISK;
+		}
 	}
 
 	// 3). Attempt to start generation
@@ -708,7 +731,7 @@ void *EmergeThread::run()
 		bool allow_gen = bedata.flags & BLOCK_EMERGE_ALLOW_GEN;
 		EMERGE_DBG_OUT("pos=" << pos << " allow_gen=" << allow_gen);
 
-		action = getBlockOrStartGen(pos, allow_gen, nullptr, &block, &bmdata, 0);
+		action = getBlockOrStartGen(pos, allow_gen, nullptr, &block, &bmdata);
 
 		/* Try to load it */
 		if (action == EMERGE_FROM_DISK) {
@@ -720,24 +743,8 @@ void *EmergeThread::run()
 				// a good, safe way to handle it.
 				m_db.loadBlock(pos, databuf);
 			}
-
-			// decompress if possible, then
 			// actually load it, then decide again
-			std::istringstream is(databuf, std::ios_base::binary);
-			u8 version = readU8(is);
-			if (is.good() && version >= 29) {
-				std::stringstream in_raw(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
-				{
-				ScopeProfiler sp(g_profiler, "EmergeThread: deCompress block", SPT_AVG, PRECISION_MICRO);
-				decompress(is, in_raw, version);
-				}
-				action = getBlockOrStartGen(pos, allow_gen, &in_raw, &block, &bmdata, version);
-			} else {
-				// unread the version
-				is.seekg(0);
-				action = getBlockOrStartGen(pos, allow_gen, &is, &block, &bmdata, 0);
-			}
-
+			action = getBlockOrStartGen(pos, allow_gen, &databuf, &block, &bmdata);
 			databuf.clear();
 		}
 

--- a/src/emerge_internal.h
+++ b/src/emerge_internal.h
@@ -76,7 +76,7 @@ private:
 	 * @return what to do for this block
 	 */
 	EmergeAction getBlockOrStartGen(v3s16 pos, bool allow_gen,
-		const std::string *from_db,  MapBlock **block, BlockMakeData *data);
+               std::istream *from_db,  MapBlock **block, BlockMakeData *data, u8 version);
 
 	MapBlock *finishGen(v3s16 pos, BlockMakeData *bmdata,
 		std::map<v3s16, MapBlock *> *modified_blocks);

--- a/src/emerge_internal.h
+++ b/src/emerge_internal.h
@@ -76,7 +76,7 @@ private:
 	 * @return what to do for this block
 	 */
 	EmergeAction getBlockOrStartGen(v3s16 pos, bool allow_gen,
-               std::istream *from_db,  MapBlock **block, BlockMakeData *data, u8 version);
+		const std::string *from_db,  MapBlock **block, BlockMakeData *data);
 
 	MapBlock *finishGen(v3s16 pos, BlockMakeData *bmdata,
 		std::map<v3s16, MapBlock *> *modified_blocks);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1376,7 +1376,11 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 
 		{
 			MapBlock mb(v3s16(0,0,0), &server);
-			ServerMap::deSerializeBlock(&mb, iss);
+			u8 version = readU8(iss);
+			if (iss.fail())
+				throw SerializationError("Failed to read MapBlock version");
+
+			mb.deSerialize(iss, version, true);
 
 			oss.str("");
 			oss.clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1374,7 +1374,11 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 
 		{
 			MapBlock mb(v3s16(0,0,0), &server);
-			ServerMap::deSerializeBlock(&mb, iss);
+			u8 version = readU8(iss);
+			if (iss.fail())
+				throw SerializationError("Failed to read MapBlock version");
+
+			mb.deSerialize(iss, version, true);
 
 			oss.str("");
 			oss.clear();

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -501,39 +501,33 @@ void MapBlock::serializeNetworkSpecific(std::ostream &os)
 
 void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 {
-	if (!ser_ver_supported_read(version))
-		throw VersionMismatchException("ERROR: MapBlock format not supported");
-
-	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()<<std::endl);
-
-	m_is_air_expired = true;
-	expandNodesIfNeeded();
-
-	if(version <= 21)
+	if(version < 29)
 	{
-		deSerialize_pre22(in_compressed, version, disk);
+		deSerialize_pre29(in_compressed, version, disk);
 		return;
 	}
 
 	// Decompress the whole block (version >= 29)
-	std::stringstream in_raw(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
-	if (version >= 29)
-		decompress(in_compressed, in_raw, version);
-	std::istream &is = version >= 29 ? in_raw : in_compressed;
+	std::stringstream is(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
+	decompress(in_compressed, is, version);
+	deSerializeUncompressed(is, version, disk);
+}
+
+void MapBlock::deSerializeUncompressed(std::istream &is, u8 version, bool disk)
+{
+	m_is_air_expired = true;
+	expandNodesIfNeeded();
 
 	u8 flags = readU8(is);
 	is_underground = (flags & 0x01) != 0;
 	// IMPORTANT: when the version is bumped to 30 we can read m_is_air from here
 	// m_is_air = (flags & 0x02) == 0;
 
-	if (version < 27)
-		m_lighting_complete = 0xFFFF;
-	else
-		m_lighting_complete = readU16(is);
+	m_lighting_complete = readU16(is);
 	m_generated = (flags & 0x08) == 0;
 
 	NameIdMapping nimap;
-	if (disk && version >= 29) {
+	if (disk) {
 		// Timestamp
 		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 				<<": Timestamp"<<std::endl);
@@ -558,83 +552,31 @@ void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 	/*
 		Bulk node data
 	*/
-	if (version >= 29) {
-		MapNode::deSerializeBulk(is, version, data, nodecount,
-			content_width, params_width);
-	} else {
-		// use in_raw from above to avoid allocating another stream object
-		decompress(is, in_raw, version);
-		MapNode::deSerializeBulk(in_raw, version, data, nodecount,
-			content_width, params_width);
-	}
+	MapNode::deSerializeBulk(is, version, data, nodecount,
+		content_width, params_width);
 
 	/*
 		NodeMetadata
 	*/
 	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 			<<": Node metadata"<<std::endl);
-	if (version >= 29) {
-		m_node_metadata.deSerialize(is, m_gamedef->idef());
-	} else {
-		try {
-			// reuse in_raw
-			in_raw.str("");
-			in_raw.clear();
-			decompress(is, in_raw, version);
-			if (version >= 23)
-				m_node_metadata.deSerialize(in_raw, m_gamedef->idef());
-			else
-				content_nodemeta_deserialize_legacy(in_raw,
-					&m_node_metadata, &m_node_timers,
-					m_gamedef->idef());
-		} catch(SerializationError &e) {
-			warningstream<<"MapBlock::deSerialize(): Ignoring an error"
-					<<" while deserializing node metadata at ("
-					<<getPos()<<": "<<e.what()<<std::endl;
-		}
-	}
+	m_node_metadata.deSerialize(is, m_gamedef->idef());
 
 	/*
 		Data that is only on disk
 	*/
 	if (disk) {
-		// Node timers
-		if (version == 23) {
-			// Read unused zero
-			readU8(is);
-		}
-		if (version == 24) {
-			TRACESTREAM(<< "MapBlock::deSerialize " << getPos()
-						<< ": Node timers (ver==24)" << std::endl);
-			m_node_timers.deSerialize(is, version);
-		}
-
 		// Static objects
 		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
 				<<": Static objects"<<std::endl);
 		m_static_objects.deSerialize(is);
 
-		if (version < 29) {
-			// Timestamp
-			TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
-				    <<": Timestamp"<<std::endl);
-			setTimestampNoChangedFlag(readU32(is));
-			m_disk_timestamp = m_timestamp;
-
-			// Node/id mapping
-			TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
-				    <<": NameIdMapping"<<std::endl);
-			nimap.deSerialize(is);
-		}
-
 		// Dynamically re-set ids based on node names
 		correctBlockNodeIds(&nimap, data, m_gamedef);
 
-		if(version >= 25){
-			TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
-					<<": Node timers (ver>=25)"<<std::endl);
-			m_node_timers.deSerialize(is, version);
-		}
+		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+				<<": Node timers (ver>=25)"<<std::endl);
+		m_node_timers.deSerialize(is, version);
 
 		if (nimap.size() == 1) {
 			tryShrinkNodes();
@@ -681,6 +623,127 @@ u32 MapBlock::clearObjects()
 /*
 	Legacy serialization
 */
+
+void MapBlock::deSerialize_pre29(std::istream &is, u8 version, bool disk)
+{
+	if (!ser_ver_supported_read(version))
+		throw VersionMismatchException("ERROR: MapBlock format not supported");
+
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()<<std::endl);
+
+	m_is_air_expired = true;
+	expandNodesIfNeeded();
+
+	if(version <= 21)
+	{
+		deSerialize_pre22(is, version, disk);
+		return;
+	}
+
+	u8 flags = readU8(is);
+	is_underground = (flags & 0x01) != 0;
+	// IMPORTANT: when the version is bumped to 30 we can read m_is_air from here
+	// m_is_air = (flags & 0x02) == 0;
+
+	if (version < 27)
+		m_lighting_complete = 0xFFFF;
+	else
+		m_lighting_complete = readU16(is);
+	m_generated = (flags & 0x08) == 0;
+
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+			<<": Bulk node data"<<std::endl);
+	u8 content_width = readU8(is);
+	u8 params_width = readU8(is);
+	if(content_width != 1 && content_width != 2)
+		throw SerializationError("MapBlock::deSerialize(): invalid content_width");
+	if(params_width != 2)
+		throw SerializationError("MapBlock::deSerialize(): invalid params_width");
+
+	/*
+		Bulk node data
+	*/
+	std::stringstream in_raw(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
+	decompress(is, in_raw, version);
+	MapNode::deSerializeBulk(in_raw, version, data, nodecount,
+		content_width, params_width);
+
+	/*
+		NodeMetadata
+	*/
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+			<<": Node metadata"<<std::endl);
+	try {
+		// reuse in_raw
+		in_raw.str("");
+		in_raw.clear();
+		decompress(is, in_raw, version);
+		if (version >= 23)
+			m_node_metadata.deSerialize(in_raw, m_gamedef->idef());
+		else
+			content_nodemeta_deserialize_legacy(in_raw,
+				&m_node_metadata, &m_node_timers,
+				m_gamedef->idef());
+	} catch(SerializationError &e) {
+		warningstream<<"MapBlock::deSerialize(): Ignoring an error"
+				<<" while deserializing node metadata at ("
+				<<getPos()<<": "<<e.what()<<std::endl;
+	}
+
+	/*
+		Data that is only on disk
+	*/
+	if (disk) {
+		// Node timers
+		if (version == 23) {
+			// Read unused zero
+			readU8(is);
+		}
+		if (version == 24) {
+			TRACESTREAM(<< "MapBlock::deSerialize " << getPos()
+						<< ": Node timers (ver==24)" << std::endl);
+			m_node_timers.deSerialize(is, version);
+		}
+
+		// Static objects
+		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+				<<": Static objects"<<std::endl);
+		m_static_objects.deSerialize(is);
+
+		// Timestamp
+		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+				<<": Timestamp"<<std::endl);
+		setTimestampNoChangedFlag(readU32(is));
+		m_disk_timestamp = m_timestamp;
+
+		NameIdMapping nimap;
+
+		// Node/id mapping
+		TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+				<<": NameIdMapping"<<std::endl);
+		nimap.deSerialize(is);
+
+		// Dynamically re-set ids based on node names
+		correctBlockNodeIds(&nimap, data, m_gamedef);
+
+		if(version >= 25){
+			TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+					<<": Node timers (ver>=25)"<<std::endl);
+			m_node_timers.deSerialize(is, version);
+		}
+
+		if (nimap.size() == 1) {
+			tryShrinkNodes();
+
+			u16 dummy;
+			m_is_air = nimap.getId("air", dummy);
+			m_is_air_expired = false;
+		}
+	}
+
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()
+			<<": Done."<<std::endl);
+}
 
 void MapBlock::deSerialize_pre22(std::istream &is, u8 version, bool disk)
 {

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -501,6 +501,11 @@ void MapBlock::serializeNetworkSpecific(std::ostream &os)
 
 void MapBlock::deSerialize(std::istream &in_compressed, u8 version, bool disk)
 {
+	if (!ser_ver_supported_read(version))
+		throw VersionMismatchException("ERROR: MapBlock format not supported");
+
+	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()<<std::endl);
+
 	if(version < 29)
 	{
 		deSerialize_pre29(in_compressed, version, disk);
@@ -626,11 +631,6 @@ u32 MapBlock::clearObjects()
 
 void MapBlock::deSerialize_pre29(std::istream &is, u8 version, bool disk)
 {
-	if (!ser_ver_supported_read(version))
-		throw VersionMismatchException("ERROR: MapBlock format not supported");
-
-	TRACESTREAM(<<"MapBlock::deSerialize "<<getPos()<<std::endl);
-
 	m_is_air_expired = true;
 	expandNodesIfNeeded();
 

--- a/src/mapblock.cpp
+++ b/src/mapblock.cpp
@@ -522,6 +522,7 @@ void MapBlock::deSerializeUncompressed(std::istream &is, u8 version, bool disk)
 {
 	m_is_air_expired = true;
 	expandNodesIfNeeded();
+	assert(version >= 29);
 
 	u8 flags = readU8(is);
 	is_underground = (flags & 0x01) != 0;
@@ -633,6 +634,7 @@ void MapBlock::deSerialize_pre29(std::istream &is, u8 version, bool disk)
 {
 	m_is_air_expired = true;
 	expandNodesIfNeeded();
+	assert(version < 29);
 
 	if(version <= 21)
 	{

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -411,6 +411,7 @@ public:
 	// If disk == true: In addition to doing other things, will add
 	// unknown blocks from id-name mapping to wndef
 	void deSerialize(std::istream &is, u8 version, bool disk);
+	void deSerializeUncompressed(std::istream &is, u8 version, bool disk);
 
 	void serializeNetworkSpecific(std::ostream &os);
 	void deSerializeNetworkSpecific(std::istream &is);
@@ -436,6 +437,7 @@ private:
 	*/
 
 	void deSerialize_pre22(std::istream &is, u8 version, bool disk);
+	void deSerialize_pre29(std::istream &is, u8 version, bool disk);
 	// check if all nodes are identical, if so convert to monoblock
 	void tryShrinkNodes();
 	// if a monoblock, expand storage back to the full array

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -706,6 +706,30 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_leve
 	return ret;
 }
 
+std::pair<std::unique_ptr<std::istream>, u8> ServerMap::createBlockIStream(const std::string *from_db)
+{
+	if (!from_db || from_db->empty()) {
+		return {nullptr, 0};
+	}
+	// attempt to uncompress the block data without holding the lock
+	auto iss = std::make_unique<std::istringstream>(*from_db, std::ios_base::binary);
+	u8 version = readU8(*iss);
+
+	if (!ser_ver_supported_read(version))
+		throw VersionMismatchException("ERROR: MapBlock format not supported");
+
+	if (iss->good() && version >= 29) {
+		// we can uncompress right here
+		ScopeProfiler sp(g_profiler, "EmergeThread: deCompress block", SPT_AVG, PRECISION_MICRO);
+		auto decomp = std::make_unique<std::stringstream>(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
+		decompress(*iss, *decomp, version);
+		// use the decompressed stream
+		return {std::move(decomp), version};
+	} else {
+		return {std::move(iss), version};
+	}
+}
+
 MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load, std::optional<u8> version)
 {
 	ScopeProfiler sp(g_profiler, "ServerMap: load block", SPT_AVG, PRECISION_MICRO);

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -723,21 +723,17 @@ MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load
 			block = block_created_new.get();
 		}
 
-		{
+		if (version >= 29) {
+			ScopeProfiler sp(g_profiler, "ServerMap: deSer block unComp", SPT_AVG, PRECISION_MICRO);
+			block->deSerializeUncompressed(is, version, true);
+		} else {
 			if (version == 0)
 				version = readU8(is);
 			if (is.fail())
 				throw SerializationError("Failed to read MapBlock version");
 
-			{
 			ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG, PRECISION_MICRO);
-
-			if (version >= 29) {
-				block->deSerializeUncompressed(is, version, true);
-			}
-			else
-				block->deSerialize(is, version, true);
-			}
+			block->deSerialize(is, version, true);
 		}
 
 		// If it's a new block, insert it to the map

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -706,7 +706,7 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_leve
 	return ret;
 }
 
-MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load, u8 version)
+MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load, std::optional<u8> version)
 {
 	ScopeProfiler sp(g_profiler, "ServerMap: load block", SPT_AVG, PRECISION_MICRO);
 	MapBlock *block = nullptr;
@@ -723,17 +723,18 @@ MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load
 			block = block_created_new.get();
 		}
 
-		if (version >= 29) {
+		if (version && *version >= 29) {
 			ScopeProfiler sp(g_profiler, "ServerMap: deSer block unComp", SPT_AVG, PRECISION_MICRO);
-			block->deSerializeUncompressed(is, version, true);
+			block->deSerializeUncompressed(is, *version, true);
 		} else {
-			if (version == 0)
+			if (!version) {
 				version = readU8(is);
-			if (is.fail())
-				throw SerializationError("Failed to read MapBlock version");
+				if (is.fail())
+					throw SerializationError("Failed to read MapBlock version");
+			}
 
 			ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG, PRECISION_MICRO);
-			block->deSerialize(is, version, true);
+			block->deSerialize(is, *version, true);
 		}
 
 		// If it's a new block, insert it to the map

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -730,7 +730,7 @@ std::pair<std::unique_ptr<std::istream>, u8> ServerMap::createBlockIStream(const
 	}
 }
 
-MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load, std::optional<u8> version)
+MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, u8 version)
 {
 	ScopeProfiler sp(g_profiler, "ServerMap: load block", SPT_AVG, PRECISION_MICRO);
 	MapBlock *block = nullptr;
@@ -747,18 +747,12 @@ MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load
 			block = block_created_new.get();
 		}
 
-		if (version && *version >= 29) {
+		if (version >= 29) {
 			ScopeProfiler sp(g_profiler, "ServerMap: deSer block unComp", SPT_AVG, PRECISION_MICRO);
-			block->deSerializeUncompressed(is, *version, true);
+			block->deSerializeUncompressed(is, version, true);
 		} else {
-			if (!version) {
-				version = readU8(is);
-				if (is.fail())
-					throw SerializationError("Failed to read MapBlock version");
-			}
-
 			ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG, PRECISION_MICRO);
-			block->deSerialize(is, *version, true);
+			block->deSerialize(is, version, true);
 		}
 
 		// If it's a new block, insert it to the map
@@ -800,9 +794,6 @@ MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load
 		}
 	}
 
-	if (save_after_load)
-		saveBlock(block);
-
 	// We just loaded it, so it's up-to-date.
 	block->resetModified();
 
@@ -819,8 +810,8 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 	}
 
 	if (!data.empty()) {
-		std::istringstream iss(data, std::ios_base::binary);
-		return loadBlock(iss, blockpos);
+		auto [is_ptr, version] = createBlockIStream(&data);
+		return loadBlock(*is_ptr.get(), blockpos, version);
 
 	}
 	return getBlockNoCreateNoEx(blockpos);

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -711,16 +711,17 @@ std::pair<std::unique_ptr<std::istream>, u8> ServerMap::createBlockIStream(const
 	if (!from_db || from_db->empty()) {
 		return {nullptr, 0};
 	}
-	// attempt to uncompress the block data without holding the lock
+	// uncompress the block data early, if possible
 	auto iss = std::make_unique<std::istringstream>(*from_db, std::ios_base::binary);
 	u8 version = readU8(*iss);
-
+	if (iss->fail())
+		throw SerializationError("Failed to read MapBlock version");
 	if (!ser_ver_supported_read(version))
 		throw VersionMismatchException("ERROR: MapBlock format not supported");
 
-	if (iss->good() && version >= 29) {
+	if (version >= 29) {
 		// we can uncompress right here
-		ScopeProfiler sp(g_profiler, "EmergeThread: deCompress block", SPT_AVG, PRECISION_MICRO);
+		ScopeProfiler sp(g_profiler, "ServerMap: early decompress block", SPT_AVG, PRECISION_MICRO);
 		auto decomp = std::make_unique<std::stringstream>(std::ios_base::binary | std::ios_base::in | std::ios_base::out);
 		decompress(*iss, *decomp, version);
 		// use the decompressed stream
@@ -812,7 +813,6 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 	if (!data.empty()) {
 		auto [is_ptr, version] = createBlockIStream(&data);
 		return loadBlock(*is_ptr.get(), blockpos, version);
-
 	}
 	return getBlockNoCreateNoEx(blockpos);
 }

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -794,7 +794,7 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 	}
 
 	if (!data.empty()) {
-		std::stringstream iss(data, std::ios_base::binary);
+		std::istringstream iss(data, std::ios_base::binary);
 		return loadBlock(iss, blockpos);
 
 	}

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -706,18 +706,7 @@ bool ServerMap::saveBlock(MapBlock *block, MapDatabase *db, int compression_leve
 	return ret;
 }
 
-void ServerMap::deSerializeBlock(MapBlock *block, std::istream &is)
-{
-	ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG, PRECISION_MICRO);
-
-	u8 version = readU8(is);
-	if (is.fail())
-		throw SerializationError("Failed to read MapBlock version");
-
-	block->deSerialize(is, version, true);
-}
-
-MapBlock *ServerMap::loadBlock(const std::string &blob, v3s16 p3d, bool save_after_load)
+MapBlock *ServerMap::loadBlock(std::istream &is, v3s16 p3d, bool save_after_load, u8 version)
 {
 	ScopeProfiler sp(g_profiler, "ServerMap: load block", SPT_AVG, PRECISION_MICRO);
 	MapBlock *block = nullptr;
@@ -735,8 +724,20 @@ MapBlock *ServerMap::loadBlock(const std::string &blob, v3s16 p3d, bool save_aft
 		}
 
 		{
-			std::istringstream iss(blob, std::ios_base::binary);
-			deSerializeBlock(block, iss);
+			if (version == 0)
+				version = readU8(is);
+			if (is.fail())
+				throw SerializationError("Failed to read MapBlock version");
+
+			{
+			ScopeProfiler sp(g_profiler, "ServerMap: deSer block", SPT_AVG, PRECISION_MICRO);
+
+			if (version >= 29) {
+				block->deSerializeUncompressed(is, version, true);
+			}
+			else
+				block->deSerialize(is, version, true);
+			}
 		}
 
 		// If it's a new block, insert it to the map
@@ -796,8 +797,11 @@ MapBlock* ServerMap::loadBlock(v3s16 blockpos)
 		m_db.loadBlock(blockpos, data);
 	}
 
-	if (!data.empty())
-		return loadBlock(data, blockpos);
+	if (!data.empty()) {
+		std::stringstream iss(data, std::ios_base::binary);
+		return loadBlock(iss, blockpos);
+
+	}
 	return getBlockNoCreateNoEx(blockpos);
 }
 

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -118,6 +118,8 @@ public:
 	bool saveBlock(MapBlock *block) override;
 	static bool saveBlock(MapBlock *block, MapDatabase *db, int compression_level = -1);
 
+	std::pair<std::unique_ptr<std::istream>, u8> createBlockIStream(const std::string *from_db);
+
 	// Load block in a synchronous fashion
 	MapBlock *loadBlock(v3s16 p);
 	/// Load a block that was already read from disk. Used by EmergeManager.

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -121,9 +121,9 @@ public:
 	// Load block in a synchronous fashion
 	MapBlock *loadBlock(v3s16 p);
 	/// Load a block that was already read from disk. Used by EmergeManager.
-	/// version != 0 indicates that the caller already read the version from the stream
+	/// Caller must pass the version if it read the version off the stream.
 	/// @return non-null block (but can be blank)
-	MapBlock *loadBlock(std::istream &is, v3s16 p, bool save_after_load=false, u8 version=0);
+	MapBlock *loadBlock(std::istream &is, v3s16 p, bool save_after_load=false, std::optional<u8> version=std::nullopt);
 
 	// Blocks are removed from the map but not deleted from memory until
 	// deleteDetachedBlocks() is called, since pointers to them may still exist

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -122,11 +122,7 @@ public:
 	MapBlock *loadBlock(v3s16 p);
 	/// Load a block that was already read from disk. Used by EmergeManager.
 	/// @return non-null block (but can be blank)
-	MapBlock *loadBlock(const std::string &blob, v3s16 p, bool save_after_load=false);
-
-	// Helper for deserializing blocks from disk
-	// @throws SerializationError
-	static void deSerializeBlock(MapBlock *block, std::istream &is);
+	MapBlock *loadBlock(std::istream &iss, v3s16 p, bool save_after_load=false, u8 version=0);
 
 	// Blocks are removed from the map but not deleted from memory until
 	// deleteDetachedBlocks() is called, since pointers to them may still exist

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -121,8 +121,9 @@ public:
 	// Load block in a synchronous fashion
 	MapBlock *loadBlock(v3s16 p);
 	/// Load a block that was already read from disk. Used by EmergeManager.
+	/// version != 0 indicates that the caller already read the version from the stream
 	/// @return non-null block (but can be blank)
-	MapBlock *loadBlock(std::istream &iss, v3s16 p, bool save_after_load=false, u8 version=0);
+	MapBlock *loadBlock(std::istream &is, v3s16 p, bool save_after_load=false, u8 version=0);
 
 	// Blocks are removed from the map but not deleted from memory until
 	// deleteDetachedBlocks() is called, since pointers to them may still exist

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -118,12 +118,14 @@ public:
 	bool saveBlock(MapBlock *block) override;
 	static bool saveBlock(MapBlock *block, MapDatabase *db, int compression_level = -1);
 
-	std::pair<std::unique_ptr<std::istream>, u8> createBlockIStream(const std::string *from_db);
+	/// @brief Splits the version off a serialized block and decompresses it early (if possible)
+	/// @return block data stream, version byte
+	static std::pair<std::unique_ptr<std::istream>, u8> createBlockIStream(const std::string *from_db);
 
 	// Load block in a synchronous fashion
 	MapBlock *loadBlock(v3s16 p);
 	/// Load a block that was already read from disk. Used by EmergeManager.
-	/// Caller must pass the version if it read the version off the stream.
+	/// Caller must use the createBlockIStream() helper before calling this
 	/// @return non-null block (but can be blank)
 	MapBlock *loadBlock(std::istream &is, v3s16 p, u8 version);
 

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -125,7 +125,7 @@ public:
 	/// Load a block that was already read from disk. Used by EmergeManager.
 	/// Caller must pass the version if it read the version off the stream.
 	/// @return non-null block (but can be blank)
-	MapBlock *loadBlock(std::istream &is, v3s16 p, bool save_after_load=false, std::optional<u8> version=std::nullopt);
+	MapBlock *loadBlock(std::istream &is, v3s16 p, u8 version);
 
 	// Blocks are removed from the map but not deleted from memory until
 	// deleteDetachedBlocks() is called, since pointers to them may still exist


### PR DESCRIPTION
This is an attempt to avoid decompressing block-data while holding locks (dblock, envlock, etc).

Naturally this leaks abstractions, _so we can argue whether it's worth it_. I tried to hide as much as I could think of.
This also includes some refactoring (like extracted older deserializaton logic out.)

On my machine I see that deserializing a block went down from 15us to 9us. (Decompressing the block data takes about 6us, so it adds up). So that's over 30% of deserialization time that does not hold any locks (and is actually parallelized with multiple emerge threads).

I also noted that load time of a large map is sped up by about 10% (more with more emerge threads).

- If you have used an LLM/AI to help with code or assets, you must disclose this.
Nope

## To do

This PR is Ready for Review.

## How to test

Load new and old maps, make sure everything loads.

If the consensus is that leaked abstractions are too high of a price to pay for this, I won't be attached...