### PR TITLE
Don't use getNodeNoEx for mapblock meshgen 

### DIFF
--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1873,6 +1873,9 @@ void MapblockMeshGenerator::generate()
 	for (cur_node.p.Y = 0; cur_node.p.Y < data->m_side_length; cur_node.p.Y++)
 	for (cur_node.p.X = 0; cur_node.p.X < data->m_side_length; cur_node.p.X++) {
 		cur_node.n = data->m_vmanip.getNodeRefUnsafeCheckFlags(blockpos_nodes + cur_node.p);
+		content_t c = cur_node.n.getContent();
+		if (c == CONTENT_AIR)
+			continue;
 		cur_node.f = &nodedef->get(cur_node.n);
 		drawNode();
 	}

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -443,7 +443,7 @@ void MapblockMeshGenerator::drawSolidNode()
 	content_t n1 = cur_node.n.getContent();
 	for (int face = 0; face < 6; face++) {
 		v3s16 p2 = blockpos_nodes + cur_node.p + tile_dirs[face];
-		MapNode neighbor = data->m_vmanip.getNodeNoEx(p2);
+		MapNode neighbor = data->m_vmanip.getNodeRefUnsafeCheckFlags(p2);
 		content_t n2 = neighbor.getContent();
 		bool backface_culling = cur_node.f->drawtype == NDT_NORMAL;
 		if (n2 == n1)
@@ -465,7 +465,8 @@ void MapblockMeshGenerator::drawSolidNode()
 				v3s16(1,0,0), v3s16(-1,0,0), v3s16(0,0,1), v3s16(0,0,-1)
 			};
 			for (const v3s16 &d : h_dirs) {
-				const ContentFeatures &f_side = nodedef->get(data->m_vmanip.getNodeNoEx(p2 + d));
+				const ContentFeatures &f_side =
+						nodedef->get(data->m_vmanip.getNodeRefUnsafeCheckFlags(p2 + d));
 
 				bool side_is_translucent = !(f_side.visuals->solidness || f_side.visuals->visual_solidness);
 				bool side_is_same_flowing_liquid =
@@ -586,8 +587,10 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 	getSpecialTile(0, &cur_liquid.tile_top);
 	getSpecialTile(1, &cur_liquid.tile);
 
-	MapNode ntop    = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p + v3s16(0,  1, 0));
-	MapNode nbottom = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p + v3s16(0, -1, 0));
+	MapNode ntop    = data->m_vmanip.getNodeRefUnsafeCheckFlags(
+			blockpos_nodes + cur_node.p + v3s16(0,  1, 0));
+	MapNode nbottom = data->m_vmanip.getNodeRefUnsafeCheckFlags(
+			blockpos_nodes + cur_node.p + v3s16(0, -1, 0));
 	cur_liquid.c_flowing = cur_node.f->liquid_alternative_flowing_id;
 	cur_liquid.c_source = cur_node.f->liquid_alternative_source_id;
 	cur_liquid.top_is_same_liquid = (ntop.getContent() == cur_liquid.c_flowing)
@@ -627,7 +630,7 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 	for (int u = -1; u <= 1; u++) {
 		LiquidData::NeighborData &neighbor = cur_liquid.neighbors[w + 1][u + 1];
 		v3s16 p2 = cur_node.p + v3s16(u, 0, w);
-		MapNode n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
+		MapNode n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(blockpos_nodes + p2);
 		neighbor.content = n2.getContent();
 		neighbor.level = -0.5f;
 		neighbor.is_same_liquid = false;
@@ -653,7 +656,7 @@ void MapblockMeshGenerator::getLiquidNeighborhood()
 		// NOTE: This doesn't get executed if neighbor
 		//       doesn't exist
 		p2.Y++;
-		n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
+		n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(blockpos_nodes + p2);
 		if (n2.getContent() == cur_liquid.c_source || n2.getContent() == cur_liquid.c_flowing)
 			neighbor.top_is_same_liquid = true;
 	}
@@ -895,7 +898,7 @@ void MapblockMeshGenerator::drawGlasslikeNode()
 		// Check this neighbor
 		v3s16 dir = g_6dirs[face];
 		v3s16 neighbor_pos = blockpos_nodes + cur_node.p + dir;
