### PR TITLE
Lua API: Improve ItemStack handling

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2326,7 +2326,7 @@ The following items are predefined and have special properties.
     * It can be overridden to change those properties:
         * globally using `core.override_item`
         * per-player using the special `"hand"` inventory list
-    * It cannot be used as an ItemStack object, because `""` represents the empty stack.
+    * It cannot be used as an `ItemStack` object, because `""` represents the empty stack.
       Therefore, it can't be stored in an inventory.
 
 Amount and wear
@@ -2355,21 +2355,19 @@ Empty stacks (defined by name `""`) are always initialized with count = 0.
 
 ### Serialized
 
-This is called "stackstring" or "itemstring". It is a simple string with
-1-4 components:
+This is called "itemstring". It is a simple string with
+1-4 components separated by exactly one space character. Syntax:
+
+    <identifier>[ <amount>[ <wear>[ <metadata>]]]
 
 1. Full item identifier ("item name")
 2. Optional amount
 3. Optional wear value
 4. Optional item metadata
 
-Syntax:
-
-    <identifier> [<amount>[ <wear>[ <metadata>]]]
-
 Examples:
 
-* (no value, `nil` or `""`): empty stack
+* `""`: empty stack
 * `"default:apple"`: 1 apple
 * `"default:dirt 5"`: 5 dirt
 * `"default:pick_stone"`: a new stone pickaxe
@@ -2397,20 +2395,18 @@ item strings encoding color information in their metadata.
 
 ### Table format
 
-The field `name` is mandatory.
-
 Examples:
 
 5 dirt nodes:
 
 ```lua
-{name="default:dirt", count=5, wear=0, metadata=""}
+{name="default:dirt", count=5, wear=0, metadata={}}
 ```
 
 A wooden pick about 1/3 worn out:
 
 ```lua
-{name="default:pick_wood", count=1, wear=21323, metadata=""}
+{name="default:pick_wood", count=1, wear=21323, metadata={}}
 ```
 
 An apple:
@@ -2422,7 +2418,8 @@ An apple:
 ### `ItemStack` format
 
 A native C++ format with many helper methods. Useful for converting
