### PR TITLE
Add dynamic lights

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -859,6 +859,10 @@ enable_translucent_foliage (Translucent foliage) bool false
 #   Requires: enable_waving_water, enable_dynamic_shadows
 enable_water_reflections (Liquid reflections) bool false
 
+#   Maximum number of dynamic point lights rendered at once.
+#   Higher values cost more to render. Hard-capped at 20.
+dynamic_lights_limit (Dynamic lights limit) int 8 0 20
+
 [*Audio]
 
 #    Volume of all sounds.

--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -860,8 +860,9 @@ enable_translucent_foliage (Translucent foliage) bool false
 enable_water_reflections (Liquid reflections) bool false
 
 #   Maximum number of dynamic point lights rendered at once.
-#   Higher values cost more to render. Hard-capped at 20.
-dynamic_lights_limit (Dynamic lights limit) int 8 0 20
+#   More lights result in lower FPS, and too many lights
+#   may exceed your GPU capabilities, especially on mobile
+dynamic_lights_limit (Dynamic lights limit) int 8 0 100
 
 [*Audio]
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -19,6 +19,15 @@ uniform float crackAnimationLength;
 uniform float crackLevel;
 uniform float crackTextureScale;
 
+// Must match MAX_DYNAMIC_LIGHTS in src/client/dynamiclight.h.
+#define MAX_DYNAMIC_LIGHTS 8
+// Client-side movable point lights, purely additive, unoccluded.
+// dynLightPos is already relative to cameraOffset, see worldPosition below.
+uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];
+uniform vec3 dynLightColor[MAX_DYNAMIC_LIGHTS];
+uniform float dynLightRadius[MAX_DYNAMIC_LIGHTS];
+uniform int dynLightCount;
+
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow texture
 	uniform sampler2D ShadowMapSampler;
@@ -425,6 +434,27 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 #endif
 #endif
 
+vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
+{
+	vec3 result = base_color;
+	for (int i = 0; i < dynLightCount; i++) {
+		float dist = length(worldPos - dynLightPos[i]);
+		float t = clamp(1.0 - (dist * dist) / (dynLightRadius[i] * dynLightRadius[i]), 0.0, 1.0);
+		float brighten = t * t;
+		// Tighter falloff than brighten - hue shift is only strong close to the light.
+		float colorize = brighten * brighten;
+
+		float luminance = dot(dynLightColor[i], vec3(0.299, 0.587, 0.114));
+		// Brighten toward white using luminance only, so the surface's own
+		// hue is preserved as a screen blend, scaled by remaining headroom.
+		result += (1.0 - result) * (luminance * brighten);
+		// Nudge hue toward the light's color, weighted down and only near it.
+		vec3 hue = dynLightColor[i] / max(luminance, 1e-4);
+		result = mix(result, result * hue, colorize * 0.35);
+	}
+	return clamp(result, 0.0, 1.0);
+}
+
 // maps [0, N] to [0, 1] like GL_REPEAT would
 vec2 uv_repeat(vec2 v)
 {
@@ -467,7 +497,10 @@ void main(void)
 		base = mix(base, crack, crack.a);
 	}
 
-	vec4 col = vec4(base.rgb * varColor.rgb, 1.0);
+	// Applied to the light term itself, before the texture multiply, so a
+	// fully dark node still shows its texture instead of flat black.
+	vec3 lit_color = applyDynamicLights(worldPosition, varColor.rgb);
+	vec4 col = vec4(base.rgb * lit_color, 1.0);
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// Fragment normal, can differ from vNormal which is derived from vertex normals.

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -19,8 +19,8 @@ uniform float crackAnimationLength;
 uniform float crackLevel;
 uniform float crackTextureScale;
 
-// Must match MAX_DYNAMIC_LIGHTS in src/client/dynamiclight.h.
-#define MAX_DYNAMIC_LIGHTS 20
+// MAX_DYNAMIC_LIGHTS is injected here by MainShaderConstantSetter::onGenerate()
+// in shader.cpp, derived from the dynamic_lights_limit setting.
 // Client-side movable point lights, purely additive, unoccluded.
 // dynLightPos is already relative to cameraOffset, see worldPosition below.
 uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];
@@ -438,6 +438,9 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
 {
 	vec3 result = base_color;
+	// Hue is accumulated and applied once after the loop so the result doesn't depend on light order.
+	vec3 hueAccum = vec3(0.0);
+	float colorizeAccum = 0.0;
 	for (int i = 0; i < dynLightCount; i++) {
 		float dist = length(worldPos - dynLightPos[i]);
 		float t = clamp(1.0 - (dist * dist) / (dynLightRadius[i] * dynLightRadius[i]), 0.0, 1.0);
@@ -451,7 +454,12 @@ vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
 		result += (1.0 - result) * (luminance * brighten);
 		// Nudge hue toward the light's color, weighted down and only near it.
 		vec3 hue = dynLightColor[i] / max(luminance, 1e-4);
-		result = mix(result, result * hue, colorize * 0.35);
+		hueAccum += hue * colorize;
+		colorizeAccum += colorize;
+	}
+	if (colorizeAccum > 0.0) {
+		vec3 avgHue = hueAccum / colorizeAccum;
+		result = mix(result, result * avgHue, min(colorizeAccum, 1.0) * 0.35);
 	}
 	return clamp(result, 0.0, 1.0);
 }

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -26,6 +26,7 @@ uniform float crackTextureScale;
 uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];
 uniform vec3 dynLightColor[MAX_DYNAMIC_LIGHTS];
 uniform float dynLightRadius[MAX_DYNAMIC_LIGHTS];
+uniform float dynLightFalloff[MAX_DYNAMIC_LIGHTS];
 uniform int dynLightCount;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS
@@ -440,7 +441,7 @@ vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
 	for (int i = 0; i < dynLightCount; i++) {
 		float dist = length(worldPos - dynLightPos[i]);
 		float t = clamp(1.0 - (dist * dist) / (dynLightRadius[i] * dynLightRadius[i]), 0.0, 1.0);
-		float brighten = t * t;
+		float brighten = pow(t, dynLightFalloff[i]);
 		// Tighter falloff than brighten - hue shift is only strong close to the light.
 		float colorize = brighten * brighten;
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -20,7 +20,7 @@ uniform float crackLevel;
 uniform float crackTextureScale;
 
 // Must match MAX_DYNAMIC_LIGHTS in src/client/dynamiclight.h.
-#define MAX_DYNAMIC_LIGHTS 8
+#define MAX_DYNAMIC_LIGHTS 20
 // Client-side movable point lights, purely additive, unoccluded.
 // dynLightPos is already relative to cameraOffset, see worldPosition below.
 uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -14,7 +14,7 @@ uniform highp vec3 cameraOffset;
 uniform float animationTimer;
 
 // Must match MAX_DYNAMIC_LIGHTS in src/client/dynamiclight.h.
-#define MAX_DYNAMIC_LIGHTS 8
+#define MAX_DYNAMIC_LIGHTS 20
 // Client-side movable point lights, purely additive, unoccluded.
 // dynLightPos is already relative to cameraOffset, see worldPosition below.
 uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -12,6 +12,15 @@ uniform float fogShadingParameter;
 // The cameraOffset is the current center of the visible world.
 uniform highp vec3 cameraOffset;
 uniform float animationTimer;
+
+// Must match MAX_DYNAMIC_LIGHTS in src/client/dynamiclight.h.
+#define MAX_DYNAMIC_LIGHTS 8
+// Client-side movable point lights, purely additive, unoccluded.
+// dynLightPos is already relative to cameraOffset, see worldPosition below.
+uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];
+uniform vec3 dynLightColor[MAX_DYNAMIC_LIGHTS];
+uniform float dynLightRadius[MAX_DYNAMIC_LIGHTS];
+uniform int dynLightCount;
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow texture
 	uniform sampler2D ShadowMapSampler;
@@ -365,6 +374,27 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 #endif
 
 
+vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
+{
+	vec3 result = base_color;
+	for (int i = 0; i < dynLightCount; i++) {
+		float dist = length(worldPos - dynLightPos[i]);
+		float t = clamp(1.0 - (dist * dist) / (dynLightRadius[i] * dynLightRadius[i]), 0.0, 1.0);
+		float brighten = t * t;
+		// Tighter falloff than brighten - hue shift is only strong close to the light.
+		float colorize = brighten * brighten;
+
+		float luminance = dot(dynLightColor[i], vec3(0.299, 0.587, 0.114));
+		// Brighten toward white using luminance only, so the surface's own
+		// hue is preserved as a screen blend, scaled by remaining headroom.
+		result += (1.0 - result) * (luminance * brighten);
+		// Nudge hue toward the light's color, weighted down and only near it.
+		vec3 hue = dynLightColor[i] / max(luminance, 1e-4);
+		result = mix(result, result * hue, colorize * 0.35);
+	}
+	return clamp(result, 0.0, 1.0);
+}
+
 void main(void)
 {
 	vec2 uv = varTexCoord.st;
@@ -385,7 +415,10 @@ void main(void)
 		discard;
 #endif
 
-	vec4 col = vec4(base.rgb * varColor.rgb, 1.0);
+	// Applied to the light term itself, before the texture multiply, so a
+	// fully dark object still shows its texture instead of flat black.
+	vec3 lit_color = applyDynamicLights(worldPosition, varColor.rgb);
+	vec4 col = vec4(base.rgb * lit_color, 1.0);
 	col.rgb *= vIDiff;
 
 #ifdef ENABLE_DYNAMIC_SHADOWS

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -13,8 +13,8 @@ uniform float fogShadingParameter;
 uniform highp vec3 cameraOffset;
 uniform float animationTimer;
 
-// Must match MAX_DYNAMIC_LIGHTS in src/client/dynamiclight.h.
-#define MAX_DYNAMIC_LIGHTS 20
+// MAX_DYNAMIC_LIGHTS is injected here by MainShaderConstantSetter::onGenerate()
+// in shader.cpp, derived from the dynamic_lights_limit setting.
 // Client-side movable point lights, purely additive, unoccluded.
 // dynLightPos is already relative to cameraOffset, see worldPosition below.
 uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];
