### PR TITLE
DevTest: Remove invalid visual_scale test nodes

### DIFF
--- a/games/devtest/mods/testnodes/drawtypes.lua
+++ b/games/devtest/mods/testnodes/drawtypes.lua
@@ -718,8 +718,6 @@ local allfaces_newsize_tt = ""..
 	S("* 'opaque': opaque")
 
 scale("allfaces", S("Transparent node"))
-scale("allfaces_optional", allfaces_newsize_tt)
-scale("allfaces_optional_waving", allfaces_newsize_tt .. "\n" .. S("Waving if waving leaves are enabled by client"))
 scale("plantlike")
 scale("plantlike_wallmounted")
 scale("torchlike_wallmounted")


### PR DESCRIPTION
As of 5.17.0-rc1, launching DevTest gives the following warnings:

> WARNING[ServerStart]: Node testnodes:allfaces_optional_double specifies visual_scale, but the selected drawtype does not support it.
> WARNING[ServerStart]: Node testnodes:allfaces_optional_half specifies visual_scale, but the selected drawtype does not support it.
> WARNING[ServerStart]: Node testnodes:allfaces_optional_waving_double specifies visual_scale, but the selected drawtype does not support it.
> WARNING[ServerStart]: Node testnodes:allfaces_optional_waving_half specifies visual_scale, but the selected drawtype does not support it.

Thus, this PR removes the following nodes from DevTest:

* `testnodes:allfaces_optional_double`
* `testnodes:allfaces_optional_half`
* `testnodes:allfaces_optional_waving_double`
* `testnodes:allfaces_optional_waving_half`

This will fix the warnings.

Reason: These nodes use a custom `visual_scale` of 2.0 (double) or 0.5 (half) which is not (or no longer) officially supported for `allfaces_optional` nodes, according to `lua_api.md`.