### PR TITLE
[no sq] Fix more vulnerabilities in mesh loaders

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -419,6 +419,7 @@ to check whether a model is a valid glTF file.
 
 Many glTF features are not supported *yet*, including:
 
+* Primitive modes other than `TRIANGLES`
 * Animations
   * `CUBICSPLINE` interpolation is not supported
   * Morph animations

--- a/irr/include/IReadFile.h
+++ b/irr/include/IReadFile.h
@@ -37,6 +37,17 @@ public:
 	/** \return Current position in the file in bytes on success or -1L on failure. */
 	virtual long getPos() const = 0;
 
+	/// Get the number of remaining bytes.
+	/// @return number of remaining bytes or -1 on failure
+	long getRemainingBytes() const
+	{
+		const auto pos = getPos();
+		const auto size = getSize();
+		if (pos < 0 || pos > size)
+			return -1;
+		return size - pos;
+	}
+
 	//! Get name of file.
 	/** \return File name as zero terminated character string. */
 	virtual const io::path &getFileName() const = 0;

--- a/irr/src/CB3DMeshFileLoader.cpp
+++ b/irr/src/CB3DMeshFileLoader.cpp
@@ -10,6 +10,7 @@
 
 #include "IVideoDriver.h"
 #include "IFileSystem.h"
+#include "SB3DStructs.h"
 #include "SkinnedMesh.h"
 #include "SSkinMeshBuffer.h"
 #include "coreutil.h"
@@ -61,6 +62,23 @@ IAnimatedMesh *CB3DMeshFileLoader::createMesh(io::IReadFile *file)
 	return std::move(AnimatedMesh).finalize();
 }
 