@@ -378,6 +378,9 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
 {
 	vec3 result = base_color;
+	// Hue is accumulated and applied once after the loop so the result doesn't depend on light order.
+	vec3 hueAccum = vec3(0.0);
+	float colorizeAccum = 0.0;
 	for (int i = 0; i < dynLightCount; i++) {
 		float dist = length(worldPos - dynLightPos[i]);
 		float t = clamp(1.0 - (dist * dist) / (dynLightRadius[i] * dynLightRadius[i]), 0.0, 1.0);
@@ -391,7 +394,12 @@ vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
 		result += (1.0 - result) * (luminance * brighten);
 		// Nudge hue toward the light's color, weighted down and only near it.
 		vec3 hue = dynLightColor[i] / max(luminance, 1e-4);
-		result = mix(result, result * hue, colorize * 0.35);
+		hueAccum += hue * colorize;
+		colorizeAccum += colorize;
+	}
+	if (colorizeAccum > 0.0) {
+		vec3 avgHue = hueAccum / colorizeAccum;
+		result = mix(result, result * avgHue, min(colorizeAccum, 1.0) * 0.35);
 	}
 	return clamp(result, 0.0, 1.0);
 }

--- a/client/shaders/object_shader/opengl_fragment.glsl
+++ b/client/shaders/object_shader/opengl_fragment.glsl
@@ -20,6 +20,7 @@ uniform float animationTimer;
 uniform vec3 dynLightPos[MAX_DYNAMIC_LIGHTS];
 uniform vec3 dynLightColor[MAX_DYNAMIC_LIGHTS];
 uniform float dynLightRadius[MAX_DYNAMIC_LIGHTS];
+uniform float dynLightFalloff[MAX_DYNAMIC_LIGHTS];
 uniform int dynLightCount;
 #ifdef ENABLE_DYNAMIC_SHADOWS
 	// shadow texture
