### PR TITLE
Improve random number generation

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9819,10 +9819,7 @@ In multiplayer mode, the error may be arbitrarily large.
 `SecureRandom`
 --------------
 
-Interface for the operating system's crypto-secure PRNG.
-
-It can be created via `SecureRandom()`.  The constructor throws an error if a
-secure random device cannot be found on the system.
+Interface for the operating system's crypto-secure PRNG. It can be created via `SecureRandom()`.
 
 ### Methods
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -370,12 +370,10 @@ check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
 
 # getentropy() is specified by POSIX in <unistd.h>,
 # some systems also provide it in <sys/random.h>.
-set(HAVE_GETENTROPY FALSE)
-if(NOT WIN32)
-	check_symbol_exists(getentropy "unistd.h;sys/random.h" FOUND_GETENTROPY)
-	if(FOUND_GETENTROPY)
-		set(HAVE_GETENTROPY TRUE)
-	endif()
+if(WIN32)
+	set(HAVE_GETENTROPY FALSE)
+else()
+	check_symbol_exists(getentropy "unistd.h;sys/random.h" HAVE_GETENTROPY)
 endif()
 # Apple requires either reading from /dev/urandom
 # or using some Swift API on non MacOS systems

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -368,6 +368,22 @@ endif()
 include(CheckSymbolExists)
 check_symbol_exists(strlcpy "string.h" HAVE_STRLCPY)
 
