### PR TITLE
Update mod security's version of loadstring to tolerate nil second arg.

### DIFF
--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -1003,7 +1003,7 @@ int ScriptApiSecurity::sl_g_loadstring(lua_State *L)
 	const char *chunk_name = "=(load)";
 
 	luaL_checktype(L, 1, LUA_TSTRING);
-	if (!lua_isnone(L, 2)) {
+	if (!lua_isnoneornil(L, 2)) {
 		luaL_checktype(L, 2, LUA_TSTRING);
 		chunk_name = lua_tostring(L, 2);
 	}


### PR DESCRIPTION
When mod security is turned off, LuaJIT's stock loadstring function tolerates being called with nil as its second argument, but currently when mod security is enabled, it requires the second argument to be a string when it's passed.

Using `lua_isnoneornil` instead of `lua_isnone` fixes the problem by skipping setting `chunk_name` in this case and leaving the default value, consistently with the normal behavior.

The third argument is ignored, which is probably fine because `safeLoadString` will fail anyway when given bytecode.

## How to test

Call `loadstring("print(...)", nil)("hello from loadstring")` from a mod when security is enabled.