@@ -380,7 +381,7 @@ vec3 applyDynamicLights(vec3 worldPos, vec3 base_color)
 	for (int i = 0; i < dynLightCount; i++) {
 		float dist = length(worldPos - dynLightPos[i]);
 		float t = clamp(1.0 - (dist * dist) / (dynLightRadius[i] * dynLightRadius[i]), 0.0, 1.0);
-		float brighten = t * t;
+		float brighten = pow(t, dynLightFalloff[i]);
 		// Tighter falloff than brighten - hue shift is only strong close to the light.
 		float colorize = brighten * brighten;
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -7000,7 +7000,7 @@ Environment access
     * A free light is not removed when whatever spawned it goes away.
       An attached one will remove it self after a few seconds though.
       To get best results, store a light's `get_guid()` and look it up again later via
-      `core.objects_by_guid`, or use 
+      `core.objects_by_guid`, or use
       `core.get_objects_in_area` / `core.get_objects_inside_radius`
 * `core.get_player_by_name(name)`: Get an `ObjectRef` to a player
     * Returns nothing in case of error (player offline, doesn't exist, ...).

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -6981,6 +6981,27 @@ Environment access
 * `core.add_item(pos, item)`: Spawn item
     * Returns `ObjectRef`, or `nil` if failed
     * Items can be added also to unloaded and non-generated blocks.
+* `core.add_light(def)`: Create a persistent client-rendered dynamic point light
+    * Returns `ObjectRef`, or `nil` if failed
+    * `def` is a table with the following fields:
+        * `pos`: initial position, required unless `object` is given
+        * `object`: optional `ObjectRef` to follow. If given, the light
+          tracks that object's position instead of `pos`, and keeps
+          following it across reload.
+          If the object is not found after a few seconds of trying,
+          the light removes itself.
+        * `color`: `ColorSpec` (default: white)
+        * `range`: radius in nodes the light reaches before fully fading out
+          (default: 8)
+        * `falloff`: exponent shaping how quickly the light dims with
+          distance - higher stays bright longer before dropping off
+          (default: 2)
+    * A light is tied to the map block containing its position.
+    * A free light is not removed when whatever spawned it goes away.
+      An attached one will remove it self after a few seconds though.
+      To get best results, store a light's `get_guid()` and look it up again later via
+      `core.objects_by_guid`, or use 
+      `core.get_objects_in_area` / `core.get_objects_inside_radius`
 * `core.get_player_by_name(name)`: Get an `ObjectRef` to a player
     * Returns nothing in case of error (player offline, doesn't exist, ...).
 * `core.get_objects_inside_radius(center, radius)`
@@ -9209,6 +9230,23 @@ You **must not** mix names and track numbers to refer to the same animation.
 * `get_entity_name()`:
     * **Deprecated**: Will be removed in a future version,
       use `:get_luaentity().name` instead.
+
+#### Light only (no-op for other objects)
+
+Objects created via `core.add_light`. Lights have no callbacks and no
+persistent Lua table (`self`) - they only carry the small set of synced
+properties below, same as any other active object.
+
+* `get_light_state()`: returns `{pos = vector}` or `{object = ObjectRef}`,
+  in the same format as `def` in `core.add_light`.
+* `set_light_state(state)`: takes `{pos = vector}` to detach and move to a
+  free-floating position, or `{object = ObjectRef}` to attach/re-attach.
+* `get_light_properties()`: returns a table with `color`, `range`
+  and `falloff`.
+    * Named `get_light_properties`, not `get_properties`, to avoid colliding
+      with the generic `ObjectRef:get_properties()` for `ObjectProperties`,
+      which is a no-op for lights.
+* `set_light_properties(props)`: updates one or more of the properties above.
 
 #### Player only (no-op for other objects)
 

--- a/src/activeobject.h
+++ b/src/activeobject.h
@@ -23,6 +23,7 @@ enum ActiveObjectType {
 // ACTIVEOBJECT_TYPE_MOBV2 = 6,
 // End obsolete stuff
 	ACTIVEOBJECT_TYPE_LUAENTITY = 7,
+	ACTIVEOBJECT_TYPE_LIGHT = 8,
 // Special type, not stored as a static object
 	ACTIVEOBJECT_TYPE_PLAYER = 100,
 // Special type, only exists as CAO

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -61,6 +61,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/inputhandler.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/item_visuals_manager.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/keycode.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/light_cao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/localplayer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mapblock_mesh.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mesh.cpp

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -49,6 +49,7 @@ set(client_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/content_cao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/content_cso.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/content_mapblock.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/dynamiclight.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/filecache.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/fontengine.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/game.cpp

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -153,6 +153,7 @@ Client::Client(
 		tsrc, this
 	),
 	m_particle_manager(std::make_unique<ParticleManager>(&m_env)),
+	m_dynamic_light_manager(std::make_unique<DynamicLightManager>()),
 	m_allow_login_or_register(allow_login_or_register),
 	m_server_ser_ver(SER_FMT_VER_INVALID),
 	m_last_chat_message_sent(time(NULL)),
@@ -2060,6 +2061,11 @@ MtEventManager* Client::getEventManager()
 ParticleManager* Client::getParticleManager()
 {
 	return m_particle_manager.get();
+}
+
+DynamicLightManager* Client::getDynamicLightManager()
+{
+	return m_dynamic_light_manager.get();
 }
 
 scene::IAnimatedMesh *Client::getMesh(const std::string &filename, bool *is_shared)

--- a/src/client/client.h
+++ b/src/client/client.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "clientenvironment.h"
+#include "dynamiclight.h"
 #include "gamedef.h"
 #include "gameparams.h" // ELoginRegister
 #include "inventorymanager.h"
@@ -376,7 +377,7 @@ public:
 	virtual ISoundManager* getSoundManager();
 	MtEventManager* getEventManager();
 	virtual ParticleManager* getParticleManager();
-
+	DynamicLightManager* getDynamicLightManager();
 	bool checkLocalPrivilege(const std::string &priv)
 	{ return checkPrivilege(priv); }
 
@@ -508,6 +509,7 @@ private:
 	std::unique_ptr<MeshUpdateManager> m_mesh_update_manager;
 	ClientEnvironment m_env;
 	std::unique_ptr<ParticleManager> m_particle_manager;
+	std::unique_ptr<DynamicLightManager> m_dynamic_light_manager;
 	std::unique_ptr<con::IConnection> m_con;
 	std::string m_address_name;
 	ELoginRegister m_allow_login_or_register = ELoginRegister::Any;

--- a/src/client/clientobject.cpp
+++ b/src/client/clientobject.cpp
@@ -22,12 +22,19 @@ ClientActiveObject::~ClientActiveObject()
 	removeFromScene(true);
 }
 
+std::unordered_map<u16, ClientActiveObject::Factory> &ClientActiveObject::getTypes()
+{
+	static std::unordered_map<u16, Factory> types;
+	return types;
+}
+
 std::unique_ptr<ClientActiveObject> ClientActiveObject::create(ActiveObjectType type,
 		Client *client, ClientEnvironment *env)
 {
 	// Find factory function
-	auto n = m_types.find(type);
-	if (n == m_types.end()) {
+	auto &types = getTypes();
+	auto n = types.find(type);
+	if (n == types.end()) {
 		// If factory is not found, just return.
 		warningstream << "ClientActiveObject: No factory for type="
 				<< (int)type << std::endl;
@@ -41,10 +48,11 @@ std::unique_ptr<ClientActiveObject> ClientActiveObject::create(ActiveObjectType 
 
 void ClientActiveObject::registerType(u16 type, Factory f)
 {
-	auto n = m_types.find(type);
-	if (n != m_types.end())
+	auto &types = getTypes();
+	auto n = types.find(type);
+	if (n != types.end())
 		return;
-	m_types[type] = f;
+	types[type] = f;
 }
 
 

--- a/src/client/clientobject.h
+++ b/src/client/clientobject.h
@@ -82,8 +82,8 @@ protected:
 	Client *m_client;
 	ClientEnvironment *m_env;
 private:
-	// Used for creating objects based on type
-	static std::unordered_map<u16, Factory> m_types;
+	// Construct-on-first-use, to avoid depending on static init order across translation units
+	static std::unordered_map<u16, Factory> &getTypes();
 };
 
 class DistanceSortedActiveObject

--- a/src/client/content_cao.cpp
+++ b/src/client/content_cao.cpp
@@ -47,8 +47,6 @@
 
 struct ToolCapabilities;
 
-std::unordered_map<u16, ClientActiveObject::Factory> ClientActiveObject::m_types;
-
 template<typename T>
 void SmoothTranslator<T>::init(T current)
 {

--- a/src/client/dynamiclight.cpp
+++ b/src/client/dynamiclight.cpp
@@ -1,0 +1,43 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "dynamiclight.h"
+#include "camera.h"
+#include <algorithm>
+
+void DynamicLightManager::addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color)
+{
+	DynamicLight &light = m_lights[id];
+	light.id = id;
+	light.pos = pos;
+	light.radius = radius;
+	light.color = color;
+}
+
+void DynamicLightManager::remove(u32 id)
+{
+	m_lights.erase(id);
+}
+
+void DynamicLightManager::cull(const Camera &camera)
+{
+	m_visible_lights.clear();
+
+	auto is_culled = camera.getFrustumCuller();
+	for (const auto &it : m_lights) {
+		const DynamicLight &light = it.second;
+		if (!is_culled(light.pos, light.radius))
+			m_visible_lights.push_back(light);
+	}
+
+	if (m_visible_lights.size() > MAX_DYNAMIC_LIGHTS) {
+		v3f cam_pos = camera.getPosition();
+		std::nth_element(m_visible_lights.begin(),
+				m_visible_lights.begin() + MAX_DYNAMIC_LIGHTS,
+				m_visible_lights.end(),
+				[&cam_pos](const DynamicLight &a, const DynamicLight &b) {
+					return a.pos.getDistanceFromSQ(cam_pos) < b.pos.getDistanceFromSQ(cam_pos);
+				});
+		m_visible_lights.resize(MAX_DYNAMIC_LIGHTS);
+	}
+}

--- a/src/client/dynamiclight.cpp
+++ b/src/client/dynamiclight.cpp
@@ -1,5 +1,6 @@
 // Luanti
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 Zenon Seth <Zenon.Seth@gmail.com>
 
 #include "dynamiclight.h"
 #include "camera.h"

--- a/src/client/dynamiclight.cpp
+++ b/src/client/dynamiclight.cpp
@@ -5,13 +5,14 @@
 #include "camera.h"
 #include <algorithm>
 
-void DynamicLightManager::addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color)
+void DynamicLightManager::addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color, float falloff)
 {
 	DynamicLight &light = m_lights[id];
 	light.id = id;
 	light.pos = pos;
 	light.radius = radius;
 	light.color = color;
+	light.falloff = falloff;
 }
 
 void DynamicLightManager::remove(u32 id)

--- a/src/client/dynamiclight.cpp
+++ b/src/client/dynamiclight.cpp
@@ -22,6 +22,21 @@ void DynamicLightManager::remove(u32 id)
 	m_lights.erase(id);
 }
 
+size_t getDynamicLightsLimitSetting()
+{
+	return std::clamp<size_t>(g_settings->getU16("dynamic_lights_limit"),
+			0, DYNAMIC_LIGHTS_CEILING);
+}
+
+size_t DynamicLightManager::getEffectiveLimit()
+{
+	if (!m_limit_resolved) {
+		m_limit = getDynamicLightsLimitSetting();
+		m_limit_resolved = true;
+	}
+	return m_limit;
+}
+
 void DynamicLightManager::cull(const Camera &camera)
 {
 	m_visible_lights.clear();
@@ -33,8 +48,7 @@ void DynamicLightManager::cull(const Camera &camera)
 			m_visible_lights.push_back(light);
 	}
 
-	size_t limit = std::min<size_t>(MAX_DYNAMIC_LIGHTS,
-			g_settings->getU16("dynamic_lights_limit"));
+	size_t limit = getEffectiveLimit();
 	if (m_visible_lights.size() > limit) {
 		v3f cam_pos = camera.getPosition();
 		std::nth_element(m_visible_lights.begin(),

--- a/src/client/dynamiclight.cpp
+++ b/src/client/dynamiclight.cpp
@@ -3,6 +3,7 @@
 
 #include "dynamiclight.h"
 #include "camera.h"
+#include "settings.h"
 #include <algorithm>
 
 void DynamicLightManager::addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color, float falloff)
@@ -31,14 +32,16 @@ void DynamicLightManager::cull(const Camera &camera)
 			m_visible_lights.push_back(light);
 	}
 
-	if (m_visible_lights.size() > MAX_DYNAMIC_LIGHTS) {
+	size_t limit = std::min<size_t>(MAX_DYNAMIC_LIGHTS,
+			g_settings->getU16("dynamic_lights_limit"));
+	if (m_visible_lights.size() > limit) {
 		v3f cam_pos = camera.getPosition();
 		std::nth_element(m_visible_lights.begin(),
-				m_visible_lights.begin() + MAX_DYNAMIC_LIGHTS,
+				m_visible_lights.begin() + limit,
 				m_visible_lights.end(),
 				[&cam_pos](const DynamicLight &a, const DynamicLight &b) {
 					return a.pos.getDistanceFromSQ(cam_pos) < b.pos.getDistanceFromSQ(cam_pos);
 				});
-		m_visible_lights.resize(MAX_DYNAMIC_LIGHTS);
+		m_visible_lights.resize(limit);
 	}
 }

--- a/src/client/dynamiclight.h
+++ b/src/client/dynamiclight.h
@@ -11,10 +11,11 @@
 
 class Camera;
 
-// Must match MAX_DYNAMIC_LIGHTS in nodes_shader/object_shader opengl_fragment.glsl.
-// This is a hard ceiling on the array size. The actual number of lights
-// rendered is further capped at runtime by the dynamic_lights_limit setting.
-constexpr size_t MAX_DYNAMIC_LIGHTS = 20;
+// Sanity ceiling on dynamic_lights_limit, shared by shader.cpp and cull() below.
+constexpr size_t DYNAMIC_LIGHTS_CEILING = 100;
+
+// dynamic_lights_limit clamped to [0, DYNAMIC_LIGHTS_CEILING], shared with shader.cpp.
+size_t getDynamicLightsLimitSetting();
 
 struct DynamicLight
 {
@@ -35,12 +36,17 @@ public:
 	void remove(u32 id);
 
 	// Selects the nearest lights intersecting the frustum out of the full pool,
-	// up to the dynamic_lights_limit setting.
+	// up to the effective limit, see getEffectiveLimit().
 	void cull(const Camera &camera);
 
 	const std::vector<DynamicLight> &getVisibleLights() const { return m_visible_lights; }
 
 private:
+	// Snapshotted once so it matches the shader array size
+	size_t getEffectiveLimit();
+
 	std::unordered_map<u32, DynamicLight> m_lights;
 	std::vector<DynamicLight> m_visible_lights;
+	size_t m_limit = 0;
+	bool m_limit_resolved = false;
 };

--- a/src/client/dynamiclight.h
+++ b/src/client/dynamiclight.h
@@ -1,5 +1,6 @@
 // Luanti
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 Zenon Seth <Zenon.Seth@gmail.com>
 
 #pragma once
 

--- a/src/client/dynamiclight.h
+++ b/src/client/dynamiclight.h
@@ -19,13 +19,16 @@ struct DynamicLight
 	v3f pos;
 	float radius = 0.0f;
 	video::SColorf color;
+	// Exponent shaping the radial falloff curve, brighten = t^falloff.
+	// Higher values keep the light near-full-strength longer before dropping off.
+	float falloff = 2.0f;
 };
 
 // Client-side, purely additive point lights on top of the real baked lighting
 class DynamicLightManager
 {
 public:
-	void addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color);
+	void addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color, float falloff = 2.0f);
 	void remove(u32 id);
 
 	// Selects the nearest MAX_DYNAMIC_LIGHTS lights intersecting the frustum out of the full pool

--- a/src/client/dynamiclight.h
+++ b/src/client/dynamiclight.h
@@ -1,0 +1,39 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "irrlichttypes_bloated.h"
+#include <SColor.h>
+#include <unordered_map>
+#include <vector>
+
+class Camera;
+
+// Must match MAX_DYNAMIC_LIGHTS in nodes_shader/object_shader opengl_fragment.glsl.
+constexpr size_t MAX_DYNAMIC_LIGHTS = 8;
+
+struct DynamicLight
+{
+	u32 id = 0;
+	v3f pos;
+	float radius = 0.0f;
+	video::SColorf color;
+};
+
+// Client-side, purely additive point lights on top of the real baked lighting
+class DynamicLightManager
+{
+public:
+	void addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color);
+	void remove(u32 id);
+
+	// Selects the nearest MAX_DYNAMIC_LIGHTS lights intersecting the frustum out of the full pool
+	void cull(const Camera &camera);
+
+	const std::vector<DynamicLight> &getVisibleLights() const { return m_visible_lights; }
+
+private:
+	std::unordered_map<u32, DynamicLight> m_lights;
+	std::vector<DynamicLight> m_visible_lights;
+};

--- a/src/client/dynamiclight.h
+++ b/src/client/dynamiclight.h
@@ -11,7 +11,9 @@
 class Camera;
 
 // Must match MAX_DYNAMIC_LIGHTS in nodes_shader/object_shader opengl_fragment.glsl.
-constexpr size_t MAX_DYNAMIC_LIGHTS = 8;
+// This is a hard ceiling on the array size. The actual number of lights
+// rendered is further capped at runtime by the dynamic_lights_limit setting.
+constexpr size_t MAX_DYNAMIC_LIGHTS = 20;
 
 struct DynamicLight
 {
@@ -31,7 +33,8 @@ public:
 	void addOrUpdate(u32 id, v3f pos, float radius, video::SColorf color, float falloff = 2.0f);
 	void remove(u32 id);
 
-	// Selects the nearest MAX_DYNAMIC_LIGHTS lights intersecting the frustum out of the full pool
+	// Selects the nearest lights intersecting the frustum out of the full pool,
+	// up to the dynamic_lights_limit setting.
 	void cull(const Camera &camera);
 
 	const std::vector<DynamicLight> &getVisibleLights() const { return m_visible_lights; }

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -305,6 +305,65 @@ public:
 	}
 };
 