+# getentropy() is specified by POSIX in <unistd.h>,
+# some systems also provide it in <sys/random.h>.
+set(HAVE_GETENTROPY FALSE)
+if(NOT WIN32)
+	check_symbol_exists(getentropy "unistd.h;sys/random.h" FOUND_GETENTROPY)
+	if(FOUND_GETENTROPY)
+		set(HAVE_GETENTROPY TRUE)
+	endif()
+endif()
+# Apple requires either reading from /dev/urandom
+# or using some Swift API on non MacOS systems
+# https://github.com/LuaJIT/LuaJIT/blob/1ee778a4e37122d8ca7d5733c590a47dafd6b15c/src/lj_prng.c#L118
+if (APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	set(HAVE_GETENTROPY FALSE)
+endif()
+
 if(UNIX)
 	check_symbol_exists(malloc_trim "malloc.h" HAVE_MALLOC_TRIM)
 else()

--- a/src/cmake_config.h.in
+++ b/src/cmake_config.h.in
@@ -32,6 +32,7 @@
 #cmakedefine01 USE_OPENSSL
 #cmakedefine01 HAVE_ENDIAN_H
 #cmakedefine01 HAVE_STRLCPY
+#cmakedefine01 HAVE_GETENTROPY
 #cmakedefine01 HAVE_MALLOC_TRIM
 #cmakedefine01 CURSES_HAVE_CURSES_H
 #cmakedefine01 CURSES_HAVE_NCURSES_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -775,16 +775,7 @@ static bool init_common(const Settings &cmd_args, int argc, char *argv[])
 
 	// Initialize random seed
 	u64 seed;
-	if (!porting::secure_rand_fill_buf(&seed, sizeof(seed))) {
-		infostream << "Secure randomness not available to seed global RNG!" << std::endl;
-		std::ostringstream oss;
-		// stuff that's somewhat unpredictable:
-		oss << time(nullptr) << porting::getTimeUs() << argc
-			<< g_settings_path << reinterpret_cast<intptr_t>(argv);
-		print_version(oss);
-		std::string data = oss.str();
-		seed = murmur_hash_64_ua(data.c_str(), data.size(), 0xc0ffee);
-	}
+	porting::secure_rand_fill_buf(&seed, sizeof(seed));
 	srand(seed);
 	mysrand(seed);
 

--- a/src/porting.cpp
+++ b/src/porting.cpp
@@ -23,6 +23,7 @@
 	#include <mmsystem.h>
 #endif
 #if !defined(_WIN32)
+	#include <algorithm>
 	#include <unistd.h>
 	#include <sys/utsname.h>
 	#if !defined(__ANDROID__)
@@ -54,6 +55,17 @@
 #if HAVE_MALLOC_TRIM
 	// glibc-only pretty much
 	#include <malloc.h>
+#endif
+
+#if HAVE_GETENTROPY
+	#include <limits.h>
+	#include <unistd.h>
+	#if defined(__has_include) && __has_include(<sys/random.h>)
+		#include <sys/random.h>
+	#endif
+	#ifndef GETENTROPY_MAX
+		#define GETENTROPY_MAX 256
+	#endif
 #endif
 
 #include "debug.h"
@@ -792,35 +804,95 @@ void initializePaths()
 
 #ifdef WIN32
 
-bool secure_rand_fill_buf(void *buf, size_t len)
+void secure_rand_fill_buf(void *buf, size_t len)
 {
 	HCRYPTPROV wctx;
 
-	if (!CryptAcquireContext(&wctx, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
-		return false;
+	bool success = CryptAcquireContext(&wctx, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
+	FATAL_ERROR_IF(!success, "CryptAcquireContext failed, this should never happen");
 
-	bool success = CryptGenRandom(wctx, len, (BYTE *)buf);
+	success = CryptGenRandom(wctx, len, (BYTE *)buf);
 	CryptReleaseContext(wctx, 0);
-	return success;
+
+	FATAL_ERROR_IF(!success, "Unable to interface with system CSPRNG, this should never happen");
 }
 
 #else
 
-bool secure_rand_fill_buf(void *buf, size_t len)
+static void fill_secure_buffer_posix(char *buf, size_t len)
 {
-	// N.B.  This function checks *only* for /dev/urandom, because on most
-	// common OSes it is non-blocking, whereas /dev/random is blocking, and it
-	// is exceptionally uncommon for there to be a situation where /dev/random
-	// exists but /dev/urandom does not.  This guesswork is necessary since
-	// random devices are not covered by any POSIX standard...
+#if HAVE_GETENTROPY
+	// https://man7.org/linux/man-pages/man3/getentropy.3.html
+	// https://man7.org/linux/man-pages/man2/getrandom.2.html
+	// https://linux.die.net/man/4/urandom
+	// https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/dev/random/randomdev.c#L116
+
+	// Linux /dev/urandom can end up being seeded with low quality predictable RNG
+	// which allows guessing values it generates by predicting initial state
+	// this is mostly an IoT issue and not an issue for full desktop or server environments
+	//
+	// /dev/random on the other hand, depending on the platform can block even if it has sufficient
+	// seeding because the authors of it assumed a CSPRNG is broken if it's not re-seeded often
+	//
+	// getentropy with flags set to zero semantics match /dev/urandom at runtime,
+	// but it checks the system got enough entropy to make the initial state of
+	// the CSPRNG unguessable by using getrandom
+	// "getrandom() will block until the entropy pool has been initialized"
+	//
+
+	// read in blocks of at most GETENTROPY_MAX bytes per POSIX
+	int status;
+	do {
+		const size_t len_read = std::min(len, static_cast<size_t>(GETENTROPY_MAX));
+		status = getentropy(buf, len_read);
+		if (status == 0) {
+			len -= len_read;
+			buf += len_read;
+		}
+	} while (status == 0 && len > 0);
+
+	if (len == 0)
+		return;
+
+	// fall through if the failure is due to not supporting the syscall required
+	FATAL_ERROR_IF(errno != ENOSYS, "Unable to get entropy with getentropy");
+#endif
 	FILE *fp = fopen("/dev/urandom", "rb");
-	if (!fp)
-		return false;
+	FATAL_ERROR_IF(!fp, "Your unix-like system does not support /dev/urandom, unable to continue");
 
 	bool success = fread(buf, len, 1, fp) == 1;
-
 	fclose(fp);
-	return success;
+
+	FATAL_ERROR_IF(!success, "Unable to read from /dev/urandom, this should never happen");
+}
+
+void secure_rand_fill_buf(void *buf, size_t len)
+{
+	// small csprng reads are piped to this instead of doing a syscall
+	constexpr size_t SMALL_BUFF_SIZE = 512; // two buffers of getentropy
+	static thread_local size_t s_thread_rand_idx = SMALL_BUFF_SIZE;
+	static thread_local char s_thread_rand_buffer[SMALL_BUFF_SIZE];
+
+	char *out_buf = static_cast<char*>(buf);
+
+	if (len < SMALL_BUFF_SIZE) {
+		// small read optimized path
+		size_t len_remaining = SMALL_BUFF_SIZE - s_thread_rand_idx;
+		if (len_remaining >= len) {
+			memcpy(out_buf, &s_thread_rand_buffer[s_thread_rand_idx], len);
+			s_thread_rand_idx += len;
+		} else {
+			// Copy over with what we have left from our current buffer
+			memcpy(out_buf, &s_thread_rand_buffer[s_thread_rand_idx], len_remaining);
+
+			// grab new entropy from system
+			fill_secure_buffer_posix(s_thread_rand_buffer, SMALL_BUFF_SIZE);
+			memcpy(&out_buf[len_remaining], s_thread_rand_buffer, len - len_remaining);
+			s_thread_rand_idx = len - len_remaining;
+		}
+	} else {
+		fill_secure_buffer_posix(out_buf, len);
+	}
 }
 
 #endif

--- a/src/porting.h
+++ b/src/porting.h
@@ -289,7 +289,7 @@ inline const char *getPlatformName()
 }
 
 // Securely fills buffer with bytes from system's random source
-[[nodiscard]] bool secure_rand_fill_buf(void *buf, size_t len);
+void secure_rand_fill_buf(void *buf, size_t len);
 
 // Call once near beginning of main function.
 void osSpecificInit();

--- a/src/script/lua_api/l_noise.cpp
+++ b/src/script/lua_api/l_noise.cpp
@@ -576,41 +576,21 @@ const luaL_Reg LuaPcgRandom::methods[] = {
 	LuaSecureRandom
 */
 
-bool LuaSecureRandom::fillRandBuf()
-{
-	return porting::secure_rand_fill_buf(m_rand_buf, RAND_BUF_SIZE);
-}
-
 int LuaSecureRandom::l_next_bytes(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 
-	LuaSecureRandom *o = checkObject<LuaSecureRandom>(L, 1);
+	// argument 1 is ignored, only its type is checked
+	luaL_checkudata(L, 1, className);
 	u32 count = lua_isnumber(L, 2) ? lua_tointeger(L, 2) : 1;
+
+	constexpr size_t RAND_BUF_SIZE = 2048;
+	char output_buf[RAND_BUF_SIZE];
 
 	// Limit count
 	count = MYMIN(RAND_BUF_SIZE, count);
-
-	// Find out whether we can pass directly from our array, or have to do some gluing
-	size_t count_remaining = RAND_BUF_SIZE - o->m_rand_idx;
-	if (count_remaining >= count) {
-		lua_pushlstring(L, o->m_rand_buf + o->m_rand_idx, count);
-		o->m_rand_idx += count;
-	} else {
-		char output_buf[RAND_BUF_SIZE];
-
-		// Copy over with what we have left from our current buffer
-		memcpy(output_buf, o->m_rand_buf + o->m_rand_idx, count_remaining);
-
-		// Refill buffer and copy over the remainder of what was requested
-		o->fillRandBuf();
-		memcpy(output_buf + count_remaining, o->m_rand_buf, count - count_remaining);
-
-		// Update index
-		o->m_rand_idx = count - count_remaining;
-
-		lua_pushlstring(L, output_buf, count);
-	}
+	porting::secure_rand_fill_buf(output_buf, count);
+	lua_pushlstring(L, output_buf, count);
 
 	return 1;
 }
@@ -618,34 +598,20 @@ int LuaSecureRandom::l_next_bytes(lua_State *L)
 
 int LuaSecureRandom::create_object(lua_State *L)
 {
-	LuaSecureRandom *o = new LuaSecureRandom();
-
-	if (!o->fillRandBuf()) {
-		delete o;
-		throw LuaError("SecureRandom: Failed to find secure random device on system");
-	}
-
-	*(void **)(lua_newuserdata(L, sizeof(void *))) = o;
+	// empty, for backwards compat
+	lua_newuserdata(L, 0);
 	luaL_getmetatable(L, className);
 	lua_setmetatable(L, -2);
 	return 1;
 }
 
-
-int LuaSecureRandom::gc_object(lua_State *L)
-{
-	delete takeObjectForGC<LuaSecureRandom>(L);
-	return 0;
-}
-
-
 void LuaSecureRandom::Register(lua_State *L)
 {
-	static const luaL_Reg metamethods[] = {
-		{"__gc", gc_object},
-		{0, 0}
-	};
-	registerClass<LuaSecureRandom>(L, methods, metamethods);
+	luaL_newmetatable(L, className);
+	lua_newtable(L);
+	luaL_register(L, NULL, methods);
+	lua_setfield(L, -2, "__index");
+	lua_pop(L, 1);
 
 	lua_register(L, className, create_object);
 }

--- a/src/script/lua_api/l_noise.h
+++ b/src/script/lua_api/l_noise.h
@@ -159,23 +159,14 @@ public:
 class LuaSecureRandom : public ModApiBase
 {
 private:
-	static const size_t RAND_BUF_SIZE = 2048;
 	static const luaL_Reg methods[];
 
-	u32 m_rand_idx;
-	char m_rand_buf[RAND_BUF_SIZE];
-
 	// Exported functions
-
-	// garbage collector
-	static int gc_object(lua_State *L);
 
 	// next_bytes(self, count) -> get count many bytes
 	static int l_next_bytes(lua_State *L);
 
 public:
-	bool fillRandBuf();
-
 	// LuaSecureRandom()
 	// Creates an LuaSecureRandom and leaves it on top of stack
 	static int create_object(lua_State *L);

--- a/src/unittest/test_random.cpp
+++ b/src/unittest/test_random.cpp
@@ -8,6 +8,7 @@
 #include "util/numeric.h"
 #include "exceptions.h"
 #include "noise.h"
+#include "porting.h"
 
 class TestRandom : public TestBase {
 public:
@@ -16,6 +17,7 @@ public:
 
 	void runTests(IGameDef *gamedef);
 
+	void testSystemRandom();
 	void testPseudoRandom();
 	void testPseudoRandomRange();
 	void testPcgRandom();
@@ -33,6 +35,7 @@ static TestRandom g_test_instance;
 
 void TestRandom::runTests(IGameDef *gamedef)
 {
+	TEST(testSystemRandom);
 	TEST(testPseudoRandom);
 	TEST(testPseudoRandomRange);
 	TEST(testPcgRandom);
@@ -42,6 +45,47 @@ void TestRandom::runTests(IGameDef *gamedef)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void TestRandom::testSystemRandom()
+{
+	char buf[1024] = {};
+	porting::secure_rand_fill_buf(buf + 1, sizeof(buf) - 2);
+	UASSERT(buf[0] == 0);
+	UASSERT(buf[sizeof(buf) - 1] == 0);
+
+	// number of set bits follows Binomial(8176, 0.5), normal approximation:
+	// int(4088 -/+ 4.89164 * sqrt(8176 * 0.25)) -> [3866, 4309]
+	// two-sided bounds for a 1 in 1 million runs failure rate
+	const int min_set_bits = 3866;
+	const int max_set_bits = 4309;
+	int set_bits = 0;
+	for (size_t i = 1; i < sizeof(buf) - 1; ++i) {
+		u8 byte = static_cast<u8>(buf[i]);
+		while (byte) {
+			set_bits += byte & 1;
+			byte >>= 1;
+		}
+	}
+	UASSERT(set_bits >= min_set_bits);
+	UASSERT(set_bits <= max_set_bits);
+
+	// when the SRP version was broken
+	// it had a buffer overflow that made it
+	// return random static data
+	// instead of system entropy
+	// this checks for that failure mode
+	// this may fail once a few million years by chance
+	// (collision for a 128-bit value)
+	// if you see this fail the CSPRNG is broken
+	constexpr int samples_to_check = 512;
+	constexpr size_t sample_size = 16;
+	char samples[samples_to_check][sample_size] = {};
+	for (int s = 0; s < samples_to_check; s++) {
+		porting::secure_rand_fill_buf(&samples[s], sample_size);
+		for (int i = 0; i < s; i++)
+			UASSERT(memcmp(samples[s], samples[i], sample_size) != 0);
+	}
+}
 
 void TestRandom::testPseudoRandom()
 {

--- a/src/util/guid.cpp
+++ b/src/util/guid.cpp
@@ -32,10 +32,7 @@ GUIDGenerator::GUIDGenerator() :
 	m_uniform(0, UINT64_MAX)
 {
 	u64 seed;
-	if (!porting::secure_rand_fill_buf(&seed, sizeof(seed))) {
-		// main.cpp initializes our internal RNG as good as possible, so fall back to it
-		myrand_bytes(&seed, sizeof(seed));
-	}
+	porting::secure_rand_fill_buf(&seed, sizeof(seed));
 
 	// Make sure we're not losing entropy or providing too few
 	static_assert(sizeof(seed) == sizeof(decltype(m_rand)::result_type), "seed type mismatch");

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -504,8 +504,7 @@ static SRP_Result calculate_H_AMK(SRP_HashAlgorithm alg, unsigned char *dest,
 static SRP_Result mpz_fill_random(mpz_t num)
 {
 	unsigned char random_buf[32];
-	if (!porting::secure_rand_fill_buf(random_buf, sizeof(random_buf)))
-		return SRP_ERR;
+	porting::secure_rand_fill_buf(random_buf, sizeof(random_buf));
 	mpz_from_bin(random_buf, sizeof(random_buf), num);
 	return SRP_OK;
 }
@@ -548,8 +547,7 @@ SRP_Result srp_create_salted_verification_key( SRP_HashAlgorithm alg,
 		*len_s = size_to_fill;
 		*bytes_s = (unsigned char *)malloc(size_to_fill);
 		if (!*bytes_s) goto error_and_exit;
-		if (!porting::secure_rand_fill_buf(*bytes_s, size_to_fill))
-			goto error_and_exit;
+		porting::secure_rand_fill_buf(*bytes_s, size_to_fill);
 	}
 
 	if (!calculate_x(


### PR DESCRIPTION
- System CSPRNG is now considered infallible, so callers no longer have to handle the return status
- it will now use getentropy on supported systems, as that only generates random numbers once the system has enough initial entropy (posix)
- secure_rand_fill_buf will keep a per-thread cache so small reads aren't any more expensive than large ones (posix)
- Windows already runs the CSPRNG in userspace with kernel seeding so don't need that change.
- Added unit tests to flag obvious CSPRNG failures, 1 in 1 million failure state should be expected


# AI usage
- Figuring out how to run the whitespace lint locally.
- Figuring out what's in the Apple <sys/random.h> header
- Fixing android build (seems to be correct)
- Some small changes, build system stuff, etc