-		MapNode neighbor = data->m_vmanip.getNodeNoExNoEmerge(neighbor_pos);
+		MapNode neighbor = data->m_vmanip.getNodeRefUnsafeCheckFlags(neighbor_pos);
 		// Don't make face if neighbor is of same type
 		if (neighbor.getContent() == cur_node.n.getContent())
 			continue;
@@ -989,7 +992,7 @@ void MapblockMeshGenerator::drawGlasslikeFramedNode()
 			if (!check_nb[i])
 				continue;
 			v3s16 n2p = blockpos_nodes + cur_node.p + g_26dirs[i];
-			MapNode n2 = data->m_vmanip.getNodeNoEx(n2p);
+			MapNode n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(n2p);
 			content_t n2c = n2.getContent();
 			if (n2c == current)
 				nb[i] = 1;
@@ -1334,7 +1337,7 @@ void MapblockMeshGenerator::drawPlantlikeRootedNode()
 	if (data->m_smooth_lighting) {
 		getSmoothLightFrame();
 	} else {
-		MapNode ntop = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p);
+		MapNode ntop = data->m_vmanip.getNodeRefUnsafeCheckFlags(blockpos_nodes + cur_node.p);
 		auto light = LightPair(getInteriorLight(ntop, 0, nodedef));
 		cur_node.lcolor = encode_light(light, cur_node.f->light_source);
 	}
