### PR TITLE
Log: Smarter line splitting (spaces and multi-byte characters)

### DIFF
--- a/src/unittest/test_logging.cpp
+++ b/src/unittest/test_logging.cpp
@@ -2,6 +2,7 @@
 
 #include "test.h"
 #include "log_internal.h"
+#include <vector>
 
 using std::ostream;
 
@@ -15,6 +16,7 @@ public:
 
 	void testNullChecks();
 	void testBitCheck();
+	void testLineBreak();
 };
 
 static TestLogging g_test_instance;
@@ -23,6 +25,7 @@ void TestLogging::runTests(IGameDef *gamedef)
 {
 	TEST(testNullChecks);
 	TEST(testBitCheck);
+	TEST(testLineBreak);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -87,4 +90,42 @@ void TestLogging::testBitCheck()
 	UASSERTEQ(std::string, logs[0].text, "EOF is (ostream:eofbit)");
 	UASSERTEQ(std::string, logs[1].text, "Fail is (ostream:failbit)");
 	UASSERTEQ(std::string, logs[2].text, "Bad is (ostream:badbit)");
+}
+
+void TestLogging::testLineBreak()
+{
+	std::vector<std::string> lines;
+	StringStreamBuffer<40> buffer([&lines](std::string_view str) {
+		//std::cout << "LOG: " << str << std::endl;
+		lines.emplace_back(str);
+	});
+
+	UASSERT(lines.empty());
+	{
+		// Test UTF-8 multibyte splitting
+		std::string_view what("\xe2\x97\x8b");
+		for (unsigned i = 0; i < 20; ++i) {
+			// (20 * 3 bytes) / 40 bytes --> 2 lines.
+			buffer.xsputn(what.data(), what.size());
+		}
+		buffer.sync();
+		UASSERT(lines.size() == 2);
+		UASSERT(*lines[0].rbegin() == '\x8b'); // last before multibyte start
+		UASSERT(IS_UTF8_MULTB_START(lines[1].at(0)));
+	}
+
+	lines.clear();
+
+	{
+		// Test split by space
+		std::string_view what("helloworld ");
+		for (unsigned i = 0; i < 20; ++i) {
+			// (20 * 11 bytes) / 40 bytes --> min. 6 lines.
+			buffer.xsputn(what.data(), what.size());
+		}
+		buffer.sync();
+		UASSERT(lines.size() >= 6);
+		UASSERT(*lines[0].rbegin() == 'd');
+		UASSERT(lines[1].at(0) == ' ');
+	}
 }

--- a/src/util/stream.h
+++ b/src/util/stream.h
@@ -36,12 +36,13 @@ public:
 			// Break line before starting a new UTF-8 character.
 			sync();
 			buffer[buffer_index++] = c;
-		} else {
-			// Normal case: append character, flush if necessary
-			buffer[buffer_index++] = c;
-			if (free_before_write == 1)
-				sync();
+			return;
 		}
+
+		// Normal case: append character, flush if necessary
+		buffer[buffer_index++] = c;
+		if (free_before_write == 1)
+			sync();
 	}
 
 	std::streamsize xsputn(const char *s, std::streamsize n) override {

--- a/src/util/stream.h
+++ b/src/util/stream.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <string_view>
 #include <functional>
+#include "util/string.h" // IS_UTF8_MULTB_START
 
 template<unsigned int BufferLength, typename Emitter = std::function<void(std::string_view)> >
 class StringStreamBuffer : public std::streambuf {
@@ -32,7 +33,7 @@ public:
 		if (free_before_write < 10 && std::isspace(c)) {
 			// Break line before space character.
 			sync();
-		} else if (free_before_write < 4 && ((unsigned char)c & 0b11000000) == 0b11000000) {
+		} else if (free_before_write < 4 && IS_UTF8_MULTB_START(c)) {
 			// Break line before starting a new UTF-8 character.
 			sync();
 			buffer[buffer_index++] = c;

--- a/src/util/stream.h
+++ b/src/util/stream.h
@@ -12,6 +12,7 @@ template<unsigned int BufferLength, typename Emitter = std::function<void(std::s
 class StringStreamBuffer : public std::streambuf {
 public:
 	StringStreamBuffer(Emitter emitter) : m_emitter(emitter) {
+		static_assert(BufferLength > 10, "Line splitting requires larger buffer");
 		buffer_index = 0;
 	}
 
@@ -25,11 +26,21 @@ public:
 		// emit only complete lines, or if the buffer is full
 		if (c == '\n') {
 			sync();
-		} else {
+			return;
+		}
+		const size_t free_before_write = BufferLength - buffer_index;
+		if (free_before_write < 10 && std::isspace(c)) {
+			// Break line before space character.
+			sync();
+		} else if (free_before_write < 4 && ((unsigned char)c & 0b11000000) == 0b11000000) {
+			// Break line before starting a new UTF-8 character.
+			sync();
 			buffer[buffer_index++] = c;
-			if (buffer_index >= BufferLength) {
+		} else {
+			// Normal case: append character, flush if necessary
+			buffer[buffer_index++] = c;
+			if (free_before_write == 1)
 				sync();
-			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #17438

## To do

This PR is Ready for Review.

## How to test

1. `//lua core.chat_send_all(string.rep("\xe2\x97\x8b", 300))` and observe A) stdout and B) debug.txt
2. `//lua core.chat_send_all(string.rep("helloworld ", 100))` and observe A) stdout and B) debug.txt

The lines must be split *better*.