### PR TITLE
Only regenerate mapblock meshes if border changed

### DIFF
--- a/src/benchmark/benchmark_lighting.cpp
+++ b/src/benchmark/benchmark_lighting.cpp
@@ -50,7 +50,7 @@ TEST_CASE("benchmark_lighting")
 	}
 
 	BENCHMARK_ADVANCED("voxalgo::update_lighting_nodes")(Catch::Benchmark::Chronometer meter) {
-		std::map<v3s16, MapBlock*> modified_blocks;
+		ModifiedMapBlocks modified_blocks;
 		meter.measure([&] {
 			map.addNodeAndUpdate(v3s16(0, 0, 0), MapNode(content_light), modified_blocks);
 			map.removeNodeAndUpdate(v3s16(0, 0, 0), modified_blocks);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -1517,7 +1517,7 @@ void Client::sendUpdateClientInfo(const ClientDynamicInfo& info)
 
 void Client::removeNode(v3s16 p)
 {
-	std::map<v3s16, MapBlock*> modified_blocks;
+	ModifiedMapBlocks modified_blocks;
 
 	try {
 		m_env.getMap().removeNodeAndUpdate(p, modified_blocks);
@@ -1526,7 +1526,8 @@ void Client::removeNode(v3s16 p)
 	}
 
 	for (const auto &modified_block : modified_blocks) {
-		addUpdateMeshTaskWithEdge(modified_block.first, false, true);
+		addUpdateMeshTaskWithEdge(modified_block.first, false, true,
+				&modified_block.second);
 	}
 }
 
@@ -1578,7 +1579,7 @@ void Client::addNode(v3s16 p, MapNode n, bool remove_metadata)
 {
 	//TimeTaker timer1("Client::addNode()");
 
-	std::map<v3s16, MapBlock*> modified_blocks;
+	ModifiedMapBlocks modified_blocks;
 
 	try {
 		//TimeTaker timer3("Client::addNode(): addNodeAndUpdate");
@@ -1588,7 +1589,8 @@ void Client::addNode(v3s16 p, MapNode n, bool remove_metadata)
 	}
 
 	for (const auto &modified_block : modified_blocks) {
-		addUpdateMeshTaskWithEdge(modified_block.first, false, true);
+		addUpdateMeshTaskWithEdge(modified_block.first, false, true,
+				&modified_block.second);
 	}
 }
 
@@ -1797,9 +1799,11 @@ void Client::addUpdateMeshTask(v3s16 p, bool ack_to_server, bool urgent)
 	m_mesh_update_manager->updateBlock(&m_env.getMap(), p, ack_to_server, urgent);
 }
 
-void Client::addUpdateMeshTaskWithEdge(v3s16 blockpos, bool ack_to_server, bool urgent)
+void Client::addUpdateMeshTaskWithEdge(v3s16 blockpos, bool ack_to_server, bool urgent,
+		const ModifiedMapBlock *modified_block)
 {
-	m_mesh_update_manager->updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent, true);
+	m_mesh_update_manager->updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent,
+			modified_block);
 }
 
 void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool urgent)
@@ -1808,7 +1812,7 @@ void Client::addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server, bool ur
 
 	v3s16 blockpos = getNodeBlockPos(nodepos);
 	v3s16 blockpos_relative = blockpos * MAP_BLOCKSIZE;
-	m_mesh_update_manager->updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent, false);
+	m_mesh_update_manager->updateBlock(&m_env.getMap(), blockpos, ack_to_server, urgent);
 	// Leading edge
 	if (nodepos.X == blockpos_relative.X)
 		addUpdateMeshTask(blockpos + v3s16(-1, 0, 0), false, urgent);

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -52,6 +52,7 @@ struct ClientDynamicInfo;
 struct ClientEvent;
 struct MapDrawControl;
 struct MapNode;
+struct ModifiedMapBlock;
 struct PlayerControl;
 struct PointedThing;
 struct ItemVisualsManager;
@@ -300,7 +301,8 @@ public:
 
 	void addUpdateMeshTask(v3s16 blockpos, bool ack_to_server=false, bool urgent=false);
 	// Including blocks at appropriate edges
