### PR TITLE
Ignore thread and userdata types in core.serialize

### DIFF
--- a/builtin/common/serialize.lua
+++ b/builtin/common/serialize.lua
@@ -8,6 +8,15 @@ local next, rawget, pairs, pcall, error, type, setfenv, loadstring
 local table_concat, string_dump, string_format, string_match, math_huge
 	= table.concat, string.dump, string.format, string.match, math.huge
 
+local unsupported_types = {userdata=true, thread=true}
+
+-- Userdata and thread can be used as a key and a value in lua tables so it must check for both.
+local function allowed_type(k,v)
+	local a = unsupported_types[type(k)] == true
+	local b = unsupported_types[type(v)] == true
+	return not (a or b)
+end
+
 -- Recursively counts occurrences of objects (non-primitives including strings) in a table.
 local function count_objects(value)
 	local counts = {}
@@ -25,12 +34,16 @@ local function count_objects(value)
 		if type_ == "table" then
 			if not count then
 				for k, v in pairs(val) do
-					count_values(k)
-					count_values(v)
+					-- Skip it if it's not a supported type.
+					if allowed_type(k, v) then
+						count_values(k)
+						count_values(v)
+					end
 				end
 			end
 		elseif type_ ~= "string" and type_ ~= "function" then
-			error("unsupported type: " .. type_)
+			-- Ignore unsupported types instead of erroring out.
+			return
 		end
 	end
 	count_values(value)
@@ -119,6 +132,12 @@ local function serialize(value, write)
 				return write(string_format("%.17g", value))
 			end
 		end
+
+		-- Failsafe for userdata/thread if it bypasses the filters.
+		if type_ == "userdata" or type_ == "thread" then
+			return write("nil")
+		end
+
 		-- Reference types: table, function and string
 		local ref = references[value]
 		if ref then
@@ -144,23 +163,31 @@ local function serialize(value, write)
 				local v = rawget(value, len + 1) -- use rawget to avoid metatables like the vector metatable
 				if v == nil then break end
 				if first then first = false else write(",") end
-				dump(v)
+				-- Write nil to preserve array indices if element is userdata.
+				if not allowed_type(v) then
+					write("nil")
+				else
+					dump(v)
+				end
 				len = len + 1
 			end
 			-- Now write map keys ([key] = value)
 			for k, v in next, value do
 				-- We have written all non-float keys in [1, len] already
 				if type(k) ~= "number" or k % 1 ~= 0 or k < 1 or k > len then
-					if first then first = false else write(",") end
-					if use_short_key(k) then
-						write(k)
-					else
-						write("[")
-						dump(k)
-						write("]")
+					-- Skip entire key if either key or value is userdata/thread.
+					if allowed_type(k, v) then
+						if first then first = false else write(",") end
+						if use_short_key(k) then
+							write(k)
+						else
+							write("[")
+							dump(k)
+							write("]")
+						end
+						write("=")
+						dump(v)
 					end
-					write("=")
-					dump(v)
 				end
 			end
 			write("}")
@@ -170,20 +197,22 @@ local function serialize(value, write)
 	-- Write the statements to fill circular tables
 	for table, ref in pairs(to_fill) do
 		for k, v in pairs(table) do
-			write("_[")
-			write(ref)
-			write("]")
-			if use_short_key(k) then
-				write(".")
-				write(k)
-			else
-				write("[")
-				dump(k)
+			if allowed_type(k, v) then
+				write("_[")
+				write(ref)
 				write("]")
+				if use_short_key(k) then
+					write(".")
+					write(k)
+				else
+					write("[")
+					dump(k)
+					write("]")
+				end
+				write("=")
+				dump(v)
+				write(";")
 			end
-			write("=")
-			dump(v)
-			write(";")
 		end
 	end
 	write("return ")
@@ -203,8 +232,10 @@ local function contains_function(value)
 			end
 			seen[val] = true
 			for k, v in pairs(val) do
-				if check(k) or check(v) then
-					return true
+				if allowed_type(k, v) then
+					if check(k) or check(v) then
+						return true
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

In extremely complex projects that handle userdata in tables, it becomes an absolute pain to nil userdata that references the player when you're trying to save the entire table to disk. This pr makes it simply ignore both userdata and thread types so the serializer doesn't explode.

- Goal of the PR
Make life easier for modders.
- How does the PR work?
Checks the types on serialization and ignores userdata and thread data (in case that ever gets used in the engine)
- Does it resolve any reported issue?
Not a clue.
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
No idea.
- If not a bug fix, why is this PR needed? What usecases does it solve?
It's a quality of life overhaul.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
Yes I have.

This PR is Ready for Review.

## How to test

Try to blow it up serializing userdata as keys or values in tables.