@@ -1373,7 +1376,7 @@ void MapblockMeshGenerator::drawFirelikeNode()
 	content_t current = cur_node.n.getContent();
 	for (int i = 0; i < 6; i++) {
 		v3s16 n2p = blockpos_nodes + cur_node.p + g_6dirs[i];
-		MapNode n2 = data->m_vmanip.getNodeNoEx(n2p);
+		MapNode n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(n2p);
 		content_t n2c = n2.getContent();
 		if (n2c != CONTENT_IGNORE && n2c != CONTENT_AIR && n2c != current) {
 			neighbor[i] = true;
@@ -1438,7 +1441,7 @@ void MapblockMeshGenerator::drawFencelikeNode()
 	// Now a section of fence, +X, if there's a post there
 	v3s16 p2 = cur_node.p;
 	p2.X++;
-	MapNode n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
+	MapNode n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(blockpos_nodes + p2);
 	const ContentFeatures *f2 = &nodedef->get(n2);
 	if (f2->drawtype == NDT_FENCELIKE) {
 		static const aabb3f bar_x1(BS / 2 - bar_len,  BS / 4 - bar_rad, -bar_rad,
@@ -1460,7 +1463,7 @@ void MapblockMeshGenerator::drawFencelikeNode()
 	// Now a section of fence, +Z, if there's a post there
 	p2 = cur_node.p;
 	p2.Z++;
-	n2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + p2);
+	n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(blockpos_nodes + p2);
 	f2 = &nodedef->get(n2);
 	if (f2->drawtype == NDT_FENCELIKE) {
 		static const aabb3f bar_z1(-bar_rad,  BS / 4 - bar_rad, BS / 2 - bar_len,
@@ -1482,7 +1485,8 @@ void MapblockMeshGenerator::drawFencelikeNode()
 
 bool MapblockMeshGenerator::isSameRail(v3s16 dir)
 {
-	MapNode node2 = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p + dir);
+	MapNode node2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(
+			blockpos_nodes + cur_node.p + dir);
 	if (node2.getContent() == cur_node.n.getContent())
 		return true;
 	const ContentFeatures &def2 = nodedef->get(node2);
@@ -1634,7 +1638,7 @@ void MapblockMeshGenerator::drawNodeboxNode()
 	for (int dir = 0; dir != 6; dir++) {
 		u8 flag = 1 << dir;
 		v3s16 p2 = blockpos_nodes + cur_node.p + nodebox_tile_dirs[dir];
-		MapNode n2 = data->m_vmanip.getNodeNoEx(p2);
+		MapNode n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(p2);
 
 		// mark neighbors that are the same node type
 		// and have the same rotation or higher level stored as param2
@@ -1649,7 +1653,7 @@ void MapblockMeshGenerator::drawNodeboxNode()
 
 		if (cur_node.f->node_box.type == NODEBOX_CONNECTED) {
 			p2 = blockpos_nodes + cur_node.p + nodebox_connection_dirs[dir];
-			n2 = data->m_vmanip.getNodeNoEx(p2);
+			n2 = data->m_vmanip.getNodeRefUnsafeCheckFlags(p2);
 			if (nodedef->nodeboxConnects(cur_node.n, n2, flag))
 				neighbors_set |= flag;
 		}
@@ -1821,17 +1825,15 @@ void MapblockMeshGenerator::errorUnknownDrawtype()
 
 void MapblockMeshGenerator::drawNode()
 {
+	if (cur_node.f->drawtype == NDT_AIRLIKE)
+		return; // Not drawn at all
+
 	cur_node.origin = intToFloat(cur_node.p, BS);
-	switch (cur_node.f->drawtype) {
-		case NDT_AIRLIKE:  // Not drawn at all
-			return;
-		case NDT_LIQUID:
-		case NDT_NORMAL: // solid nodes don’t need the usual setup
-			drawSolidNode();
-			return;
-		default:
-			break;
+	if (cur_node.f->drawtype == NDT_LIQUID || cur_node.f->drawtype == NDT_NORMAL) {
+		drawSolidNode(); // Solid nodes don’t need the usual setup
+		return;
 	}
+
 	if (data->m_smooth_lighting) {
 		getSmoothLightFrame();
 	} else {
@@ -1860,10 +1862,19 @@ void MapblockMeshGenerator::generate()
 {
 	ZoneScoped;
 
+	// getNodeRefUnsafeCheckFlags can be used for nodes up to 3 away
+	// Also see MeshMakeData::fillBlockDataBegin and MeshMakeData::fillSingleNode
+	// Currently all drawtypes use at most nodes one away except for NDT_PLANTLIKE_ROOTED
+	// which reads nodes at y+2 for getSmoothLightFrame
+	assert(data->m_vmanip.m_area.contains(VoxelArea(
+		blockpos_nodes - 3,
+		blockpos_nodes + data->m_side_length + 2
+	)));
+
 	for (cur_node.p.Z = 0; cur_node.p.Z < data->m_side_length; cur_node.p.Z++)
 	for (cur_node.p.Y = 0; cur_node.p.Y < data->m_side_length; cur_node.p.Y++)
 	for (cur_node.p.X = 0; cur_node.p.X < data->m_side_length; cur_node.p.X++) {
-		cur_node.n = data->m_vmanip.getNodeNoEx(blockpos_nodes + cur_node.p);
+		cur_node.n = data->m_vmanip.getNodeRefUnsafeCheckFlags(blockpos_nodes + cur_node.p);
 		cur_node.f = &nodedef->get(cur_node.n);
 		drawNode();
 	}

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1830,7 +1830,7 @@ void MapblockMeshGenerator::drawNode()
 
 	cur_node.origin = intToFloat(cur_node.p, BS);
 	if (cur_node.f->drawtype == NDT_LIQUID || cur_node.f->drawtype == NDT_NORMAL) {
-		drawSolidNode(); // Solid nodes don’t need the usual setup
+		drawSolidNode(); // Solid nodes don't need the usual setup
 		return;
 	}
 
@@ -1866,10 +1866,8 @@ void MapblockMeshGenerator::generate()
 	// Also see MeshMakeData::fillBlockDataBegin and MeshMakeData::fillSingleNode
 	// Currently all drawtypes use at most nodes one away except for NDT_PLANTLIKE_ROOTED
 	// which reads nodes at y+2 for getSmoothLightFrame
-	assert(data->m_vmanip.m_area.contains(VoxelArea(
-		blockpos_nodes - 3,
-		blockpos_nodes + data->m_side_length + 2
-	)));
+	assert(data->m_vmanip.m_area.contains(blockpos_nodes - 3));
+	assert(data->m_vmanip.m_area.contains(blockpos_nodes + (data->m_side_length + 2)));
 
 	for (cur_node.p.Z = 0; cur_node.p.Z < data->m_side_length; cur_node.p.Z++)
 	for (cur_node.p.Y = 0; cur_node.p.Y < data->m_side_length; cur_node.p.Y++)

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -1867,7 +1867,7 @@ void MapblockMeshGenerator::generate()
 	// Currently all drawtypes use at most nodes one away except for NDT_PLANTLIKE_ROOTED
 	// which reads nodes at y+2 for getSmoothLightFrame
 	assert(data->m_vmanip.m_area.contains(blockpos_nodes - 3));
-	assert(data->m_vmanip.m_area.contains(blockpos_nodes + (data->m_side_length + 2)));
+	assert(data->m_vmanip.m_area.contains(blockpos_nodes + v3s16(data->m_side_length + 2)));
 
 	for (cur_node.p.Z = 0; cur_node.p.Z < data->m_side_length; cur_node.p.Z++)
 	for (cur_node.p.Y = 0; cur_node.p.Y < data->m_side_length; cur_node.p.Y++)

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -654,8 +654,7 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data):
 		for (ofs.Y = 0; ofs.Y < mesh_grid.cell_size; ofs.Y++)
 		for (ofs.X = 0; ofs.X < mesh_grid.cell_size; ofs.X++) {
 			v3s16 p = (bp + ofs) * MAP_BLOCKSIZE;
-			assert(data->m_vmanip.m_area.contains(p));
-			if (data->m_vmanip.getNodeRefUnsafeCheckFlags(p).getContent() != CONTENT_IGNORE) {
+			if (data->m_vmanip.getNodeNoExNoEmerge(p).getContent() != CONTENT_IGNORE) {
 				MinimapMapblock *block = new MinimapMapblock;
 				m_minimap_mapblocks[mesh_grid.getOffsetIndex(ofs)] = block;
 				block->getMinimapNodes(&data->m_vmanip, data->m_nodedef, p);

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -654,7 +654,8 @@ MapBlockMesh::MapBlockMesh(Client *client, MeshMakeData *data):
 		for (ofs.Y = 0; ofs.Y < mesh_grid.cell_size; ofs.Y++)
 		for (ofs.X = 0; ofs.X < mesh_grid.cell_size; ofs.X++) {
 			v3s16 p = (bp + ofs) * MAP_BLOCKSIZE;
-			if (data->m_vmanip.getNodeNoEx(p).getContent() != CONTENT_IGNORE) {
+			assert(data->m_vmanip.m_area.contains(p));
+			if (data->m_vmanip.getNodeRefUnsafeCheckFlags(p).getContent() != CONTENT_IGNORE) {
 				MinimapMapblock *block = new MinimapMapblock;
 				m_minimap_mapblocks[mesh_grid.getOffsetIndex(ofs)] = block;
 				block->getMinimapNodes(&data->m_vmanip, data->m_nodedef, p);

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -727,6 +727,10 @@ void Minimap::updateActiveMarkers()
 
 void MinimapMapblock::getMinimapNodes(VoxelManipulator *vmanip, const NodeDefManager *nodedef, const v3s16 &pos)
 {
+	// Uses getNodeRefUnsafeCheckFlags
+	assert(vmanip->m_area.contains(pos));
+	assert(vmanip->m_area.contains(pos + (MAP_BLOCKSIZE - 1)));
+
 	for (s16 x = 0; x < MAP_BLOCKSIZE; x++)
 	for (s16 z = 0; z < MAP_BLOCKSIZE; z++) {
 		s16 air_count = 0;
@@ -735,7 +739,6 @@ void MinimapMapblock::getMinimapNodes(VoxelManipulator *vmanip, const NodeDefMan
 
 		for (s16 y = MAP_BLOCKSIZE -1; y >= 0; y--) {
 			v3s16 p(x, y, z);
-			assert(vmanip->m_area.contains(pos + p));
 			MapNode n = vmanip->getNodeRefUnsafeCheckFlags(pos + p);
 			const ContentFeatures &f = nodedef->get(n);
 			if (!surface_found && f.drawtype != NDT_AIRLIKE) {

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -729,7 +729,7 @@ void MinimapMapblock::getMinimapNodes(VoxelManipulator *vmanip, const NodeDefMan
 {
 	// Uses getNodeRefUnsafeCheckFlags
 	assert(vmanip->m_area.contains(pos));
-	assert(vmanip->m_area.contains(pos + (MAP_BLOCKSIZE - 1)));
+	assert(vmanip->m_area.contains(pos + v3s16(MAP_BLOCKSIZE - 1)));
 
 	for (s16 x = 0; x < MAP_BLOCKSIZE; x++)
 	for (s16 z = 0; z < MAP_BLOCKSIZE; z++) {

--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -735,7 +735,8 @@ void MinimapMapblock::getMinimapNodes(VoxelManipulator *vmanip, const NodeDefMan
 
 		for (s16 y = MAP_BLOCKSIZE -1; y >= 0; y--) {
 			v3s16 p(x, y, z);
-			MapNode n = vmanip->getNodeNoEx(pos + p);
+			assert(vmanip->m_area.contains(pos + p));
+			MapNode n = vmanip->getNodeRefUnsafeCheckFlags(pos + p);
 			const ContentFeatures &f = nodedef->get(n);
 			if (!surface_found && f.drawtype != NDT_AIRLIKE) {
 				mmpixel->height = y;

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -52,9 +52,10 @@ public:
 		data.m_smooth_lighting = smooth_lighting;
 		data.m_enable_water_reflections = false;
 		data.m_blockpos = {0, 0, 0};
-		for (s16 x = -10; x <= 10; x++)
-		for (s16 y = -10; y <= 10; y++)
-		for (s16 z = -10; z <= 10; z++)
+		// MapblockMeshGenerator needs a margin of at least 3
+		for (s16 x = -3; x <= 3; x++)
+		for (s16 y = -3; y <= 3; y++)
+		for (s16 z = -3; z <= 3; z++)
 			data.m_vmanip.setNode({x, y, z}, {CONTENT_AIR, 0, 0});
 		return data;
 	}

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -52,9 +52,9 @@ public:
 		data.m_smooth_lighting = smooth_lighting;
 		data.m_enable_water_reflections = false;
 		data.m_blockpos = {0, 0, 0};
-		for (s16 x = -1; x <= 1; x++)
-		for (s16 y = -1; y <= 1; y++)
-		for (s16 z = -1; z <= 1; z++)
+		for (s16 x = -10; x <= 10; x++)
+		for (s16 y = -10; y <= 10; y++)
+		for (s16 z = -10; z <= 10; z++)
 			data.m_vmanip.setNode({x, y, z}, {CONTENT_AIR, 0, 0});
 		return data;
 	}


### PR DESCRIPTION
Extracted from #17407,

TL;DR makes meshgen for mostly airlike mapblocks about 1.5 times faster.

It replaces every `getNodeNoEx` (and `getNodeNoExNoEmerge`) with `getNodeRefUnsafeCheckFlags` in mapblock meshgen. I replaced it now everywhere for consistency.

And it also reorders things in `drawNode` to not set `cur_node.origin` for airlike nodes.
(This only makes a very small difference when building with -O3, but I was able to measure it consistently for mapblock that mostly contain air. However, it doesn't make the code look worse, so I would still keep it. Using `getNodeNoExNoEmerge` makes a much bigger difference.)

### Mesurments

I had a hard time measuring the total meshgen time consistently, so I measured individual mapblocks instead.

This shows the time spent in the `MapBlockMesh` constructor for different mapblocks, using this PR and master.
It was in a mountain-ish area with trees next to an ocean. 
Compiled release builds (-O3) and with LTO.
Each point is the median of at least 10 samples. Mapblock meshes that got generated less than 10 times are filtered out.
(The mapblocks are somewhat sorted by position, but it doesn't matter here anyway, and they are all distinct.)

<img width="2669" height="1469" alt="output" src="https://github.com/user-attachments/assets/419ae466-9228-4d80-a175-11d1fa1c744e" />

You can see that it makes a difference for mapblocks that contain mostly airlike nodes. For more complex blocks which are harder to compute anyway `getNodeNoEx` is not a big factor anymore.

If you sum up all values below 200, in this graph, it's 2391 in master and 1366 with this PR.

## To do

Ready for Review.

Waiting in feature freeze.

## How to test

Read the code and make sure there are no bugs.