-	void addUpdateMeshTaskWithEdge(v3s16 blockpos, bool ack_to_server=false, bool urgent=false);
+	void addUpdateMeshTaskWithEdge(v3s16 blockpos, bool ack_to_server=false, bool urgent=false,
+			const ModifiedMapBlock *modified_block=nullptr);
 	void addUpdateMeshTaskForNode(v3s16 nodepos, bool ack_to_server=false, bool urgent=false);
 
 	bool hasClientEvents() const { return !m_client_event_queue.empty(); }

--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -307,7 +307,7 @@ MeshUpdateManager::MeshUpdateManager(Client *client):
 }
 
 void MeshUpdateManager::updateBlock(Map *map, v3s16 p, bool ack_block_to_server,
-		bool urgent, bool update_neighbors)
+		bool urgent, const ModifiedMapBlock *modified_block)
 {
 	static thread_local const bool many_neighbors =
 			g_settings->getBool("smooth_lighting")
@@ -317,13 +317,30 @@ void MeshUpdateManager::updateBlock(Map *map, v3s16 p, bool ack_block_to_server,
 				<< p << std::endl;
 		return;
 	}
-	if (update_neighbors) {
+	if (modified_block) {
 		if (many_neighbors) {
-			for (v3s16 dp : g_26dirs)
+			for (v3s16 dp : g_26dirs) {
+				if (dp.X ==  1 && !((modified_block->m_borders >> 2) & 1))
+					continue;
+				if (dp.X == -1 && !((modified_block->m_borders >> 5) & 1))
+					continue;
+				if (dp.Y ==  1 && !((modified_block->m_borders >> 1) & 1))
+					continue;
+				if (dp.Y == -1 && !((modified_block->m_borders >> 4) & 1))
+					continue;
+				if (dp.Z ==  1 && !((modified_block->m_borders >> 0) & 1))
+					continue;
+				if (dp.Z == -1 && !((modified_block->m_borders >> 3) & 1))
+					continue;
+
 				m_queue_in.addBlock(map, p + dp, false, urgent, true);
+			}
 		} else {
-			for (v3s16 dp : g_6dirs)
-				m_queue_in.addBlock(map, p + dp, false, urgent, true);
+			for (int i = 0; i < 6; i++) {
+				if ((modified_block->m_borders >> i) & 1) {
+					m_queue_in.addBlock(map, p + g_6dirs[i], false, urgent, true);
+				}
+			}
 		}
 	}
 	deferUpdate();

--- a/src/client/mesh_generator_thread.h
+++ b/src/client/mesh_generator_thread.h
@@ -17,6 +17,7 @@ class Map;
 class MapBlock;
 class MapBlockMesh;
 struct MeshMakeData;
+struct ModifiedMapBlock;
 class Client;
 
 struct QueuedMeshUpdate
@@ -150,7 +151,7 @@ public:
 	// Caches the block at p and its neighbors (if needed) and queues a mesh
 	// update for the block at p
 	void updateBlock(Map *map, v3s16 p, bool ack_block_to_server, bool urgent,
-			bool update_neighbors = false);
+			const ModifiedMapBlock *modified_block = nullptr);
 
 	void putResult(MeshUpdateResult &&r);
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -160,7 +160,7 @@ void Map::setNode(v3s16 p, MapNode n)
 }
 
 void Map::addNodeAndUpdate(v3s16 p, MapNode n,
-		std::map<v3s16, MapBlock*> &modified_blocks,
+		ModifiedMapBlocks &modified_blocks,
 		bool remove_metadata)
 {
 	// Collect old node for rollback
@@ -187,7 +187,7 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 		n.setLight(LIGHTBANK_NIGHT, oldnode.getLightRaw(LIGHTBANK_NIGHT, oldf), f);
 		set_node_in_block(m_gamedef->ndef(), block, relpos, n);
 
-		modified_blocks[blockpos] = block;
+		modified_blocks[blockpos].update(relpos);
 	} else {
 		// Ignore light (because calling voxalgo::update_lighting_nodes)
 		n.setLight(LIGHTBANK_DAY, 0, f);
@@ -215,7 +215,7 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 }
 
 void Map::removeNodeAndUpdate(v3s16 p,
-		std::map<v3s16, MapBlock*> &modified_blocks)
+		ModifiedMapBlocks &modified_blocks)
 {
 	addNodeAndUpdate(p, MapNode(CONTENT_AIR), modified_blocks, true);
 }