+static constexpr int HEADER_BYTES = 8; // 4 + 4 bytes type + size
+
+std::optional<SB3dChunkHeader> CB3DMeshFileLoader::readChunkHeader(size_t sizelim)
+{
+	SB3dChunkHeader header;
+	B3DFile->read(&header.name, sizeof(header.name));
+	B3DFile->read(&header.size, sizeof(header.size));
+#ifdef __BIG_ENDIAN__
+	header.size = os::Byteswap::byteswap(header.size);
+#endif
+	if (header.size < 0 || (size_t)header.size + HEADER_BYTES > sizelim) {
+		os::Printer::log("Invalid chunk size", B3DFile->getFileName(), ELL_ERROR);
+		return std::nullopt;
+	}
+	return header;
+}
+
 bool CB3DMeshFileLoader::load()
 {
 	B3dStack.clear();
@@ -68,21 +86,17 @@ bool CB3DMeshFileLoader::load()
 	NormalsInFile = false;
 	HasVertexColors = false;
 
-	//------ Get header ------
+	const auto header = readChunkHeader(B3DFile->getRemainingBytes());
+	if (!header)
+		return false;
 
-	SB3dChunkHeader header;
-	B3DFile->read(&header, sizeof(header));
-#ifdef __BIG_ENDIAN__
-	header.size = os::Byteswap::byteswap(header.size);
-#endif
-
-	if (strncmp(header.name, "BB3D", 4) != 0) {
+	if (strncmp(header->name, "BB3D", 4) != 0) {
 		os::Printer::log("File is not a b3d file. Loading failed (No header found)", B3DFile->getFileName(), ELL_ERROR);
 		return false;
 	}
 
 	// Add main chunk...
-	B3dStack.push_back(SB3dChunk(header, B3DFile->getPos() - 8));
+	B3dStack.push_back(SB3dChunk(*header, B3DFile->getPos() - HEADER_BYTES));
 
 	// Get file version, but ignore it, as it's not important with b3d files...
 	s32 fileVersion;
@@ -93,12 +107,11 @@ bool CB3DMeshFileLoader::load()
 
 	//------ Read main chunk ------
 
-	while ((B3dStack.getLast().startposition + B3dStack.getLast().length) > B3DFile->getPos()) {
-		B3DFile->read(&header, sizeof(header));
-#ifdef __BIG_ENDIAN__
-		header.size = os::Byteswap::byteswap(header.size);
-#endif
-		B3dStack.push_back(SB3dChunk(header, B3DFile->getPos() - 8));
+	while (const auto remaining_bytes = getRemainingBytesInChunk()) {
+		const auto header = readChunkHeader(remaining_bytes);
+		if (!header)
+			return false;
+		B3dStack.push_back(SB3dChunk(*header, B3DFile->getPos() - HEADER_BYTES));
 
 		if (strncmp(B3dStack.getLast().name, "TEXS", 4) == 0) {
 			if (!readChunkTEXS())
@@ -162,15 +175,11 @@ bool CB3DMeshFileLoader::readChunkNODE(SkinnedMesh::SJoint *inJoint)
 	else
 		joint->GlobalMatrix = transform.buildMatrix();
 
-	while (B3dStack.getLast().startposition + B3dStack.getLast().length > B3DFile->getPos()) // this chunk repeats
-	{
-		SB3dChunkHeader header;
-		B3DFile->read(&header, sizeof(header));
-#ifdef __BIG_ENDIAN__
-		header.size = os::Byteswap::byteswap(header.size);
-#endif
-
-		B3dStack.push_back(SB3dChunk(header, B3DFile->getPos() - 8));
+	while (const auto remaining_bytes = getRemainingBytesInChunk()) {
+		const auto header = readChunkHeader(remaining_bytes);
+		if (!header)
+			return false;
+		B3dStack.push_back(SB3dChunk(*header, B3DFile->getPos() - HEADER_BYTES));
 
 		if (strncmp(B3dStack.getLast().name, "NODE", 4) == 0) {
 			if (!readChunkNODE(joint))
@@ -220,15 +229,11 @@ bool CB3DMeshFileLoader::readChunkMESH(SkinnedMesh::SJoint *inJoint)
 	NormalsInFile = false;
 	HasVertexColors = false;
 
-	while ((B3dStack.getLast().startposition + B3dStack.getLast().length) > B3DFile->getPos()) // this chunk repeats
-	{
-		SB3dChunkHeader header;
-		B3DFile->read(&header, sizeof(header));
-#ifdef __BIG_ENDIAN__
-		header.size = os::Byteswap::byteswap(header.size);
-#endif
-
-		B3dStack.push_back(SB3dChunk(header, B3DFile->getPos() - 8));
+	while (const auto remaining_bytes = getRemainingBytesInChunk()) {
+		const auto header = readChunkHeader(remaining_bytes);
+		if (!header)
+			return false;
+		B3dStack.push_back(SB3dChunk(*header, B3DFile->getPos() - HEADER_BYTES));
 
 		if (strncmp(B3dStack.getLast().name, "VRTS", 4) == 0) {
 			if (!readChunkVRTS(inJoint))
@@ -513,8 +518,8 @@ bool CB3DMeshFileLoader::readChunkBONE(SkinnedMesh::SJoint *inJoint)
 	os::Printer::log(logStr.c_str(), ELL_DEBUG);
 #endif
 
-	if (B3dStack.getLast().length > 8) {
-		while ((B3dStack.getLast().startposition + B3dStack.getLast().length) > B3DFile->getPos()) // this chunk repeats
+	if (B3dStack.getLast().length > HEADER_BYTES) {
+		while (getRemainingBytesInChunk() > 0) // this chunk repeats
 		{
 			u32 globalVertexID;
 			f32 strength;

--- a/irr/src/CB3DMeshFileLoader.cpp
+++ b/irr/src/CB3DMeshFileLoader.cpp
@@ -263,7 +263,6 @@ bool CB3DMeshFileLoader::readChunkMESH(SkinnedMesh::SJoint *inJoint)
 
 				for (i = 0; i < (s32)meshBuffer->getVertexCount(); ++i) {
 					meshBuffer->getVertex(i)->Normal.normalize();
-					BaseVertices[VerticesStart + i].Normal = meshBuffer->getVertex(i)->Normal;
 				}
 			}
 		} else {
@@ -445,7 +444,7 @@ bool CB3DMeshFileLoader::readChunkTRIS(scene::SSkinMeshBuffer *meshBuffer, u32 m
 		vertex_id[2] += vertices_Start;
 
 		for (s32 i = 0; i < 3; ++i) {
-			if ((u32)vertex_id[i] >= AnimatedVertices_VertexID.size()) {
+			if (vertex_id[i] < vertices_Start || (u32)vertex_id[i] >= AnimatedVertices_VertexID.size()) {
 				os::Printer::log("Illegal vertex index found", B3DFile->getFileName(), ELL_ERROR);
 				return false;
 			}

--- a/irr/src/CB3DMeshFileLoader.cpp
+++ b/irr/src/CB3DMeshFileLoader.cpp
@@ -482,17 +482,10 @@ bool CB3DMeshFileLoader::readChunkTRIS(scene::SSkinMeshBuffer *meshBuffer, u32 m
 						Vertex->Color.setAlpha((s32)(B3dMaterial->alpha * 255.0f));
 
 					// Use texture's scale
-					if (B3dMaterial->Textures[0]) {
-						Vertex->TCoords.X *= B3dMaterial->Textures[0]->Xscale;
-						Vertex->TCoords.Y *= B3dMaterial->Textures[0]->Yscale;
+					if (const auto tex_id = B3dMaterial->texture_ids[0]) {
+						Vertex->TCoords.X *= Textures[*tex_id].Xscale;
+						Vertex->TCoords.Y *= Textures[*tex_id].Yscale;
 					}
-					/*
-					if (B3dMaterial->Textures[1])
-					{
-						Vertex->TCoords2.X *=B3dMaterial->Textures[1]->Xscale;
-						Vertex->TCoords2.Y *=B3dMaterial->Textures[1]->Yscale;
-					}
-					*/
 				}
 			}
 		}
@@ -738,14 +731,14 @@ bool CB3DMeshFileLoader::readChunkBRUS()
 			texture_id = os::Byteswap::byteswap(texture_id);
 #endif
 			//--- Get pointers to the texture, based on the IDs ---
-			if ((u32)texture_id < Textures.size()) {
-				B3dMaterial.Textures[i] = &Textures[texture_id];
+			if (texture_id >= 0 && (u16)texture_id < Textures.size()) {
+				B3dMaterial.texture_ids[i] = (u16) texture_id;
 #ifdef _B3D_READER_DEBUG
 				os::Printer::log("Layer", core::stringc(i).c_str(), ELL_DEBUG);
 				os::Printer::log("using texture", Textures[texture_id].TextureName.c_str(), ELL_DEBUG);
 #endif
 			} else
-				B3dMaterial.Textures[i] = 0;
+				B3dMaterial.texture_ids[i].reset();
 		}
 		// skip other texture ids
 		for (i = 0; i < n_texs_offset; ++i) {
@@ -761,21 +754,21 @@ bool CB3DMeshFileLoader::readChunkBRUS()
 		}
 
 		// Fixes problems when the lightmap is on the first texture:
-		if (B3dMaterial.Textures[0] != 0) {
-			if (B3dMaterial.Textures[0]->Flags & 65536) { // 65536 = secondary UV
-				SB3dTexture *TmpTexture;
-				TmpTexture = B3dMaterial.Textures[1];
-				B3dMaterial.Textures[1] = B3dMaterial.Textures[0];
-				B3dMaterial.Textures[0] = TmpTexture;
+		if (const auto tex_id = B3dMaterial.texture_ids[0]) {
+			const auto &texture = Textures[*tex_id];
+			if (texture.Flags & 65536) { // 65536 = secondary UV
+				std::swap(B3dMaterial.texture_ids[0], B3dMaterial.texture_ids[1]);
 			}
 		}
 
 		// If a preceeding texture slot is empty move the others down:
 		for (i = num_textures; i > 0; --i) {
 			for (u32 j = i - 1; j < num_textures - 1; ++j) {
-				if (B3dMaterial.Textures[j + 1] != 0 && B3dMaterial.Textures[j] == 0) {
-					B3dMaterial.Textures[j] = B3dMaterial.Textures[j + 1];
-					B3dMaterial.Textures[j + 1] = 0;
+				auto &cur = B3dMaterial.texture_ids[j];
+				auto &next = B3dMaterial.texture_ids[j + 1];
+				if (!cur.has_value() && next.has_value()) {
+					cur = next;
+					next.reset();
 				}
 			}
 		}
@@ -783,15 +776,16 @@ bool CB3DMeshFileLoader::readChunkBRUS()
 		//------ Convert blitz flags/blend to irrlicht -------
 
 		// Two textures:
-		if (B3dMaterial.Textures[1]) {
+		if (B3dMaterial.texture_ids[1].has_value()) {
 			B3dMaterial.Material.MaterialType = video::EMT_TRANSPARENT_VERTEX_ALPHA;
 			B3dMaterial.Material.ZWriteEnable = video::EZW_OFF;
-		} else if (B3dMaterial.Textures[0]) { // One texture:
+		} else if (const auto tex_id = B3dMaterial.texture_ids[0]) { // One texture:
+			const auto &texture = Textures[*tex_id];
 			// Flags & 0x1 is usual SOLID, 0x8 is mipmap (handled before)
-			if (B3dMaterial.Textures[0]->Flags & 0x2) { // (Alpha mapped)
+			if (texture.Flags & 0x2) { // (Alpha mapped)
 				B3dMaterial.Material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL;
 				B3dMaterial.Material.ZWriteEnable = video::EZW_OFF;
-			} else if (B3dMaterial.Textures[0]->Flags & 0x4)                                  //(Masked)
+			} else if (texture.Flags & 0x4) // (Masked)
 				B3dMaterial.Material.MaterialType = video::EMT_TRANSPARENT_ALPHA_CHANNEL_REF; // TODO: create color key texture
 			else if (B3dMaterial.alpha == 1.f)
 				B3dMaterial.Material.MaterialType = video::EMT_SOLID;

--- a/irr/src/CB3DMeshFileLoader.h
+++ b/irr/src/CB3DMeshFileLoader.h
@@ -37,6 +37,7 @@ public:
 
 private:
 	bool load();
+	std::optional<SB3dChunkHeader> readChunkHeader(size_t sizelim);
 	bool readChunkNODE(SkinnedMesh::SJoint *InJoint);
 	bool readChunkMESH(SkinnedMesh::SJoint *InJoint);
 	bool readChunkVRTS(SkinnedMesh::SJoint *InJoint);
@@ -49,6 +50,12 @@ private:
 
 	std::string readString();
 	void readFloats(f32 *vec, u32 count);
+
+	size_t getRemainingBytesInChunk() const
+	{
+		return std::max<long>(0, B3dStack.getLast().startposition +
+				B3dStack.getLast().length - B3DFile->getPos());
+	}
 
 	core::array<SB3dChunk> B3dStack;
 

--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -29,7 +29,6 @@
 #include <numeric>
 #include <optional>
 #include <stdexcept>
-#include <tuple>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -86,14 +85,12 @@ template <class T>
 SelfType::Accessor<T>
 SelfType::Accessor<T>::sparseIndices(const tiniergltf::GlTF &model,
 		const tiniergltf::AccessorSparseIndices &indices,
-		const std::size_t count)
+		const std::size_t count,
+		const std::size_t byteStride)
 {
 	const auto &view = model.bufferViews->at(indices.bufferView);
-	const auto byteStride = view.byteStride.value_or(indices.elementSize());
-
 	const auto &buffer = model.buffers->at(view.buffer);
 	const auto source = buffer.data.data() + view.byteOffset + indices.byteOffset;
-
 	return SelfType::Accessor<T>(source, byteStride, count);
 }
 
@@ -102,14 +99,11 @@ SelfType::Accessor<T>
 SelfType::Accessor<T>::sparseValues(const tiniergltf::GlTF &model,
 		const tiniergltf::AccessorSparseValues &values,
 		const std::size_t count,
-		const std::size_t defaultByteStride)
+		const std::size_t byteStride)
 {
 	const auto &view = model.bufferViews->at(values.bufferView);
-	const auto byteStride = view.byteStride.value_or(defaultByteStride);
-
 	const auto &buffer = model.buffers->at(view.buffer);
 	const auto source = buffer.data.data() + view.byteOffset + values.byteOffset;
-
 	return SelfType::Accessor<T>(source, byteStride, count);
 }
 
@@ -151,20 +145,17 @@ SelfType::Accessor<T>::make(const tiniergltf::GlTF &model, std::size_t accessorI
 		const auto indicesAccessor = ([&]() -> AccessorVariant<u8, u16, u32> {
 			switch (accessor.sparse->indices.componentType) {
 			case tiniergltf::AccessorSparseIndices::ComponentType::UNSIGNED_BYTE:
-				return Accessor<u8>::sparseIndices(model, accessor.sparse->indices, overriddenCount);
+				return Accessor<u8>::sparseIndices(model, accessor.sparse->indices, overriddenCount, sizeof(u8));
 			case tiniergltf::AccessorSparseIndices::ComponentType::UNSIGNED_SHORT:
-				return Accessor<u16>::sparseIndices(model, accessor.sparse->indices, overriddenCount);
+				return Accessor<u16>::sparseIndices(model, accessor.sparse->indices, overriddenCount, sizeof(u16));
 			case tiniergltf::AccessorSparseIndices::ComponentType::UNSIGNED_INT:
-				return Accessor<u32>::sparseIndices(model, accessor.sparse->indices, overriddenCount);
+				return Accessor<u32>::sparseIndices(model, accessor.sparse->indices, overriddenCount, sizeof(u32));
 			}
 			throw std::logic_error("invalid enum value");
 		})();
 
 		const auto valuesAccessor = Accessor<T>::sparseValues(model,
-				accessor.sparse->values, overriddenCount,
-				accessor.bufferView.has_value()
-						? model.bufferViews->at(*accessor.bufferView).byteStride.value_or(accessor.elementSize())
-						: accessor.elementSize());
+				accessor.sparse->values, overriddenCount, accessor.elementSize());
 
 		for (std::size_t i = 0; i < overriddenCount; ++i) {
 			u32 index;
@@ -374,15 +365,13 @@ static void checkIndices(const std::vector<u16> &indices, const std::size_t nVer
 	}
 }
 
+// Generate descending indices nVerts - 1, ..., 0
 static std::vector<u16> generateIndices(const std::size_t nVerts)
 {
 	std::vector<u16> indices(nVerts);
-	for (std::size_t i = 0; i < nVerts; i += 3) {
-		// Reverse winding order per triangle
-		indices[i] = i + 2;
-		indices[i + 1] = i + 1;
-		indices[i + 2] = i;
-	}
+	std::iota(indices.begin(), indices.end(), 0);
+	// Reverses winding order (and "triangle order", but that doesn't matter)
+	std::reverse(indices.begin(), indices.end());
 	return indices;
 }
 
@@ -415,6 +404,14 @@ void SelfType::MeshExtractor::addPrimitive(
 	if (n_vertices >= std::numeric_limits<u16>::max())
 		throw std::runtime_error("too many vertices");
 
+	if (primitive.mode != tiniergltf::MeshPrimitive::Mode::TRIANGLES) {
+		// TODO support other primitive modes. Requires changes outside of this loader:
+		// recalculateNormals() and many other mesh helpers are written
+		// with an implicit assumption that mesh buffers only store triangles.
+		warn("ignoring primitive using a mode other than TRIANGLES");
+		return;
+	}
+
 	auto maybeIndices = getIndices(primitive);
 	std::vector<u16> indices;
 	if (maybeIndices.has_value()) {
@@ -424,6 +421,8 @@ void SelfType::MeshExtractor::addPrimitive(
 		// Non-indexed geometry
 		indices = generateIndices(vertices->size());
 	}
+	if (indices.size() % 3 != 0)
+		throw std::runtime_error("index count for triangles not divisible by 3");
 
 	auto *meshbuf = new SSkinMeshBuffer(std::move(*vertices), std::move(indices));
 	const auto meshbufNr = m_irr_model.addMeshBuffer(meshbuf);

--- a/irr/src/CGLTFMeshFileLoader.cpp
+++ b/irr/src/CGLTFMeshFileLoader.cpp
@@ -433,7 +433,7 @@ void SelfType::MeshExtractor::addPrimitive(
 			const auto &texture = material.pbrMetallicRoughness->baseColorTexture;
 			if (texture.has_value()) {
 				m_irr_model.setTextureSlot(meshbufNr, static_cast<u32>(texture->index));
-				const auto samplerIdx = m_gltf_model.textures->at(texture->index).sampler;
+				const auto samplerIdx = m_gltf_model.textures.value().at(texture->index).sampler;
 				if (samplerIdx.has_value()) {
 					auto &sampler = m_gltf_model.samplers->at(*samplerIdx);
 					auto &layer = meshbuf->getMaterial().TextureLayers[0];

--- a/irr/src/CGLTFMeshFileLoader.h
+++ b/irr/src/CGLTFMeshFileLoader.h
@@ -47,12 +47,13 @@ private:
 		static Accessor sparseIndices(
 				const tiniergltf::GlTF &model,
 				const tiniergltf::AccessorSparseIndices &indices,
-				const std::size_t count);
+				const std::size_t count,
+				const std::size_t byteStride);
 		static Accessor sparseValues(
 				const tiniergltf::GlTF &model,
 				const tiniergltf::AccessorSparseValues &values,
 				const std::size_t count,
-				const std::size_t defaultByteStride);
+				const std::size_t byteStride);
 		static Accessor base(
 				const tiniergltf::GlTF &model,
 				std::size_t accessorIdx);

--- a/irr/src/CXMeshFileLoader.cpp
+++ b/irr/src/CXMeshFileLoader.cpp
@@ -552,6 +552,10 @@ bool CXMeshFileLoader::parseDataObjectMesh(SXMesh &mesh)
 
 	// read faces
 	const u32 nFaces = readInt();
+	if (nFaces > (1U << 28 /* leave a couple bits of wiggle room */)) {
+		os::Printer::log("Too many faces", ELL_ERROR);
+		SET_ERR_AND_RETURN();
+	}
 
 	mesh.Indices.set_used(nFaces * 3);
 	mesh.IndexCountPerFace.set_used(nFaces);
@@ -572,7 +576,13 @@ bool CXMeshFileLoader::parseDataObjectMesh(SXMesh &mesh)
 			// read face indices
 			polygonfaces.set_used(fcnt);
 			u32 triangles = (fcnt - 2);
-			mesh.Indices.set_used(mesh.Indices.size() + ((triangles - 1) * 3));
+			// Compute in u64 to avoid overflows
+			u64 nIndices = mesh.Indices.size() + (u64)(triangles - 1) * 3;
+			if (nIndices > (1U << 28 /* leave a couple bits of wiggle room */)) {
+				os::Printer::log("Too many indices", ELL_ERROR);
+				SET_ERR_AND_RETURN();
+			}
+			mesh.Indices.set_used(nIndices);
 			mesh.IndexCountPerFace[k] = (u16)(triangles * 3);
 
 			for (u32 f = 0; f < fcnt; ++f)

--- a/irr/src/SB3DStructs.h
+++ b/irr/src/SB3DStructs.h
@@ -11,6 +11,10 @@
 #include "SMaterial.h"
 #include "irrMath.h"
 
+#include <optional>
+#include <string>
+#include <array>
+
 namespace scene
 {
 
@@ -54,15 +58,12 @@ struct SB3dMaterial
 			red(1.0f), green(1.0f),
 			blue(1.0f), alpha(1.0f), shininess(0.0f), blend(1),
 			fx(0)
-	{
-		for (u32 i = 0; i < video::MATERIAL_MAX_TEXTURES; ++i)
-			Textures[i] = 0;
-	}
+	{}
 	video::SMaterial Material;
 	f32 red, green, blue, alpha;
 	f32 shininess;
 	s32 blend, fx;
-	SB3dTexture *Textures[video::MATERIAL_MAX_TEXTURES];
+	std::array<std::optional<u16>, video::MATERIAL_MAX_TEXTURES> texture_ids;
 };
 
 } // end namespace scene

--- a/irr/src/SkinnedMesh.cpp
+++ b/irr/src/SkinnedMesh.cpp
@@ -407,6 +407,10 @@ void SkinnedMeshBuilder::topoSortJoints()
 
 	// Levelorder
 	for (u16 i = 0; i < n; ++i) {
+		if (new_to_old_id.size() <= i) {
+			// happens if and only if not all nodes are reachable from a root
+			throw std::runtime_error("joint hierarchy must be acyclic");
+		}
 		new_to_old_id.insert(new_to_old_id.end(),
 				children[new_to_old_id[i]].begin(),
 				children[new_to_old_id[i]].end());

--- a/lib/tiniergltf/tiniergltf.hpp
+++ b/lib/tiniergltf/tiniergltf.hpp
@@ -1404,10 +1404,21 @@ struct GlTF {
 		checkForall(animations, [&](const Animation &animation) {
 			for (const auto &sampler : animation.samplers) {
 				checkIndex(accessors, sampler.input);
-				const auto &accessor = accessors->at(sampler.input);
-				check(accessor.type == Accessor::Type::SCALAR);
-				check(accessor.componentType == Accessor::ComponentType::FLOAT);
+				const auto &in_acc = accessors->at(sampler.input);
+				check(in_acc.type == Accessor::Type::SCALAR);
+				check(in_acc.componentType == Accessor::ComponentType::FLOAT);
 				checkIndex(accessors, sampler.output);
+				const auto &out_acc = accessors->at(sampler.output);
+				switch (sampler.interpolation) {
+				case AnimationSampler::Interpolation::STEP:
+				case AnimationSampler::Interpolation::LINEAR:
+					check(in_acc.count == out_acc.count);
+					break;
+				case AnimationSampler::Interpolation::CUBICSPLINE:
+					check(in_acc.count >= 2);
+					check(out_acc.count == in_acc.count * 3);
+					break;
+				}
 			}
 			for (const auto &channel : animation.channels) {
 				checkIndex(nodes, channel.target.node);

--- a/lib/tiniergltf/tiniergltf.hpp
+++ b/lib/tiniergltf/tiniergltf.hpp
@@ -1296,7 +1296,7 @@ struct GlTF {
 
 		const auto checkAccessor = [&](const auto &accessor,
 				std::size_t bufferView, std::size_t byteOffset, std::size_t count) {
-			const BufferView &view = bufferViews->at(bufferView);
+			const BufferView &view = bufferViews.value().at(bufferView);
 			if (view.byteStride.has_value())
 				check(*view.byteStride % accessor.componentSize() == 0);
 

--- a/lib/tiniergltf/tiniergltf.hpp
+++ b/lib/tiniergltf/tiniergltf.hpp
@@ -1118,6 +1118,39 @@ static inline std::string uriError(const std::string &uri) {
 	throw std::runtime_error("unsupported URI: " + uri);
 }
 
+template<bool skinning_attrs, typename T>
+static size_t checkConsistentAttributeCounts(const T &attributes,
+		const std::optional<std::vector<Accessor>> &accessors)
+{
+	// All present attribute accessors must have the same count, which is the number of vertices.
+	std::optional<size_t> vertex_count;
+	const auto check_accessor_idx = [&](std::optional<size_t> accessor_idx) {
+		if (!accessor_idx.has_value())
+			return;
+		const auto count = accessors.value().at(*accessor_idx).count;
+		if (!vertex_count)
+			vertex_count = count;
+		else
+			check(*vertex_count == count);
+	};
+	check_accessor_idx(attributes.position);
+	check_accessor_idx(attributes.normal);
+	check_accessor_idx(attributes.tangent);
+	const auto check_accessor_idxs = [&](const auto &accessor_idxs) {
+		checkForall(accessor_idxs, [&](const std::size_t &i) {
+			check_accessor_idx(i);
+		});
+	};
+	check_accessor_idxs(attributes.texcoord);
+	check_accessor_idxs(attributes.color);
+	if constexpr (skinning_attrs) {
+		check_accessor_idxs(attributes.joints);
+		check_accessor_idxs(attributes.weights);
+	}
+	// At least one attribute must be specified
+	return vertex_count.value();
+}
+
 struct GlTF {
 	std::optional<std::vector<Accessor>> accessors;
 	std::optional<std::vector<Animation>> animations;
@@ -1279,8 +1312,10 @@ struct GlTF {
 				checkAccessor(accessor, *accessor.bufferView, accessor.byteOffset, accessor.count);
 			if (accessor.sparse.has_value()) {
 				const auto &indices = accessor.sparse->indices;
+				check(!bufferViews.value().at(indices.bufferView).byteStride.has_value());
 				checkAccessor(indices, indices.bufferView, indices.byteOffset, accessor.sparse->count);
 				const auto &values = accessor.sparse->values;
+				check(!bufferViews.value().at(values.bufferView).byteStride.has_value());
 				checkAccessor(accessor, values.bufferView, values.byteOffset, accessor.sparse->count);
 			}
 		});
@@ -1323,6 +1358,9 @@ struct GlTF {
 						check(material.occlusionTexture->texCoord < primitive.attributes.texcoord->size());
 					}
 				}
+
+				const size_t vertex_count = checkConsistentAttributeCounts<true>(primitive.attributes, accessors);
+
 				checkForall(primitive.targets, [&](const MeshPrimitive::MorphTargets &target) {
 					checkIndex(accessors, target.normal);
 					checkIndex(accessors, target.position);
@@ -1333,6 +1371,8 @@ struct GlTF {
 					checkForall(target.color, [&](const std::size_t &i) {
 						checkIndex(accessors, i);
 					});
+					const size_t target_vertex_count = checkConsistentAttributeCounts<false>(target, accessors);
+					check(vertex_count == target_vertex_count);
 				});
 			}
 		});


### PR DESCRIPTION
See the individual commits for details. I've deliberately tried to keep the fixes minimal so this is easy to review. The b3d reader could be refactored nicely but that's for another time.

Claude Fable / Opus were used to find the underlying vulnerabilities and to review my fixes. The vulnerabilities can probably be found easily using a range of LLMs with similar capabilities to Opus.

## How to test

- Observe code carefully
- :eye: some meshes