+class DynamicLightUniformSetter : public IShaderUniformSetter
+{
+	Client *m_client;
+
+	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS * 3> m_positions{"dynLightPos"};
+	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS * 3> m_colors{"dynLightColor"};
+	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS> m_radii{"dynLightRadius"};
+	CachedPixelShaderSetting<s32> m_count{"dynLightCount"};
+
+public:
+	DynamicLightUniformSetter(Client *client) :
+		m_client(client)
+	{}
+
+	void onSetUniforms(video::IMaterialRendererServices *services) override
+	{
+		v3f cam_offset = intToFloat(m_client->getCamera()->getOffset(), BS);
+
+		float positions[MAX_DYNAMIC_LIGHTS * 3] = {};
+		float colors[MAX_DYNAMIC_LIGHTS * 3] = {};
+		float radii[MAX_DYNAMIC_LIGHTS] = {};
+		s32 count = 0;
+
+		for (const DynamicLight &light : m_client->getDynamicLightManager()->getVisibleLights()) {
+			v3f rel_pos = light.pos - cam_offset;
+			positions[count * 3 + 0] = rel_pos.X;
+			positions[count * 3 + 1] = rel_pos.Y;
+			positions[count * 3 + 2] = rel_pos.Z;
+			colors[count * 3 + 0] = light.color.r;
+			colors[count * 3 + 1] = light.color.g;
+			colors[count * 3 + 2] = light.color.b;
+			radii[count] = light.radius;
+			count++;
+		}
+
+		m_positions.set(positions, services);
+		m_colors.set(colors, services);
+		m_radii.set(radii, services);
+		m_count.set(&count, services);
+	}
+};
+
+class DynamicLightUniformSetterFactory : public IShaderUniformSetterFactory
+{
+	Game *m_game;
+
+public:
+	DynamicLightUniformSetterFactory(Game *game) :
+		m_game(game)
+	{}
+
+	virtual IShaderUniformSetter *create(const std::string &name)
+	{
+		if (str_starts_with(name, "shadow/"))
+			return nullptr;
+		return new DynamicLightUniformSetter(m_game->getClient());
+	}
+};
+
 class NodeShaderConstantSetter : public IShaderConstantSetter
 {
 public:
@@ -874,6 +933,9 @@ bool Game::createClient(const GameStartData &start_data)
 
 	shader_src->addShaderUniformSetterFactory(
 		std::make_unique<FogShaderUniformSetterFactory>());
+
+	shader_src->addShaderUniformSetterFactory(
+		std::make_unique<DynamicLightUniformSetterFactory>(this));
 
 	ShadowRenderer::preInit(shader_src);
 
@@ -3473,6 +3535,17 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 		Update particles
 	*/
 	client->getParticleManager()->step(dtime);
+
+	/*
+		Update dynamic lights
+	*/
+	// TEMPORARY test hack: a light that follows the player, to validate
+	// the dynamic-light shader path before LightSAO/LightCAO exist.
+	// Remove once there's a real way to spawn one.
+	client->getDynamicLightManager()->addOrUpdate(
+			1, player->getPosition() + v3f(0.0f, BS, 0.0f),
+			8.0f * BS, video::SColorf(1.0f, 0.6f, 0.2f));
+	client->getDynamicLightManager()->cull(*camera);
 
 	/*
 		Damage camera tilt

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -312,6 +312,7 @@ class DynamicLightUniformSetter : public IShaderUniformSetter
 	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS * 3> m_positions{"dynLightPos"};
 	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS * 3> m_colors{"dynLightColor"};
 	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS> m_radii{"dynLightRadius"};
+	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS> m_falloffs{"dynLightFalloff"};
 	CachedPixelShaderSetting<s32> m_count{"dynLightCount"};
 
 public:
@@ -326,6 +327,7 @@ public:
 		float positions[MAX_DYNAMIC_LIGHTS * 3] = {};
 		float colors[MAX_DYNAMIC_LIGHTS * 3] = {};
 		float radii[MAX_DYNAMIC_LIGHTS] = {};
+		float falloffs[MAX_DYNAMIC_LIGHTS] = {};
 		s32 count = 0;
 
 		for (const DynamicLight &light : m_client->getDynamicLightManager()->getVisibleLights()) {
@@ -337,12 +339,14 @@ public:
 			colors[count * 3 + 1] = light.color.g;
 			colors[count * 3 + 2] = light.color.b;
 			radii[count] = light.radius;
+			falloffs[count] = light.falloff;
 			count++;
 		}
 
 		m_positions.set(positions, services);
 		m_colors.set(colors, services);
 		m_radii.set(radii, services);
+		m_falloffs.set(falloffs, services);
 		m_count.set(&count, services);
 	}
 };
@@ -3544,7 +3548,7 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	// Remove once there's a real way to spawn one.
 	client->getDynamicLightManager()->addOrUpdate(
 			1, player->getPosition() + v3f(0.0f, BS, 0.0f),
-			8.0f * BS, video::SColorf(1.0f, 0.6f, 0.2f));
+			8.0f * BS, video::SColorf(1.0f, 0.6f, 0.2f), 2.0f);
 	client->getDynamicLightManager()->cull(*camera);
 
 	/*

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3543,12 +3543,6 @@ void Game::updateFrame(ProfilerGraph *graph, RunStats *stats, f32 dtime,
 	/*
 		Update dynamic lights
 	*/
-	// TEMPORARY test hack: a light that follows the player, to validate
-	// the dynamic-light shader path before LightSAO/LightCAO exist.
-	// Remove once there's a real way to spawn one.
-	client->getDynamicLightManager()->addOrUpdate(
-			1, player->getPosition() + v3f(0.0f, BS, 0.0f),
-			8.0f * BS, video::SColorf(1.0f, 0.6f, 0.2f), 2.0f);
 	client->getDynamicLightManager()->cull(*camera);
 
 	/*

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -309,11 +309,22 @@ class DynamicLightUniformSetter : public IShaderUniformSetter
 {
 	Client *m_client;
 
-	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS * 3> m_positions{"dynLightPos"};
-	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS * 3> m_colors{"dynLightColor"};
-	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS> m_radii{"dynLightRadius"};
-	CachedPixelShaderSetting<float, MAX_DYNAMIC_LIGHTS> m_falloffs{"dynLightFalloff"};
+	// Sent at runtime size via setPixelShaderConstant, with change-detection against m_last_* below.
+	std::vector<float> m_last_positions;
+	std::vector<float> m_last_colors;
+	std::vector<float> m_last_radii;
+	std::vector<float> m_last_falloffs;
 	CachedPixelShaderSetting<s32> m_count{"dynLightCount"};
+
+	static void sendIfChanged(video::IMaterialRendererServices *services, const char *name,
+			std::vector<float> &last, std::vector<float> &&next)
+	{
+		if (next == last)
+			return;
+		services->setPixelShaderConstant(
+				services->getPixelShaderConstantID(name), next.data(), (int)next.size());
+		last = std::move(next);
+	}
 
 public:
 	DynamicLightUniformSetter(Client *client) :
@@ -324,29 +335,34 @@ public:
 	{
 		v3f cam_offset = intToFloat(m_client->getCamera()->getOffset(), BS);
 
-		float positions[MAX_DYNAMIC_LIGHTS * 3] = {};
-		float colors[MAX_DYNAMIC_LIGHTS * 3] = {};
-		float radii[MAX_DYNAMIC_LIGHTS] = {};
-		float falloffs[MAX_DYNAMIC_LIGHTS] = {};
-		s32 count = 0;
+		const auto &lights = m_client->getDynamicLightManager()->getVisibleLights();
+		s32 count = (s32)lights.size();
 
-		for (const DynamicLight &light : m_client->getDynamicLightManager()->getVisibleLights()) {
+		std::vector<float> positions(count * 3);
+		std::vector<float> colors(count * 3);
+		std::vector<float> radii(count);
+		std::vector<float> falloffs(count);
+
+		for (s32 i = 0; i < count; i++) {
+			const DynamicLight &light = lights[i];
 			v3f rel_pos = light.pos - cam_offset;
-			positions[count * 3 + 0] = rel_pos.X;
-			positions[count * 3 + 1] = rel_pos.Y;
-			positions[count * 3 + 2] = rel_pos.Z;
-			colors[count * 3 + 0] = light.color.r;
-			colors[count * 3 + 1] = light.color.g;
-			colors[count * 3 + 2] = light.color.b;
-			radii[count] = light.radius;
-			falloffs[count] = light.falloff;
-			count++;
+			positions[i * 3 + 0] = rel_pos.X;
+			positions[i * 3 + 1] = rel_pos.Y;
+			positions[i * 3 + 2] = rel_pos.Z;
+			colors[i * 3 + 0] = light.color.r;
+			colors[i * 3 + 1] = light.color.g;
+			colors[i * 3 + 2] = light.color.b;
+			radii[i] = light.radius;
+			falloffs[i] = light.falloff;
 		}
 
-		m_positions.set(positions, services);
-		m_colors.set(colors, services);
-		m_radii.set(radii, services);
-		m_falloffs.set(falloffs, services);
+		if (count > 0) {
+			sendIfChanged(services, "dynLightPos", m_last_positions, std::move(positions));
+			sendIfChanged(services, "dynLightColor", m_last_colors, std::move(colors));
+			sendIfChanged(services, "dynLightRadius", m_last_radii, std::move(radii));
+			sendIfChanged(services, "dynLightFalloff", m_last_falloffs, std::move(falloffs));
+		}
+
 		m_count.set(&count, services);
 	}
 };

--- a/src/client/light_cao.cpp
+++ b/src/client/light_cao.cpp
@@ -1,0 +1,115 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 Zenon Seth <Zenon.Seth@gmail.com>
+
+#include "light_cao.h"
+#include "client.h"
+#include "client/clientenvironment.h"
+#include "client/dynamiclight.h"
+#include "constants.h"
+#include "util/serialize.h"
+#include <sstream>
+
+LightCAO::LightCAO(Client *client, ClientEnvironment *env) :
+		ClientActiveObject(0, client, env)
+{
+	// Runs during global static initialization for the file-scope
+	// proto_LightCAO below, where client is nullptr
+	if (!client)
+		ClientActiveObject::registerType(getType(), create);
+}
+
+LightCAO::~LightCAO()
+{
+	removeFromScene(true);
+}
+
+std::unique_ptr<ClientActiveObject> LightCAO::create(Client *client, ClientEnvironment *env)
+{
+	return std::make_unique<LightCAO>(client, env);
+}
+
+void LightCAO::removeFromScene(bool permanent)
+{
+	if (!m_registered)
+		return;
+	m_client->getDynamicLightManager()->remove(getId());
+	m_registered = false;
+}
+
+void LightCAO::step(float dtime, ClientEnvironment *env)
+{
+	// Re-read every frame: while attached, the target CAO's own position is
+	// updated/interpolated elsewhere, so this is what keeps us following it
+	// smoothly instead of only moving on the throttled server resends.
+	if (m_registered)
+		updateManager();
+}
+
+void LightCAO::initialize(const std::string &data)
+{
+	std::istringstream is(data, std::ios::binary);
+	u8 version = readU8(is);
+	if (version != 1)
+		return;
+	deserializeState(is);
+	deserializeProperties(is);
+	updateManager();
+}
+
+void LightCAO::processMessage(const std::string &data)
+{
+	std::istringstream is(data, std::ios::binary);
+	auto cmd = (LightCommand)readU8(is);
+	switch (cmd) {
+	case LightCommand::LIGHT_CMD_SET_STATE:
+		deserializeState(is);
+		break;
+	case LightCommand::LIGHT_CMD_SET_PROPERTIES:
+		deserializeProperties(is);
+		break;
+	default:
+		return;
+	}
+	updateManager();
+}
+
+void LightCAO::deserializeState(std::istream &is)
+{
+	bool attached = readU8(is);
+	if (attached) {
+		m_attached_id = readU16(is);
+	} else {
+		m_attached_id = 0;
+		m_pos = readV3F32(is);
+	}
+}
+
+void LightCAO::deserializeProperties(std::istream &is)
+{
+	m_properties.color = readARGB8(is);
+	m_properties.range = readF32(is);
+	m_properties.falloff = readF32(is);
+}
+
+void LightCAO::updateManager()
+{
+	if (m_attached_id != 0) {
+		if (ClientActiveObject *target = m_env->getActiveObject(m_attached_id)) {
+			m_pos = target->getPosition();
+			m_have_pos = true;
+		}
+	} else {
+		m_have_pos = true;
+	}
+
+	if (!m_have_pos)
+		return;
+
+	m_registered = true;
+	m_client->getDynamicLightManager()->addOrUpdate(getId(), m_pos, m_properties.range,
+			video::SColorf(m_properties.color), m_properties.falloff);
+}
+
+// Prototype: registers ACTIVEOBJECT_TYPE_LIGHT's factory at static-init time.
+static LightCAO proto_LightCAO(nullptr, nullptr);

--- a/src/client/light_cao.h
+++ b/src/client/light_cao.h
@@ -1,0 +1,59 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 Zenon Seth <Zenon.Seth@gmail.com>
+
+#pragma once
+
+#include "client/clientobject.h"
+#include "constants.h"
+#include "light_common.h"
+#include <SColor.h>
+
+/*
+	Client-side counterpart of LightSAO (src/server/light_sao.h).
+	Has no scene node - its only job is to register/update/remove itself in
+	the client's DynamicLightManager, keyed by its own object id. When
+	attached, the server only tells us which object id to follow once; we
+	then read that object's own already smoothly-interpolated CAO position
+	every step, rather than have the server resend positions continuously.
+*/
+class LightCAO : public ClientActiveObject
+{
+public:
+	LightCAO(Client *client, ClientEnvironment *env);
+	~LightCAO() override;
+
+	ActiveObjectType getType() const override { return ACTIVEOBJECT_TYPE_LIGHT; }
+	static std::unique_ptr<ClientActiveObject> create(Client *client, ClientEnvironment *env);
+
+	void addToScene(ITextureSource *tsrc, scene::ISceneManager *smgr) override {}
+	void removeFromScene(bool permanent) override;
+	void initialize(const std::string &data) override;
+	void processMessage(const std::string &data) override;
+
+	void step(float dtime, ClientEnvironment *env) override;
+
+	bool getCollisionBox(aabb3f *toset) const override { return false; }
+	bool getSelectionBox(aabb3f *toset) const override { return false; }
+	bool collideWithObjects() const override { return false; }
+
+private:
+	struct Properties
+	{
+		video::SColor color = video::SColor(0xFFFFFFFF);
+		float range = 8.0f * BS;
+		float falloff = 2.0f;
+	};
+
+	void deserializeState(std::istream &is);
+	void deserializeProperties(std::istream &is);
+	void updateManager();
+
+	// Either m_attached_id is nonzero, meaning follow that object's live
+	// position, or it's 0 and m_pos is the free-floating position last sent.
+	object_t m_attached_id = 0;
+	v3f m_pos;
+	bool m_have_pos = false;
+	Properties m_properties;
+	bool m_registered = false;
+};

--- a/src/client/shader.cpp
+++ b/src/client/shader.cpp
@@ -10,6 +10,7 @@
 #include "util/container.h"
 #include "util/thread.h"
 #include "settings.h"
+#include "client/dynamiclight.h"
 #include <ICameraSceneNode.h>
 #include <IGPUProgrammingServices.h>
 #include <IMaterialRenderer.h>
@@ -21,6 +22,7 @@
 #include "client/tile.h"
 
 #include <mt_opengl.h>
+#include <algorithm>
 
 /*
 	A cache from shader name to shader path
@@ -210,6 +212,9 @@ public:
 
 	void onGenerate(const std::string &name, ShaderConstants &constants) override
 	{
+		// Min 1 cause a zero-size GLSL array is illegal but in practice can still be 0 when no lights are given
+		constants["MAX_DYNAMIC_LIGHTS"] = std::max<int>(1, (int)getDynamicLightsLimitSetting());
+
 		constants["ENABLE_TONE_MAPPING"] = g_settings->getBool("tone_mapping") ? 1 : 0;
 
 		if (g_settings->getBool("enable_dynamic_shadows")) {

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -341,6 +341,7 @@ void set_default_settings()
 	settings->setDefault("enable_volumetric_lighting", "false");
 	settings->setDefault("enable_water_reflections", "false");
 	settings->setDefault("enable_translucent_foliage", "false");
+	settings->setDefault("dynamic_lights_limit", "8");
 
 	// Effects Shadows
 	settings->setDefault("enable_dynamic_shadows", "false");

--- a/src/light_common.h
+++ b/src/light_common.h
@@ -1,0 +1,14 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 Zenon Seth <Zenon.Seth@gmail.com>
+
+#pragma once
+
+#include "irrlichttypes.h"
+
+// Wire commands for LightSAO/LightCAO's own private message protocol
+enum class LightCommand : u8
+{
+	LIGHT_CMD_SET_STATE,
+	LIGHT_CMD_SET_PROPERTIES,
+};

--- a/src/script/common/c_content.cpp
+++ b/src/script/common/c_content.cpp
@@ -19,10 +19,14 @@
 #include "tool.h"
 #include "noise.h"
 #include "porting.h" // strlcpy
+#include "cpp_api/s_base.h"
+#include "server/light_sao.h"
 #include "server/player_sao.h"
+#include "serverenvironment.h"
 #include "util/pointedthing.h"
 #include "debug.h" // For FATAL_ERROR
 #include <SColor.h>
+#include <algorithm>
 #include <json/json.h>
 #include "mapgen/treegen.h"
 
@@ -648,6 +652,74 @@ void push_object_properties(lua_State *L, const ObjectProperties *prop)
 
 	// Remember to update object_property_keys above
 	// when adding a new property
+}
+
+/******************************************************************************/
+void read_light_state(lua_State *L, int index, v3f &pos, std::string &attached_guid)
+{
+	if (index < 0)
+		index = lua_gettop(L) + 1 + index;
+	luaL_checktype(L, index, LUA_TTABLE);
+
+	attached_guid.clear();
+	lua_getfield(L, index, "object");
+	if (!lua_isnil(L, -1)) {
+		ObjectRef *ref = ModApiBase::checkObject<ObjectRef>(L, -1);
+		ServerActiveObject *sao = ObjectRef::getobject(ref);
+		if (!sao)
+			throw LuaError("light state references an invalid object");
+		attached_guid = sao->getGUID();
+		pos = sao->getBasePosition();
+		lua_pop(L, 1); // object
+	} else {
+		lua_pop(L, 1); // object (nil)
+		lua_getfield(L, index, "pos");
+		pos = read_v3f(L, -1) * BS;
+		lua_pop(L, 1); // pos
+	}
+}
+
+void push_light_state(lua_State *L, v3f pos, u16 attached_id, ServerEnvironment *env)
+{
+	lua_createtable(L, 0, 1);
+
+	ServerActiveObject *target = attached_id != 0 ? env->getActiveObject(attached_id) : nullptr;
+	if (target) {
+		ModApiBase::getScriptApiBase(L)->objectrefGetOrCreate(L, target);
+		lua_setfield(L, -2, "object");
+	} else {
+		push_v3f(L, pos / BS);
+		lua_setfield(L, -2, "pos");
+	}
+}
+
+void read_light_properties(lua_State *L, int index, LightProperties &properties)
+{
+	if (index < 0)
+		index = lua_gettop(L) + 1 + index;
+	luaL_checktype(L, index, LUA_TTABLE);
+
+	lua_getfield(L, index, "color");
+	if (!lua_isnil(L, -1))
+		read_color(L, -1, &properties.color);
+	lua_pop(L, 1);
+
+	// Shader does pow()/division with these - undefined for values <= 0
+	float range = getfloatfield_default(L, index, "range", properties.range / BS) * BS;
+	properties.range = std::max(range, 0.01f * BS);
+	float falloff = getfloatfield_default(L, index, "falloff", properties.falloff);
+	properties.falloff = std::max(falloff, 0.01f);
+}
+
+void push_light_properties(lua_State *L, const LightProperties &properties)
+{
+	lua_newtable(L);
+	push_ARGB8(L, properties.color);
+	lua_setfield(L, -2, "color");
+	lua_pushnumber(L, properties.range / BS);
+	lua_setfield(L, -2, "range");
+	lua_pushnumber(L, properties.falloff);
+	lua_setfield(L, -2, "falloff");
 }
 
 /******************************************************************************/

--- a/src/script/common/c_content.h
+++ b/src/script/common/c_content.h
@@ -33,6 +33,8 @@ class Inventory;
 class InventoryList;
 class NodeDefManager;
 class ServerActiveObject;
+class ServerEnvironment;
+struct LightProperties;
 
 struct CollisionMoveResult;
 struct ContentFeatures;
@@ -111,6 +113,16 @@ void read_object_properties(lua_State *L, int index,
 		IItemDefManager *idef, bool fallback = false);
 
 void push_object_properties(lua_State *L, const ObjectProperties *prop);
+
+/// Reads either a `pos` or `object` field, matching core.add_light's def.
+/// @param attached_guid cleared, then filled in if `object` was given
+void read_light_state(lua_State *L, int index, v3f &pos, std::string &attached_guid);
+/// Pushes `pos` as-is if not attached, otherwise a live `ObjectRef` for the
+/// attached target if currently active.
+void push_light_state(lua_State *L, v3f pos, u16 attached_id, ServerEnvironment *env);
+/// @param index stack index of the def/properties table
+void read_light_properties(lua_State *L, int index, LightProperties &properties);
+void push_light_properties(lua_State *L, const LightProperties &properties);
 
 void push_inventory_list(lua_State *L, const InventoryList &invlist);
 void push_inventory_lists(lua_State *L, const Inventory &inv);

--- a/src/script/cpp_api/s_base.h
+++ b/src/script/cpp_api/s_base.h
@@ -17,6 +17,7 @@ extern "C" {
 }
 
 #include "irrlichttypes.h"
+#include "irr_v3d.h"
 #include "common/c_internal.h"
 #include "debug.h"
 #include "config.h"
@@ -60,8 +61,11 @@ class Environment;
 class GUIEngine;
 class SSCSMEnvironment;
 class ServerActiveObject;
+class ServerEnvironment;
 struct PlayerHPChangeReason;
 struct ModVFS;
+
+void push_light_state(lua_State *L, v3f pos, u16 attached_id, ServerEnvironment *env);
 
 class ScriptApiBase : protected LuaHelper {
 public:
@@ -133,6 +137,8 @@ protected:
 	friend class ModApiEnv;
 	friend class LuaVoxelManip;
 	friend class TestMoveAction; // needs getStack()
+	friend void push_light_state(lua_State *L, v3f pos, u16 attached_id,
+			ServerEnvironment *env);
 
 	/*
 		Subtle edge case with coroutines: If for whatever reason you have a

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -26,6 +26,7 @@
 #include "face_position_cache.h"
 #include "remoteplayer.h"
 #include "servermap.h"
+#include "server/light_sao.h"
 #include "server/luaentity_sao.h"
 #include "server/player_sao.h"
 #include "util/string.h"
@@ -587,6 +588,35 @@ int ModApiEnv::l_add_entity(lua_State *L)
 	// If already deleted (can happen in on_activate), return nil
 	if (obj->isGone())
 		return 0;
+	getScriptApiBase(L)->objectrefGetOrCreate(L, obj);
+	return 1;
+}
+
+int ModApiEnv::l_add_light(lua_State *L)
+{
+	GET_ENV_PTR;
+
+	luaL_checktype(L, 1, LUA_TTABLE);
+
+	v3f pos;
+	std::string attached_guid;
+	read_light_state(L, 1, pos, attached_guid);
+
+	LightProperties properties;
+	read_light_properties(L, 1, properties);
+
+	std::unique_ptr<ServerActiveObject> obj_u = std::make_unique<LightSAO>(
+			env, pos, LightAttachment{std::move(attached_guid)}, properties);
+	auto obj = obj_u.get();
+	int objectid = env->addActiveObject(std::move(obj_u));
+	// If failed to add, return nothing
+	if (objectid == 0)
+		return 0;
+
+	// If already deleted somehow, return nil
+	if (obj->isGone())
+		return 0;
+
 	getScriptApiBase(L)->objectrefGetOrCreate(L, obj);
 	return 1;
 }
@@ -1380,6 +1410,7 @@ void ModApiEnv::Initialize(lua_State *L, int top)
 	API_FCT(add_node_level);
 	API_FCT(get_node_boxes);
 	API_FCT(add_entity);
+	API_FCT(add_light);
 	API_FCT(find_nodes_with_meta);
 	API_FCT(get_meta);
 	API_FCT(get_node_timer);

--- a/src/script/lua_api/l_env.h
+++ b/src/script/lua_api/l_env.h
@@ -131,6 +131,9 @@ private:
 	// pos = {x=num, y=num, z=num}
 	static int l_add_item(lua_State *L);
 
+	// add_light(def) -> ObjectRef or nil
+	static int l_add_light(lua_State *L);
+
 	// get_connected_players()
 	static int l_get_connected_players(lua_State *L);
 

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -25,6 +25,7 @@
 #include "serverenvironment.h"
 #include "settings.h"
 #include "hud_element.h"
+#include "server/light_sao.h"
 #include "server/luaentity_sao.h"
 #include "server/player_sao.h"
 #include "server/serverinventorymgr.h"
@@ -51,6 +52,16 @@ LuaEntitySAO* ObjectRef::getluaobject(ObjectRef *ref)
 	if (sao->getType() != ACTIVEOBJECT_TYPE_LUAENTITY)
 		return nullptr;
 	return (LuaEntitySAO*)sao;
+}
+
+LightSAO* ObjectRef::getlightobject(ObjectRef *ref)
+{
+	ServerActiveObject *sao = getobject(ref);
+	if (sao == nullptr)
+		return nullptr;
+	if (sao->getType() != ACTIVEOBJECT_TYPE_LIGHT)
+		return nullptr;
+	return (LightSAO*)sao;
 }
 
 PlayerSAO* ObjectRef::getplayersao(ObjectRef *ref)
@@ -1441,6 +1452,69 @@ int ObjectRef::l_get_luaentity(lua_State *L)
 
 	luaentity_get(L, entitysao->getId());
 	return 1;
+}
+
+/* Light-only */
+
+// get_light_state(self)
+int ObjectRef::l_get_light_state(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	LightSAO *light = getlightobject(ref);
+	if (light == nullptr)
+		return 0;
+
+	push_light_state(L, light->getBasePosition(), light->getAttachedId(), light->getEnv());
+	return 1;
+}
+
+// set_light_state(self, state)
+int ObjectRef::l_set_light_state(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	LightSAO *light = getlightobject(ref);
+	if (light == nullptr)
+		return 0;
+
+	v3f pos;
+	std::string attached_guid;
+	read_light_state(L, 2, pos, attached_guid);
+
+	if (attached_guid.empty())
+		light->setPos(pos);
+	else
+		light->setAttachedGUID(std::move(attached_guid));
+	return 0;
+}
+
+// get_light_properties(self)
+int ObjectRef::l_get_light_properties(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	LightSAO *light = getlightobject(ref);
+	if (light == nullptr)
+		return 0;
+
+	push_light_properties(L, light->getProperties());
+	return 1;
+}
+
+// set_light_properties(self, properties)
+int ObjectRef::l_set_light_properties(lua_State *L)
+{
+	NO_MAP_LOCK_REQUIRED;
+	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
+	LightSAO *light = getlightobject(ref);
+	if (light == nullptr)
+		return 0;
+
+	LightProperties properties = light->getProperties();
+	read_light_properties(L, 2, properties);
+	light->setProperties(properties);
+	return 0;
 }
 
 /* Player-only */
@@ -3078,6 +3152,12 @@ luaL_Reg ObjectRef::methods[] = {
 	luamethod_aliased(ObjectRef, set_sprite, setsprite),
 	luamethod(ObjectRef, get_entity_name),
 	luamethod(ObjectRef, get_luaentity),
+
+	// Light-only
+	luamethod(ObjectRef, get_light_state),
+	luamethod(ObjectRef, set_light_state),
+	luamethod(ObjectRef, get_light_properties),
+	luamethod(ObjectRef, set_light_properties),
 
 	// Player-only
 	luamethod(ObjectRef, is_player),

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -1474,13 +1474,14 @@ int ObjectRef::l_set_light_state(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ObjectRef *ref = checkObject<ObjectRef>(L, 1);
-	LightSAO *light = getlightobject(ref);
-	if (light == nullptr)
-		return 0;
 
 	v3f pos;
 	std::string attached_guid;
 	read_light_state(L, 2, pos, attached_guid);
+
+	LightSAO *light = getlightobject(ref);
+	if (light == nullptr)
+		return 0;
 
 	if (attached_guid.empty())
 		light->setPos(pos);
@@ -1513,6 +1514,11 @@ int ObjectRef::l_set_light_properties(lua_State *L)
 
 	LightProperties properties = light->getProperties();
 	read_light_properties(L, 2, properties);
+
+	// The read above may have re-entered Lua, so light could be gone now.
+	light = getlightobject(ref);
+	if (light == nullptr)
+		return 0;
 	light->setProperties(properties);
 	return 0;
 }

--- a/src/script/lua_api/l_object.h
+++ b/src/script/lua_api/l_object.h
@@ -10,6 +10,7 @@
 
 class ServerActiveObject;
 class LuaEntitySAO;
+class LightSAO;
 class PlayerSAO;
 class RemotePlayer;
 
@@ -42,6 +43,8 @@ private:
 
 
 	static LuaEntitySAO* getluaobject(ObjectRef *ref);
+
+	static LightSAO* getlightobject(ObjectRef *ref);
 
 	static PlayerSAO* getplayersao(ObjectRef *ref);
 
@@ -224,6 +227,20 @@ private:
 
 	// get_luaentity(self)
 	static int l_get_luaentity(lua_State *L);
+
+	/* Light-only */
+
+	// get_light_state(self)
+	static int l_get_light_state(lua_State *L);
+
+	// set_light_state(self, state)
+	static int l_set_light_state(lua_State *L);
+
+	// get_light_properties(self)
+	static int l_get_light_properties(lua_State *L);
+
+	// set_light_properties(self, properties)
+	static int l_set_light_properties(lua_State *L);
 
 	/* Player-only */
 

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -6,6 +6,7 @@ set(common_server_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/ban.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/blockmodifier.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/clientiface.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/light_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/luaentity_sao.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/mods.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/player_sao.cpp

--- a/src/server/activeobjectmgr.cpp
+++ b/src/server/activeobjectmgr.cpp
@@ -155,6 +155,16 @@ void ActiveObjectMgr::getObjectsInArea(const aabb3f &box,
 	});
 }
 
+ServerActiveObject *ActiveObjectMgr::getActiveObjectByGUID(const std::string &guid)
+{
+	for (auto &ao_it : m_active_objects.iter()) {
+		ServerActiveObject *object = ao_it.second.get();
+		if (object && !object->isGone() && object->getGUID() == guid)
+			return object;
+	}
+	return nullptr;
+}
+
 void ActiveObjectMgr::getAddedActiveObjectsAroundPos(
 		v3f player_pos, const std::string &player_name,
 		f32 radius, f32 player_radius,

--- a/src/server/activeobjectmgr.h
+++ b/src/server/activeobjectmgr.h
@@ -41,6 +41,9 @@ public:
 			const std::set<u16> &current_objects,
 			std::vector<u16> &added_objects);
 
+	// Linear scan - active objects are not indexed by GUID.
+	ServerActiveObject *getActiveObjectByGUID(const std::string &guid);
+
 private:
 	k_d_tree::DynamicKdTrees<3, f32, u16> m_spatial_index;
 };

--- a/src/server/light_sao.cpp
+++ b/src/server/light_sao.cpp
@@ -1,0 +1,203 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 Zenon Seth <Zenon.Seth@gmail.com>
+
+#include "light_sao.h"
+#include "constants.h"
+#include "exceptions.h"
+#include "serverenvironment.h"
+#include "util/serialize.h"
+
+namespace
+{
+
+void serializeStaticState(std::ostream &os, v3f pos, const std::string &attached_guid)
+{
+	writeU8(os, !attached_guid.empty());
+	if (!attached_guid.empty())
+		os << serializeString16(attached_guid);
+	writeV3F32(os, pos);
+}
+
+// Returns the deserialized pos; attached_guid is filled in if present.
+v3f deserializeStaticState(std::istream &is, std::string &attached_guid)
+{
+	bool attached = readU8(is);
+	if (attached)
+		attached_guid = deSerializeString16(is);
+	return readV3F32(is);
+}
+
+void serializeProperties(std::ostream &os, const LightProperties &properties)
+{
+	writeARGB8(os, properties.color);
+	writeF32(os, properties.range);
+	writeF32(os, properties.falloff);
+}
+
+void deserializeProperties(std::istream &is, LightProperties &properties)
+{
+	properties.color = readARGB8(is);
+	properties.range = readF32(is);
+	properties.falloff = readF32(is);
+}
+
+} // namespace
+
+LightSAO::LightSAO(ServerEnvironment *env, v3f pos, const std::string &data) :
+		ServerActiveObject(env, pos)
+{
+	std::istringstream is(data, std::ios::binary);
+	u8 version = readU8(is);
+	if (version != 1)
+		throw SerializationError("unsupported LightSAO version");
+
+	m_guid.deSerialize(is);
+	setBasePosition(deserializeStaticState(is, m_attached_guid));
+	deserializeProperties(is, m_properties);
+}
+
+LightSAO::LightSAO(ServerEnvironment *env, v3f pos, LightAttachment attachment,
+		const LightProperties &properties) :
+		ServerActiveObject(env, pos),
+		m_attached_guid(std::move(attachment.guid)),
+		m_guid(env->getGUIDGenerator().next()),
+		m_properties(properties)
+{
+}
+
+void LightSAO::addedToEnvironment(u32 dtime_s)
+{
+	// Force an immediate attempt but don't count the offilne gap toward the unresolved timeout
+	resolveAttachment(0.0f, true);
+}
+
+void LightSAO::step(float dtime, bool send_recommended)
+{
+	resolveAttachment(dtime);
+
+	m_last_sent_position_timer += dtime;
+
+	if (!send_recommended)
+		return;
+
+	// Attachment or target changes are always worth an immediate resend
+	if (m_attached_id != m_last_sent_attached_id) {
+		sendState(false);
+		return;
+	}
+
+	// While attached, the client is already following the target
+	// no per-step position resends needed.
+	if (m_attached_id != 0)
+		return;
+
+	float minchange = getPositionResendMinChange(m_last_sent_position_timer);
+
+	if (getBasePosition().getDistanceFrom(m_last_sent_pos) > minchange)
+		sendState(false);
+}
+
+void LightSAO::getStaticData(std::string *result) const
+{
+	std::ostringstream os(std::ios::binary);
+	writeU8(os, 1);
+	m_guid.serialize(os);
+	serializeStaticState(os, getBasePosition(), m_attached_guid);
+	serializeProperties(os, m_properties);
+
+	*result = os.str();
+}
+
+std::string LightSAO::getClientInitializationData(u16 protocol_version)
+{
+	std::ostringstream os(std::ios::binary);
+	writeU8(os, 1); // version
+	writeU8(os, m_attached_id != 0);
+	if (m_attached_id != 0)
+		writeU16(os, m_attached_id);
+	else
+		writeV3F32(os, getBasePosition());
+	serializeProperties(os, m_properties);
+	return os.str();
+}
+
+void LightSAO::setPos(v3f pos)
+{
+	m_attached_guid.clear();
+	m_attached_id = 0;
+	setBasePosition(pos);
+	sendState();
+}
+
+void LightSAO::setAttachedGUID(std::string attached_guid)
+{
+	m_attached_guid = std::move(attached_guid);
+	resolveAttachment(0.0f, true);
+	sendState();
+}
+
+void LightSAO::setProperties(const LightProperties &properties)
+{
+	m_properties = properties;
+	sendProperties();
+}
+
+void LightSAO::resolveAttachment(float dtime, bool force)
+{
+	if (m_attached_guid.empty())
+		return;
+
+	// Cheap path: id from last resolve is still valid, no GUID scan needed
+	if (m_attached_id != 0) {
+		if (ServerActiveObject *target = m_env->getActiveObject(m_attached_id)) {
+			setBasePosition(target->getBasePosition());
+			m_unresolved_time = 0.0f;
+			m_time_since_last_scan = 0.0f;
+			return;
+		}
+		m_attached_id = 0;
+	}
+
+	m_unresolved_time += dtime;
+	m_time_since_last_scan += dtime;
+	if (!force && m_time_since_last_scan < ATTACHMENT_RESCAN_INTERVAL)
+		return;
+	m_time_since_last_scan = 0.0f;
+
+	// Id lookup failed or wasn't known yet - fall back to the slow scan
+	if (ServerActiveObject *target = m_env->getActiveObjectByGUID(m_attached_guid)) {
+		m_attached_id = target->getId();
+		setBasePosition(target->getBasePosition());
+		m_unresolved_time = 0.0f;
+		return;
+	}
+
+	// Still not found after retrying - give up rather than scanning forever
+	if (m_unresolved_time >= ATTACHMENT_TIMEOUT)
+		markForRemoval();
+}
+
+void LightSAO::sendState(bool reliable)
+{
+	std::ostringstream os(std::ios::binary);
+	writeU8(os, (u8)LightCommand::LIGHT_CMD_SET_STATE);
+	writeU8(os, m_attached_id != 0);
+	if (m_attached_id != 0)
+		writeU16(os, m_attached_id);
+	else
+		writeV3F32(os, getBasePosition());
+	m_messages_out.emplace(getId(), reliable, os.str());
+
+	m_last_sent_attached_id = m_attached_id;
+	m_last_sent_pos = getBasePosition();
+	m_last_sent_position_timer = 0.0f;
+}
+
+void LightSAO::sendProperties()
+{
+	std::ostringstream os(std::ios::binary);
+	writeU8(os, (u8)LightCommand::LIGHT_CMD_SET_PROPERTIES);
+	serializeProperties(os, m_properties);
+	m_messages_out.emplace(getId(), true, os.str());
+}

--- a/src/server/light_sao.h
+++ b/src/server/light_sao.h
@@ -1,0 +1,92 @@
+// Luanti
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Copyright (C) 2026 Zenon Seth <Zenon.Seth@gmail.com>
+
+#pragma once
+
+#include "constants.h"
+#include "light_common.h"
+#include "serveractiveobject.h"
+#include "util/guid.h"
+#include <SColor.h>
+
+// Distinguishes the "attach to this GUID" constructor from the
+// "raw serialized blob" constructor, otherwise both would take a plain
+// std::string and be ambiguous
+struct LightAttachment
+{
+	std::string guid; // empty means free-floating
+};
+
+struct LightProperties
+{
+	video::SColor color = video::SColor(0xFFFFFFFF);
+	float range = 8.0f * BS;
+	float falloff = 2.0f;
+};
+
+// A lightweight, persistent, server-side point light with no callbacks or Lua state
+// Just a position, optionally by GUID so attachment survives reload
+class LightSAO : public ServerActiveObject
+{
+public:
+	LightSAO() = delete;
+	// Used by the environment to load a stored light
+	LightSAO(ServerEnvironment *env, v3f pos, const std::string &data);
+	// Used by the Lua API
+	LightSAO(ServerEnvironment *env, v3f pos, LightAttachment attachment,
+			const LightProperties &properties);
+
+	ActiveObjectType getType() const override { return ACTIVEOBJECT_TYPE_LIGHT; }
+
+	void addedToEnvironment(u32 dtime_s) override;
+	void step(float dtime, bool send_recommended) override;
+
+	bool isStaticAllowed() const override { return true; }
+	void getStaticData(std::string *result) const override;
+	std::string getClientInitializationData(u16 protocol_version) override;
+
+	std::string getGUID() const override { return m_guid.base64(); }
+
+	bool getCollisionBox(aabb3f *toset) const override { return false; }
+	bool getSelectionBox(aabb3f *toset) const override { return false; }
+	bool collideWithObjects() const override { return false; }
+
+	// Detaches if attached, and moves to a free-floating position.
+	void setPos(v3f pos);
+	void setAttachedGUID(std::string attached_guid);
+	object_t getAttachedId() const { return m_attached_id; }
+	const LightProperties &getProperties() const { return m_properties; }
+	void setProperties(const LightProperties &properties);
+
+private:
+	// How often to retry the linear GUID scan while unresolved,
+	// and how long to keep retrying before giving up and removing it.
+	static constexpr float ATTACHMENT_RESCAN_INTERVAL = 1.0f;
+	static constexpr float ATTACHMENT_TIMEOUT = 2.0f;
+
+	// Resolves m_attached_guid to m_attached_id and refreshes pos if attached.
+	// force bypasses the rescan throttle, for the initial resolve attempt.
+	void resolveAttachment(float dtime, bool force = false);
+
+	// Sends the attached object's id or the free-floating position
+	// The client then tracks that object's own CAO position itself.
+	void sendState(bool reliable = true);
+	// Queues a LIGHT_CMD_SET_PROPERTIES message.
+	void sendProperties();
+
+	std::string m_attached_guid; // empty if free-floating
+	ServerActiveObject::object_t m_attached_id = 0;
+	MyGUID m_guid;
+	LightProperties m_properties;
+
+	// What was last sent to clients, to know when a resend is warranted.
+	ServerActiveObject::object_t m_last_sent_attached_id = 0;
+	v3f m_last_sent_pos;
+	float m_last_sent_position_timer = 0.0f;
+
+	// How long the target has been continuously unresolved
+	// and how long since the last GUID scan attempt
+	float m_unresolved_time = 0.0f;
+	float m_time_since_last_scan = 0.0f;
+};

--- a/src/server/luaentity_sao.cpp
+++ b/src/server/luaentity_sao.cpp
@@ -223,12 +223,7 @@ void LuaEntitySAO::step(float dtime, bool send_recommended)
 	if(!isAttached())
 	{
 		// TODO: force send when acceleration changes enough?
-		float minchange = 0.2*BS;
-		if(m_last_sent_position_timer > 1.0){
-			minchange = 0.01*BS;
-		} else if(m_last_sent_position_timer > 0.2){
-			minchange = 0.05*BS;
-		}
+		float minchange = getPositionResendMinChange(m_last_sent_position_timer);
 		float move_d = getBasePosition().getDistanceFrom(m_last_sent_position);
 		move_d += m_last_sent_move_precision;
 		float vel_d = m_velocity.getDistanceFrom(m_last_sent_velocity);

--- a/src/server/serveractiveobject.cpp
+++ b/src/server/serveractiveobject.cpp
@@ -32,6 +32,15 @@ float ServerActiveObject::getMinimumSavedMovement()
 	return 2.0*BS;
 }
 
+float getPositionResendMinChange(float last_sent_position_timer)
+{
+	if (last_sent_position_timer > 1.0f)
+		return 0.01f * BS;
+	if (last_sent_position_timer > 0.2f)
+		return 0.05f * BS;
+	return 0.2f * BS;
+}
+
 ItemStack ServerActiveObject::getWieldedItem(ItemStack *selected, ItemStack *hand) const
 {
 	*selected = ItemStack();

--- a/src/server/serveractiveobject.h
+++ b/src/server/serveractiveobject.h
@@ -38,6 +38,10 @@ struct PlayerHPChangeReason;
 class Inventory;
 struct InventoryLocation;
 
+// Minimum position change worth an unreliable resend, given time since the
+// last one - the longer the gap, the smaller a change is still worth sending.
+float getPositionResendMinChange(float last_sent_position_timer);
+
 class ServerActiveObject : public ActiveObject
 {
 public:

--- a/src/serverenvironment.cpp
+++ b/src/serverenvironment.cpp
@@ -6,6 +6,7 @@
 #include <stack>
 #include <utility>
 #include "serverenvironment.h"
+#include "exceptions.h"
 #include "irr_aabb3d.h"
 #include "settings.h"
 #include "log.h"
@@ -34,6 +35,7 @@
 #if USE_LEVELDB
 #include "database/database-leveldb.h"
 #endif
+#include "server/light_sao.h"
 #include "server/luaentity_sao.h"
 #include "server/player_sao.h"
 
@@ -1570,6 +1572,8 @@ std::unique_ptr<ServerActiveObject> ServerEnvironment::createSAO(ActiveObjectTyp
 	switch (type) {
 		case ACTIVEOBJECT_TYPE_LUAENTITY:
 			return std::make_unique<LuaEntitySAO>(this, pos, data);
+		case ACTIVEOBJECT_TYPE_LIGHT:
+			return std::make_unique<LightSAO>(this, pos, data);
 		default:
 			warningstream << "ServerActiveObject: No factory for type=" << type << std::endl;
 	}
@@ -1590,9 +1594,17 @@ void ServerEnvironment::activateObjects(MapBlock *block, u32 dtime_s)
 	// Activate stored objects
 	std::vector<StaticObject> new_stored;
 	for (const StaticObject &s_obj : block->m_static_objects.getAllStored()) {
-		// Create an active object from the data
-		std::unique_ptr<ServerActiveObject> obj =
-				createSAO((ActiveObjectType)s_obj.type, s_obj.pos, s_obj.data);
+		// Just drop any corrupt or incompatible saved objects
+		std::unique_ptr<ServerActiveObject> obj;
+		try {
+			obj = createSAO((ActiveObjectType)s_obj.type, s_obj.pos, s_obj.data);
+		} catch (SerializationError &e) {
+			errorstream << "ServerEnvironment::activateObjects(): "
+				<< "failed to deserialize static object in block "
+				<< block->getPos() << " type=" << (int)s_obj.type
+				<< ": " << e.what() << std::endl;
+			continue;
+		}
 		// If couldn't create object, store static data back.
 		if (!obj) {
 			errorstream << "ServerEnvironment::activateObjects(): "

--- a/src/serverenvironment.h
+++ b/src/serverenvironment.h
@@ -162,6 +162,12 @@ public:
 		return m_ao_manager.getActiveObject(id);
 	}
 
+	// Linear scan - only finds objects that are currently active.
+	ServerActiveObject *getActiveObjectByGUID(const std::string &guid)
+	{
+		return m_ao_manager.getActiveObjectByGUID(guid);
+	}
+
 	/*
 		Add an active object to the environment.
 		Environment handles deletion of object.


### PR DESCRIPTION
Add compact, short information about your PR for easier understanding:

- Goal of the PR
  - Enable dynamic lights
- How does the PR work?
  - Modifies shaders to handle up to 20 (max number hardcoded) lights
  - Adds a new Light CAO/SAO, that optionally can be attached to an entity and is more lightweight than one
  - Adds a lua api to allow spawning of these lights + attach them to entities, including player
  - Adds a new setting in Settings to let players pick how many dynamic lights to be drawn at once, max 20.
- Does it resolve any reported issue?
  - https://github.com/luanti-org/luanti/issues/15371
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  - Don't think so
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - Usecase of mods wanting to add lights
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  - I have used Claude to write boilerplate of the lua parsing, and help me catch bugs in my implementation. All code otherwise written and reviewed by me.

## To do

This PR is Ready for Review.


## How to test

<details>

<summary>Lua code for below vide</summary>

```lua
local MOVE_SPEED = 1.5 -- nodes/sec
local DESTROY_DELAY = 3 -- seconds after colliding, before the entity removes itself
local FLY_COLORS = {
	"#ff6666ff", -- red
	"#66ff66ff", -- green
	"#6666ffff", -- blue
	"#ffffffff", -- white
}
local fly_color_index = 0

local function next_fly_color()
	fly_color_index = fly_color_index % #FLY_COLORS + 1
	return FLY_COLORS[fly_color_index]
end

minetest.register_entity("z_test:moving_light", {
	initial_properties = {
		visual = "sprite",
		textures = {"light.png"},
		visual_size = {x = 0.3, y = 0.3},
		collisionbox = {-0.1, -0.1, -0.1, 0.1, 0.1, 0.1},
		physical = true,
		pointable = false,
		static_save = false,
	},
	collide_timer = nil,
	on_activate = function(self, staticdata)
		self.object:set_acceleration(vector.zero())
		core.add_light({
			object = self.object,
			color = staticdata ~= "" and staticdata or FLY_COLORS[1],
			range = 6,
			falloff = 2.5,
		})
	end,
	on_step = function(self, dtime, moveresult)
		if self.collide_timer then
			self.collide_timer = self.collide_timer + dtime
			if self.collide_timer >= DESTROY_DELAY then
				self.object:remove()
			end
			return
		end
		if moveresult and moveresult.collides then
			self.collide_timer = 0
			self.object:set_velocity(vector.zero())
		end
	end,
})

-- playername -> guid of the light currently attached to them via the wand
local player_lights = {}
local CLEANUP_RADIUS = 5

local function clear_nearby_lights(center)
	local min_pos = vector.subtract(center, CLEANUP_RADIUS)
	local max_pos = vector.add(center, CLEANUP_RADIUS)
	local count = 0
	for _, obj in ipairs(core.get_objects_in_area(min_pos, max_pos)) do
		if obj:get_light_properties() then
			obj:remove()
			count = count + 1
		end
	end
	return count
end

minetest.register_tool("z_test:light_wand", {
	description = "Light Wand",
	inventory_image = "wand.png",
	wield_image = "wand.png",
	stack_max = 1,
	on_use = function(itemstack, user, pointed_thing)
		if not user then return end
		local name = user:get_player_name()

		local guid = player_lights[name]
		local existing = guid and core.objects_by_guid[guid]
		if existing then
			player_lights[name] = nil
			local count = clear_nearby_lights(user:get_pos())
			core.chat_send_player(name, "Removed " .. count .. " light(s) nearby.")
			return
		end

		local light = core.add_light({
			object = user,
			color = "#ffaa44ff",
			range = 6,
			falloff = 2,
		})
		if not light then return end
		player_lights[name] = light:get_guid()
		core.chat_send_player(name, "Light attached to you.")
	end,
	on_secondary_use = function(itemstack, user, pointed_thing)
		if not user then return end
		local pos = user:get_pos()
		pos.y = pos.y + 1.5
		local dir = user:get_look_dir()
		local obj = core.add_entity(pos, "z_test:moving_light", next_fly_color())
		if not obj then return end
		obj:set_velocity(vector.multiply(dir, MOVE_SPEED))
		core.chat_send_player(user:get_player_name(), "Moving light launched.")
	end,
})

```

</details>


## Video

https://github.com/user-attachments/assets/bc1dfc5f-b221-4f8a-a389-b95aa4bd8ddb