@@ -229,7 +229,7 @@ bool Map::addNodeWithEvent(v3s16 p, MapNode n, bool remove_metadata)
 
 	bool succeeded = true;
 	try{
-		std::map<v3s16, MapBlock*> modified_blocks;
+		ModifiedMapBlocks modified_blocks;
 		addNodeAndUpdate(p, n, modified_blocks, remove_metadata);
 
 		event.setModifiedBlocks(modified_blocks);
@@ -251,7 +251,7 @@ bool Map::removeNodeWithEvent(v3s16 p)
 
 	bool succeeded = true;
 	try{
-		std::map<v3s16, MapBlock*> modified_blocks;
+		ModifiedMapBlocks modified_blocks;
 		removeNodeAndUpdate(p, modified_blocks);
 
 		event.setModifiedBlocks(modified_blocks);

--- a/src/map.h
+++ b/src/map.h
@@ -61,7 +61,8 @@ struct MapEditEvent
 		modified_blocks.push_back(getNodeBlockPos(pos));
 	}
 
-	void setModifiedBlocks(const std::map<v3s16, MapBlock *>& blocks)
+	template<class T>
+	void setModifiedBlocks(const std::map<v3s16, T>& blocks)
 	{
 		assert(modified_blocks.empty()); // only meant for initialization (once)
 		modified_blocks.reserve(blocks.size());
@@ -149,10 +150,10 @@ public:
 		These handle lighting but not faces.
 	*/
 	virtual void addNodeAndUpdate(v3s16 p, MapNode n,
-			std::map<v3s16, MapBlock*> &modified_blocks,
+			ModifiedMapBlocks &modified_blocks,
 			bool remove_metadata = true);
 	void removeNodeAndUpdate(v3s16 p,
-			std::map<v3s16, MapBlock*> &modified_blocks);
+			ModifiedMapBlocks &modified_blocks);
 
 	/*
 		Wrappers for the latter ones.

--- a/src/mapblock.h
+++ b/src/mapblock.h
@@ -259,12 +259,12 @@ public:
 	//// Non-checking variants of the above
 	////
 
-	inline MapNode getNodeNoCheck(s16 x, s16 y, s16 z)
+	inline MapNode getNodeNoCheck(s16 x, s16 y, s16 z) const
 	{
 		return data[m_is_mono_block ? 0 : z * zstride + y * ystride + x];
 	}
 
-	inline MapNode getNodeNoCheck(v3s16 p)
+	inline MapNode getNodeNoCheck(v3s16 p) const
 	{
 		return getNodeNoCheck(p.X, p.Y, p.Z);
 	}
@@ -563,6 +563,29 @@ private:
 };
 
 typedef std::vector<MapBlock*> MapBlockVect;
+
+// Stores information about what parts of a MapBlock got modified
+struct ModifiedMapBlock
+{
+	// Whether borders changed, bit field, order like in g_6dirs
+	u8 m_borders = 0;
+
+	// A single node changed
+	void update(v3s16 rel_pos)
+	{
+		m_borders |= rel_pos.Z == MAP_BLOCKSIZE - 1;
+		m_borders |= (rel_pos.Y == MAP_BLOCKSIZE - 1) << 1;
+		m_borders |= (rel_pos.X == MAP_BLOCKSIZE - 1) << 2;
+		m_borders |= (rel_pos.Z == 0) << 3;
+		m_borders |= (rel_pos.Y == 0) << 4;
+		m_borders |= (rel_pos.X == 0) << 5;
+	}
+
+	// Nothing or everything changed
+	ModifiedMapBlock(bool modified = false) : m_borders(modified ? 0xFF : 0) {}
+};
+
+typedef std::map<v3s16, ModifiedMapBlock> ModifiedMapBlocks;
 
 inline bool objectpos_over_limit(v3f p)
 {

--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -335,7 +335,8 @@ void Client::handleCommand_BlockData(NetworkPacket* pkt)
 	/*
 		Add it to mesh update queue and set it to be acknowledged after update.
 	*/
-	addUpdateMeshTaskWithEdge(p, true);
+	ModifiedMapBlock modified_block{true};
+	addUpdateMeshTaskWithEdge(p, true, false, &modified_block);
 }
 
 void Client::handleCommand_Inventory(NetworkPacket* pkt)