-between formats. See the [Class Reference](#class-reference) section for details.
+between formats. See the [Class reference](#class-reference)
+-> [ItemStack](#itemstack) chapter for details.
 
 
 
@@ -8623,8 +8620,13 @@ This means that all callbacks will be called twice (once for each action).
 
 An `ItemStack` is a stack of items.
 
-It can be created via `ItemStack(x)`, where x is an `ItemStack`,
-an itemstring, a table or `nil`.
+* `ItemStack([x])`: returns an `ItemStack`
+    * `x`: (optional) Is one of the following:
+        * nil value: Empty stack
+        * string value: an "itemstring".
+        * table value: ItemStack [Table format](#table-format).
+            * The `name` field is mandatory.
+
 
 ### Methods
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -2351,6 +2351,8 @@ and `ItemStack`.
 When an item must be passed to a function, it can usually be in any of
 these formats.
 
+Empty stacks (defined by name `""`) are always initialized with count = 0.
+
 ### Serialized
 
 This is called "stackstring" or "itemstring". It is a simple string with
@@ -2367,6 +2369,7 @@ Syntax:
 
 Examples:
 
+* (no value, `nil` or `""`): empty stack
 * `"default:apple"`: 1 apple
 * `"default:dirt 5"`: 5 dirt
 * `"default:pick_stone"`: a new stone pickaxe
@@ -2393,6 +2396,8 @@ and `core.itemstring_with_color(item, colorstring)` may be used to create
 item strings encoding color information in their metadata.
 
 ### Table format
+
+The field `name` is mandatory.
 
 Examples:
 

--- a/games/devtest/mods/unittests/inventory.lua
+++ b/games/devtest/mods/unittests/inventory.lua
@@ -1,10 +1,18 @@
 local function test_itemstack_ctor()
+	-- Valid uses (no warning must be shown)
 	assert(ItemStack(""):is_known() == true)
+	assert(ItemStack("air"):get_count() == 1)
+	assert(ItemStack("air 10"):get_count() == 10)
+	assert(ItemStack("air 10 1234"):get_wear() == 1234)
+	assert(ItemStack({name = "foo bar baz"}):get_name() == "foo bar baz")
+
+	core.log("warning", "--- ItemStack warnings mandatory after this line ---")
+
 	-- Should trigger a deprecation warning or error
 	assert(ItemStack("-- invalid!"):get_name() == "--")
 	assert(ItemStack("-- invalid!"):is_known() == false)
+	assert(ItemStack(" 3"):is_known() == true) -- empty item name but with count
 
-	assert(ItemStack({name = "-- foo bar"}):get_name() == "-- foo bar")
 	-- Should trigger a deprecation warning or error
 	assert(ItemStack({}):get_name() == "")
 end

--- a/games/devtest/mods/unittests/inventory.lua
+++ b/games/devtest/mods/unittests/inventory.lua
@@ -1,10 +1,11 @@
 local function test_itemstack_ctor()
+	-- See also: test_inventory.cpp -> testItemStack
 	-- Valid uses (no warning must be shown)
 	assert(ItemStack(""):is_known() == true)
 	assert(ItemStack("air"):get_count() == 1)
 	assert(ItemStack("air 10"):get_count() == 10)
 	assert(ItemStack("air 10 1234"):get_wear() == 1234)
-	assert(ItemStack({name = "foo bar baz"}):get_name() == "foo bar baz")
+	assert(ItemStack({name = "foobar"}):get_name() == "foobar")
 
 	core.log("warning", "--- ItemStack warnings mandatory after this line ---")
 
@@ -12,6 +13,7 @@ local function test_itemstack_ctor()
 	assert(ItemStack("-- invalid!"):get_name() == "--")
 	assert(ItemStack("-- invalid!"):is_known() == false)
 	assert(ItemStack(" 3"):is_known() == true) -- empty item name but with count
+	assert(ItemStack({name = "foo bar"}):get_name() == "foo bar")
 
 	-- Should trigger a deprecation warning or error
 	assert(ItemStack({}):get_name() == "")

--- a/games/devtest/mods/unittests/inventory.lua
+++ b/games/devtest/mods/unittests/inventory.lua
@@ -1,3 +1,18 @@
+local function test_itemstack_ctor()
+	assert(ItemStack(""):is_known() == true)
+	-- Should trigger a deprecation warning or error
+	assert(ItemStack("-- invalid!"):get_name() == "--")
+	assert(ItemStack("-- invalid!"):is_known() == false)
+
+	assert(ItemStack({name = "-- foo bar"}):get_name() == "-- foo bar")
+	-- Should trigger a deprecation warning or error
+	assert(ItemStack({}):get_name() == "")
+end
+
+unittests.register("test_itemstack_ctor", test_itemstack_ctor)
+
+
+
 local function get_stack_with_meta(count)
 	return ItemStack({name = "air", count = count, meta = {test = "abc"}})
 end

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -181,6 +181,13 @@ void ItemStack::deSerialize(std::istream &is, IItemDefManager *itemdef)
 		{
 			// The real thing
 
+			if (name.empty() && !is.eof()) {
+				warningstream << "Empty name passed to ItemStack."
+					<< " In a future engine version, this will result in an error." << std::endl;
+				// TODO: enable this in 5.19.0
+				//throw SerializationError("Invalid stack size");
+			}
+
 			// Apply item aliases
 			if (itemdef)
 				name = itemdef->getAlias(name);

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -182,10 +182,10 @@ void ItemStack::deSerialize(std::istream &is, IItemDefManager *itemdef)
 			// The real thing
 
 			if (name.empty() && !is.eof()) {
-				warningstream << "Empty name passed to ItemStack."
+				warningstream << "Empty name with trailing characters passed to ItemStack."
 					<< " In a future engine version, this will result in an error." << std::endl;
 				// TODO: enable this in 5.19.0
-				//throw SerializationError("Invalid stack size");
+				//throw SerializationError("Empty stack name");
 			}
 
 			// Apply item aliases
@@ -207,12 +207,17 @@ void ItemStack::deSerialize(std::istream &is, IItemDefManager *itemdef)
 
 				if (endp && *endp == '\0') {
 					count = val;
+					if ((long)count != val) {
+						warningstream << "Out-of bounds stack count '" << count_str << "' (name='"
+							<< name << "')." << std::endl;
+					}
 				} else {
 					// Read failed. Do not clear the stack.
 					count = 1;
 
-					warningstream << "Failed to parse stack size '" << count_str
-						<< "'. In a future engine version, this will result in an error." << std::endl;
+					warningstream << "Failed to parse stack size '" << count_str << "' (name='"
+						<< name << "'). In a future engine version, this will result in an error."
+						<< std::endl;
 					// TODO: enable this in 5.19.0
 					//throw SerializationError("Invalid stack size");
 				}

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -193,7 +193,23 @@ void ItemStack::deSerialize(std::istream &is, IItemDefManager *itemdef)
 				break;
 			}
 
-			count = stoi(count_str);
+			// Read size (count)
+			{
+				char *endp = nullptr;
+				long val = strtol(count_str.c_str(), &endp, 10);
+
+				if (endp && *endp == '\0') {
+					count = val;
+				} else {
+					// Read failed. Do not clear the stack.
+					count = 1;
+
+					warningstream << "Failed to parse stack size '" << count_str
+						<< "'. In a future engine version, this will result in an error." << std::endl;
+					// TODO: enable this in 5.19.0
+					//throw SerializationError("Invalid stack size");
+				}
+			}
 
 			// Read the wear
 			std::string wear_str;

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1513,7 +1513,11 @@ ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
 	else if(lua_istable(L, index))
 	{
 		// Convert from table
-		std::string name = getstringfield_default(L, index, "name", "");
+		std::string name;
+		if (!getstringfield(L, index, "name", name)) {
+			log_deprecated(L, "ItemStack({ ... }) constructed without a 'name' field. "
+				"In a future engine version, this will result in an error.");
+		}
 		int count = getintfield_default(L, index, "count", 1);
 		int wear = getintfield_default(L, index, "wear", 0);
 

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -1518,6 +1518,10 @@ ItemStack read_item(lua_State* L, int index, IItemDefManager *idef)
 			log_deprecated(L, "ItemStack({ ... }) constructed without a 'name' field. "
 				"In a future engine version, this will result in an error.");
 		}
+		if (name.find_first_of(' ') != std::string::npos) {
+			log_deprecated(L, "ItemStack({ ... }) constructed with 'name' containing space characters. "
+				"In a future engine version, this will result in an error.");
+		}
 		int count = getintfield_default(L, index, "count", 1);
 		int wear = getintfield_default(L, index, "wear", 0);
 

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -50,7 +50,7 @@ void TestInventory::testItemStack(IItemDefManager *idef)
 		UASSERT(stack.count == 1);
 		UASSERT(stack.wear == 0);
 
-		// Surplus spaces are NOT ignored.
+		// Surplus spaces are NOT ignored. Count defaults to 1. "10" goes nowhere.
 		is = std::istringstream("foo:bar_baz   10", std::ios::binary);
 		stack.deSerialize(is, idef);
 

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -85,8 +85,8 @@ void TestInventory::testItemStack(IItemDefManager *idef)
 		std::istringstream is("foo:negative -6 -4321", std::ios::binary);
 		stack.deSerialize(is, idef);
 
-		UASSERT(stack.count == UINT16_MAX -    6 + 1);
-		UASSERT(stack.wear  == UINT16_MAX - 4321 + 1);
+		UASSERTEQ(s32, stack.count, UINT16_MAX -    6 + 1);
+		UASSERTEQ(s32, stack.wear,  UINT16_MAX - 4321 + 1);
 
 		// Unsigned overflow
 		is = std::istringstream("foo:overflow 65537 65538", std::ios::binary);

--- a/src/unittest/test_inventory.cpp
+++ b/src/unittest/test_inventory.cpp
@@ -8,6 +8,7 @@
 
 #include "gamedef.h"
 #include "inventory.h"
+#include "itemdef.h"
 
 class TestInventory : public TestBase {
 public:
@@ -16,6 +17,7 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
+	void testItemStack(IItemDefManager *idef);
 	void testSerializeDeserialize(IItemDefManager *idef);
 
 	static const char *serialized_inventory_in;
@@ -27,10 +29,73 @@ static TestInventory g_test_instance;
 
 void TestInventory::runTests(IGameDef *gamedef)
 {
+	TEST(testItemStack, gamedef->getItemDefManager());
 	TEST(testSerializeDeserialize, gamedef->getItemDefManager());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TestInventory::testItemStack(IItemDefManager *idef)
+{
+	auto *widef = dynamic_cast<IWritableItemDefManager *>(idef);
+	UASSERT(widef);
+
+	// Craftitem / Node
+	{
+		ItemStack stack;
+		std::istringstream is("foo:bar_baz", std::ios::binary);
+		stack.deSerialize(is, idef);
+
+		UASSERT(stack.name == "foo:bar_baz");
+		UASSERT(stack.count == 1);
+		UASSERT(stack.wear == 0);
+
+		// Surplus spaces are NOT ignored.
+		is = std::istringstream("foo:bar_baz   10", std::ios::binary);
+		stack.deSerialize(is, idef);
+
+		UASSERT(stack.name == "foo:bar_baz");
+		UASSERT(stack.count == 1);
+		UASSERT(stack.wear == 0);
+
+	}
+
+	// Tool
+	{
+		ItemDefinition def;
+		def.name = "foo:bar_tool";
+		def.type = ItemType::ITEM_TOOL;
+		widef->registerItem(def);
+
+		ItemStack stack;
+		std::istringstream is("foo:bar_tool 10 4321", std::ios::binary);
+		stack.deSerialize(is, idef);
+
+		UASSERT(stack.name == "foo:bar_tool");
+		UASSERT(stack.count == 1); // tools cannot stack
+		UASSERT(stack.wear == 4321);
+
+		widef->unregisterItem(def.name);
+	}
+
+	// Obscurities
+	{
+		// Unsigned underflow
+		ItemStack stack;
+		std::istringstream is("foo:negative -6 -4321", std::ios::binary);
+		stack.deSerialize(is, idef);
+
+		UASSERT(stack.count == UINT16_MAX -    6 + 1);
+		UASSERT(stack.wear  == UINT16_MAX - 4321 + 1);
+
+		// Unsigned overflow
+		is = std::istringstream("foo:overflow 65537 65538", std::ios::binary);
+		stack.deSerialize(is, idef);
+
+		UASSERT(stack.count == 1);
+		UASSERT(stack.wear == 2);
+	}
+}
 
 void TestInventory::testSerializeDeserialize(IItemDefManager *idef)
 {


### PR DESCRIPTION
This helps modders to catch incorrect creation of 'ItemStack' objects by raising warnings.

Fixes #17353

## To do

This PR is Ready for Review.

## How to test

1. Run the devtest unittests