--- a/src/servermap.cpp
+++ b/src/servermap.cpp
@@ -455,7 +455,7 @@ bool ServerMap::isBlockInQueue(v3s16 pos)
 }
 
 void ServerMap::addNodeAndUpdate(v3s16 p, MapNode n,
-		std::map<v3s16, MapBlock*> &modified_blocks,
+		ModifiedMapBlocks &modified_blocks,
 		bool remove_metadata)
 {
 	Map::addNodeAndUpdate(p, n, modified_blocks, remove_metadata);
@@ -766,7 +766,7 @@ MapBlock *ServerMap::loadBlock(const std::string &blob, v3s16 p3d, bool save_aft
 		ReflowScan scanner(this, m_emerge->ndef);
 		scanner.scan(block, &m_transforming_liquid);
 
-		std::map<v3s16, MapBlock*> modified_blocks;
+		ModifiedMapBlocks modified_blocks;
 		// Fix lighting if necessary
 		voxalgo::update_block_border_lighting(this, block, modified_blocks);
 		if (!modified_blocks.empty()) {

--- a/src/servermap.h
+++ b/src/servermap.h
@@ -96,7 +96,7 @@ public:
 	bool isBlockInQueue(v3s16 pos);
 
 	void addNodeAndUpdate(v3s16 p, MapNode n,
-			std::map<v3s16, MapBlock*> &modified_blocks,
+			ModifiedMapBlocks &modified_blocks,
 			bool remove_metadata) override;
 
 	/*

--- a/src/unittest/test_voxelalgorithms.cpp
+++ b/src/unittest/test_voxelalgorithms.cpp
@@ -114,7 +114,7 @@ void TestVoxelAlgorithms::testLighting(IGameDef *gamedef)
 
 	// Place two holes on the edges a torch in the center.
 	{
-		std::map<v3s16, MapBlock*> modified_blocks;
+		ModifiedMapBlocks modified_blocks;
 		map.addNodeAndUpdate(v3s16(-10, 0, 0), MapNode(CONTENT_AIR), modified_blocks);
 		map.addNodeAndUpdate(v3s16(9, 10, -9), MapNode(t_CONTENT_WATER), modified_blocks);
 		map.addNodeAndUpdate(v3s16(0, 0, 0), MapNode(t_CONTENT_TORCH), modified_blocks);

--- a/src/voxelalgorithms.cpp
+++ b/src/voxelalgorithms.cpp
@@ -229,6 +229,21 @@ bool step_rel_block_pos(direction dir, relative_v3 &rel_pos,
 	return false;
 }
 
+// Helper for templated functions
+void update_modified_blocks(ModifiedMapBlocks &modified_blocks,
+		mapblock_v3 bp, MapBlock *block, v3s16 rel_pos)
+{
+	modified_blocks[bp].update(rel_pos);
+
+}
+
+void update_modified_blocks(std::map<v3s16, MapBlock*> &modified_blocks, mapblock_v3 bp,
+		MapBlock *block, v3s16 rel_pos)
+{
+	modified_blocks[bp] = block;
+}
+
+
 /*
  * Removes all light that is potentially emitted by the specified
  * light sources. These nodes will have zero light.
@@ -239,9 +254,10 @@ bool step_rel_block_pos(direction dir, relative_v3 &rel_pos,
  * \param light_sources nodes that should be re-lighted
  * \param modified_blocks output, all modified map blocks are added to this
  */
+template <class MB>
 void unspread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 	UnlightQueue &from_nodes, ReLightQueue &light_sources,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+	MB &modified_blocks)
 {
 	// Stores data popped from from_nodes
 	u8 current_light;
@@ -298,11 +314,8 @@ void unspread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 					neighbor_block->setNodeNoCheck(neighbor_rel_pos, neighbor);
 					from_nodes.push(neighbor_light, neighbor_rel_pos,
 						neighbor_block_pos, neighbor_block, i);
-					// The current node was modified earlier, so its block
-					// is in modified_blocks.
-					if (current.block != neighbor_block) {
-						modified_blocks[neighbor_block_pos] = neighbor_block;
-					}
+					update_modified_blocks(modified_blocks, neighbor_block_pos,
+							neighbor_block, neighbor_rel_pos);
 				}
 			} else {
 				// The neighbor can light up this node.
@@ -339,9 +352,10 @@ void unspread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
  * \param light_sources starting nodes
  * \param modified_blocks output, all modified map blocks are added to this
  */
+template <class MB>
 void spread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 	LightQueue &light_sources,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+	MB &modified_blocks)
 {
 	// The light the current node can provide to its neighbors.
 	u8 spreading_light;
@@ -381,11 +395,8 @@ void spread_light(Map *map, const NodeDefManager *nodemgr, LightBank bank,
 					neighbor_block->setNodeNoCheck(neighbor_rel_pos, neighbor);
 					light_sources.push(spreading_light, neighbor_rel_pos,
 						neighbor_block_pos, neighbor_block, i);
-					// The current node was modified earlier, so its block
-					// is in modified_blocks.
-					if (current.block != neighbor_block) {
-						modified_blocks[neighbor_block_pos] = neighbor_block;
-					}
+					update_modified_blocks(modified_blocks, neighbor_block_pos,
+							neighbor_block, neighbor_rel_pos);
 				}
 			}
 		}
@@ -451,9 +462,10 @@ bool is_sunlight_above(Map *map, v3s16 pos, const NodeDefManager *ndef)
 
 static constexpr LightBank banks[] = { LIGHTBANK_DAY, LIGHTBANK_NIGHT };
 
+template <class MB>
 void update_lighting_nodes(Map *map,
 	const std::vector<std::pair<v3s16, MapNode>> &oldnodes,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+	MB &modified_blocks)
 {
 	const NodeDefManager *ndef = map->getNodeDefManager();
 	// For node getter functions
@@ -500,7 +512,7 @@ void update_lighting_nodes(Map *map,
 			u8 old_light = it->second.getLight(bank, ndef->getLightingFlags(it->second));
 
 			// Add the block of the added node to modified_blocks
-			modified_blocks[block_pos] = block;
+			update_modified_blocks(modified_blocks, block_pos, block, rel_pos);
 
 			// Get new light level of the node
 			u8 new_light = 0;
@@ -626,6 +638,12 @@ void update_lighting_nodes(Map *map,
 		spread_light(map, ndef, bank, light_sources, modified_blocks);
 	}
 }
+template void update_lighting_nodes(Map *map,
+		const std::vector<std::pair<v3s16, MapNode>> &oldnodes,
+		ModifiedMapBlocks &modified_blocks);
+template void update_lighting_nodes(Map *map,
+		const std::vector<std::pair<v3s16, MapNode>> &oldnodes,
+		std::map<v3s16, MapBlock*> &modified_blocks);
 
 /*!
  * Borders of a map block in relative node coordinates.
@@ -675,7 +693,7 @@ bool is_light_locally_correct(Map *map, const NodeDefManager *ndef,
 }
 
 void update_block_border_lighting(Map *map, MapBlock *block,
-	std::map<v3s16, MapBlock*> &modified_blocks)
+		ModifiedMapBlocks &modified_blocks)
 {
 	const NodeDefManager *ndef = map->getNodeDefManager();
 	// Since invalid light is not common, do not allocate
@@ -724,7 +742,8 @@ void update_block_border_lighting(Map *map, MapBlock *block,
 							// Initialize for unlighting
 							n.setLight(bank, 0, ndef->getLightingFlags(n));
 							b->setNodeNoCheck(x, y, z, n);
-							modified_blocks[b->getPos()]=b;
+							update_modified_blocks(modified_blocks, b->getPos(),
+									b, relative_v3(x, y, z));
 							disappearing_lights.push(light,
 								relative_v3(x, y, z), b->getPos(), b,
 								6);

--- a/src/voxelalgorithms.h
+++ b/src/voxelalgorithms.h
@@ -10,6 +10,7 @@
 class Map;
 class MapBlock;
 class MMVManip;
+struct ModifiedMapBlock;
 
 namespace voxalgo
 {
@@ -26,10 +27,11 @@ namespace voxalgo
  * \param modified_blocks output, contains all map blocks that
  * the function modified
  */
+template <class MB> // ServerMap::transformLiquidsLocal does not use ModifiedMapBlock yet
 void update_lighting_nodes(
 	Map *map,
 	const std::vector<std::pair<v3s16, MapNode>> &oldnodes,
-	std::map<v3s16, MapBlock*> &modified_blocks);
+	MB &modified_blocks);
 
 /*!
  * Updates borders of the given mapblock.
@@ -41,7 +43,7 @@ void update_lighting_nodes(
  * the function modified
  */
 void update_block_border_lighting(Map *map, MapBlock *block,
-	std::map<v3s16, MapBlock*> &modified_blocks);
+	std::map<v3s16, ModifiedMapBlock> &modified_blocks);
 
 /*!
  * Copies back nodes from a voxel manipulator


### PR DESCRIPTION
This improves the performance of mapblock meshgen by about 10x, sometimes.
(Mapblock meshgen takes up a big portion of CPU time according to my profiling, but it doesn't use the main thread, so it's not that noticeable.)

The profiling window (press F6) `Client: Mesh making`  while holding dig/place and moving around (or dig straight down) shows about 600-1000ms using master and about 70-200ms with this PR. (Compiled release built, but without LTO, using one meshgen thread.)

### Changes

Only updates neighboring meshes if the border changed also see https://github.com/luanti-org/luanti/issues/16264#issuecomment-2974717886 it reduces the amount of meshes that have to be regenerated on dig ~/place~ from 27 to about 1-3. In the future the `ModifiedMapBlocks` struct could store more detailed information, like if only the light changed or maybe more advanced things like a bloom filter.
  I decided to store all 6 borders and not just one bool, since border updates are very likely, because of spreading light.

<details>
  <summary>Future work</summary>

There is a lot more that could be done to improve `MapblockMeshGenerator::generate` e.g. for `getSmoothLightCombined`. Maybe some drawtyps are slow, I have only profiled it on a normal world.

If the server sends a changed mapblock all 26 neighboring meshes still get recalculated. Maybe it would be good to send more information about which parts of the mapblock changed. The lighting code for the mapblock meshgen should probobly also be seperated, such that you can update only the light. The light spread is the main reason why we update the neighboring meshes anyway.

And of course incremental meshgen updates #16264 since you usually only change a single node anyway, it would also be helpful for LOD mesh drawtype things.
</details>

## To do

Ready for Review.

- [x] Test again
- ~Send `ModifiedMapBlocks` to clients or calculate diff client side~

## How to test

- Set the `mesh_generation_threads` setting to 1 (and keep all other meshgen settings default.)
- Open the profiling window (press F6) and look at `Client: Mesh making`

Apply this patch on top of the PR, it prints whenever a new blocks gets sent to the client and how many mapblock meshes get generated. (You could also apply it on master to see what happes there.)
<details>
  <summary>Patch</summary>

``` diff
diff --git a/src/client/mesh_generator_thread.cpp b/src/client/mesh_generator_thread.cpp
index b6f5927c7..8991cfad5 100644
--- a/src/client/mesh_generator_thread.cpp
+++ b/src/client/mesh_generator_thread.cpp
@@ -254,14 +254,19 @@ MeshUpdateWorkerThread::MeshUpdateWorkerThread(Client *client, MeshUpdateQueue *
 	m_generation_interval = rangelim(m_generation_interval, 0, 25);
 }
 
+std::mutex cout_m;
+
 void MeshUpdateWorkerThread::doUpdate()
 {
+	int poped = 0;
+
 	QueuedMeshUpdate *q;
 	while ((q = m_queue_in->pop())) {
 		ScopeProfiler sp(g_profiler, "Client: Mesh making (sum)");
 
 		// This generates the mesh:
 		MapBlockMesh *mesh_new = new MapBlockMesh(m_client, q->data);
+		poped++;
 
 		MeshUpdateResult r;
 		r.p = q->p;
@@ -283,6 +288,10 @@ void MeshUpdateWorkerThread::doUpdate()
 		if (m_generation_interval)
 			sleep_ms(m_generation_interval);
 	}
+	if (poped > 0) {
+		std::lock_guard<std::mutex> lock(cout_m);
+		std::cout << "poped: " << poped << std::endl;
+	}
 }
 
 /*
diff --git a/src/server.cpp b/src/server.cpp
index 5c6cee5ca..34d6d580d 100644
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2608,6 +2608,10 @@ void Server::SendBlocks(float dtime)
 	// Lowest is most important.
 	std::sort(queue.begin(), queue.end());
 
+	if (queue.size() > 0)
+		printf("sent blocks %zu\n", queue.size());
+
+
 	ClientInterface::AutoLock clientlock(m_clients);
 
 	// Maximal total count calculation

```

</details>

Start the game and wait some time until no more blocks get sent.
Dig and place some nodes (maybe also at a block border) and notice that no blocks get sent and only a few mapblock meshes get generated.

Look at the code and make sure there are no bugs.
