### PR TITLE
Update builtin help formspec with search and new look

### DIFF
--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -11,20 +11,20 @@ local LIST_FORMSPEC = [[
 	]]
 
 local LIST_FORMSPEC_DESCRIPTION = [[
-		size[13,9.65]
+		size[13,7.5]
 		label[0,-0.1;%s]
 		tablecolumns[color;tree;text;text]
-		table[0,0.5;12.8,4.5;list;%s;%i]
-		box[0,5.05;12.8,1;]
-		textarea[0.35,5.1;12.9,1;;;%s]
+		table[0,0.5;12.8,4.8;list;%s;%i]
+		box[0,5.5;12.8,1.5;]
+		textarea[0.35,5.55;12.9,1.7;;;%s]
 		field_close_on_enter[search_text;false]
-		field[0.3,7.55;8.9,0.8;search_text;;%s]
+		field[7,0.05;4.95,0.8;search_text;;%s]
 		field_enter_after_edit[search_text;true]
-		image_button[9.3,7.27;0.85,0.85;search.png;btn_search;]
-		image_button[10.2,7.27;0.85,0.85;clear.png;btn_clear;]
+		image_button[11.5,-0.25;0.8,0.8;search.png;btn_search;]
+		image_button[12.15,-0.25;0.8,0.8;clear.png;btn_clear;]
 		tooltip[btn_search;%s]
 		tooltip[btn_clear;%s]
-		button_exit[5,8.6;3,1;quit;%s]
+		button_exit[5,7;3,1;quit;%s]
 	]]
 
 local F = core.formspec_escape

--- a/builtin/common/information_formspecs.lua
+++ b/builtin/common/information_formspecs.lua
@@ -11,19 +11,38 @@ local LIST_FORMSPEC = [[
 	]]
 
 local LIST_FORMSPEC_DESCRIPTION = [[
-		size[13,7.5]
+		size[13,9.65]
 		label[0,-0.1;%s]
 		tablecolumns[color;tree;text;text]
-		table[0,0.5;12.8,4.8;list;%s;%i]
-		box[0,5.5;12.8,1.5;]
-		textarea[0.35,5.55;12.9,1.7;;;%s]
-		button_exit[5,7;3,1;quit;%s]
+		table[0,0.5;12.8,4.5;list;%s;%i]
+		box[0,5.05;12.8,1;]
+		textarea[0.35,5.1;12.9,1;;;%s]
+		field_close_on_enter[search_text;false]
+		field[0.3,7.55;8.9,0.8;search_text;;%s]
+		field_enter_after_edit[search_text;true]
+		image_button[9.3,7.27;0.85,0.85;search.png;btn_search;]
+		image_button[10.2,7.27;0.85,0.85;clear.png;btn_clear;]
+		tooltip[btn_search;%s]
+		tooltip[btn_clear;%s]
+		button_exit[5,8.6;3,1;quit;%s]
 	]]
 
 local F = core.formspec_escape
 local S = core.get_translator("__builtin")
 local check_player_privs = core.check_player_privs
 
+-- Mirrors format_help_line() in chatcommands.lua so /help <cmd> and double-click match
+local function format_help_line(cmd, def)
+	local cmd_marker = INIT == "client" and "." or "/"
+	local msg = core.colorize("#00ffff", cmd_marker .. cmd)
+	if def.params and def.params ~= "" then
+		msg = msg .. " " .. def.params
+	end
+	if def.description and def.description ~= "" then
+		msg = msg .. ": " .. def.description
+	end
+	return msg
+end
 
 -- CHAT COMMANDS FORMSPEC
 
@@ -50,7 +69,38 @@ end
 
 core.after(0, load_mod_command_tree)
 
-local function build_chatcommands_formspec(name, sel, copy)
+-- Returns cmds whose name contains `search`, flattened across all mods and sorted by cmd name
+local function get_flat_matches(search)
+	local search_lc = search:lower()
+	local matches = {}
+	for _, mod_data in ipairs(mod_cmds) do
+		for _, cmd in ipairs(mod_data[2]) do
+			if cmd[1]:lower():find(search_lc, 1, true) then
+				matches[#matches + 1] = cmd
+			end
+		end
+	end
+	table.sort(matches, function(a, b) return a[1] < b[1] end)
+	return matches
+end
+
+-- Per-player current search text for the help formspec.
+local current_search = {}
+local CLIENT_SEARCH_KEY = "client" -- for singleplayer
+
+if INIT ~= "client" then
+	core.register_on_leaveplayer(function(player)
+		current_search[player:get_player_name()] = nil
+	end)
+end
+
+local function build_chatcommands_formspec(name, sel, copy, search)
+	local search_key = name or CLIENT_SEARCH_KEY
+	if search == nil then
+		search = current_search[search_key] or ""
+	end
+	current_search[search_key] = search
+
 	local rows = {}
 	rows[1] = "#FFF,0,"..F(S("Command"))..","..F(S("Parameters"))
 
@@ -58,24 +108,43 @@ local function build_chatcommands_formspec(name, sel, copy)
 		.. "any entry in the list.").. "\n" ..
 		S("Double-click to copy the entry to the chat history.")
 
-	for i, data in ipairs(mod_cmds) do
-		rows[#rows + 1] = COLOR_BLUE .. ",0," .. F(data[1]) .. ","
-		for j, cmds in ipairs(data[2]) do
+	-- Handle a matched entry: show its description, and copy it to chat if requested.
+	local function handle_selected(cmds)
+		description = cmds[2].description
+		if search ~= "" then
+			description = S("From mod: @1", cmds[2].mod_origin) .. "\n" .. description
+		end
+		if copy then
+			local msg = format_help_line(cmds[1], cmds[2])
+			if INIT == "client" then
+				core.display_chat_message(msg)
+			else
+				core.chat_send_player(name, msg)
+			end
+		end
+	end
+
+	if search == "" then
+		for i, data in ipairs(mod_cmds) do
+			rows[#rows + 1] = COLOR_BLUE .. ",0," .. F(data[1]) .. ","
+			for j, cmds in ipairs(data[2]) do
+				local has_priv = INIT == "client" or check_player_privs(name, cmds[2].privs)
+				rows[#rows + 1] = ("%s,1,%s,%s"):format(
+					has_priv and COLOR_GREEN or COLOR_GRAY,
+					cmds[1], F(cmds[2].params))
+				if sel == #rows then
+					handle_selected(cmds)
+				end
+			end
+		end
+	else -- filter and show only list of commands, flattened
+		for _, cmds in ipairs(get_flat_matches(search)) do
 			local has_priv = INIT == "client" or check_player_privs(name, cmds[2].privs)
-			rows[#rows + 1] = ("%s,1,%s,%s"):format(
+			rows[#rows + 1] = ("%s,0,%s,%s"):format(
 				has_priv and COLOR_GREEN or COLOR_GRAY,
 				cmds[1], F(cmds[2].params))
 			if sel == #rows then
-				description = cmds[2].description
-				if copy then
-					local msg = S("Command: @1 @2",
-						core.colorize("#0FF", (INIT == "client" and "." or "/") .. cmds[1]), cmds[2].params)
-					if INIT == "client" then
-						core.display_chat_message(msg)
-					else
-						core.chat_send_player(name, msg)
-					end
-				end
+				handle_selected(cmds)
 			end
 		end
 	end
@@ -83,7 +152,10 @@ local function build_chatcommands_formspec(name, sel, copy)
 	return LIST_FORMSPEC_DESCRIPTION:format(
 			F(S("Available commands: (see also: /help <cmd>)")),
 			table.concat(rows, ","), sel or 0,
-			F(description), F(S("Close"))
+			F(description),
+			F(search),
+			F(S("Search")), F(S("Clear")),
+			F(S("Close"))
 		)
 end
 
@@ -115,6 +187,17 @@ local function build_privs_formspec(name)
 end
 
 
+-- Returns the new search text if `fields` is a search/clear action, else nil
+local function get_requested_search(fields)
+	if fields.btn_clear then
+		return ""
+	end
+	if fields.btn_search or fields.key_enter_field == "search_text" then
+		return fields.search_text or ""
+	end
+	return nil
+end
+
 -- DETAILED CHAT COMMAND INFORMATION
 if INIT == "client" then
 	core.register_on_formspec_input(function(formname, fields)
@@ -122,8 +205,12 @@ if INIT == "client" then
 			return
 		end
 
+		local search = get_requested_search(fields)
 		local event = core.explode_table_event(fields.list)
-		if event.type ~= "INV" then
+		if search ~= nil then
+			core.show_formspec("__builtin:help_cmds",
+				build_chatcommands_formspec(nil, nil, false, search))
+		elseif event.type ~= "INV" then
 			core.show_formspec("__builtin:help_cmds",
 				build_chatcommands_formspec(nil, event.row, event.type == "DCL"))
 		end
@@ -134,9 +221,13 @@ else
 			return
 		end
 
+		local name = player:get_player_name()
+		local search = get_requested_search(fields)
 		local event = core.explode_table_event(fields.list)
-		if event.type ~= "INV" then
-			local name = player:get_player_name()
+		if search ~= nil then
+			core.show_formspec(name, "__builtin:help_cmds",
+				build_chatcommands_formspec(name, nil, false, search))
+		elseif event.type ~= "INV" then
 			core.show_formspec(name, "__builtin:help_cmds",
 				build_chatcommands_formspec(name, event.row, event.type == "DCL"))
 		end
@@ -146,10 +237,10 @@ end
 function core.show_general_help_formspec(name)
 	if INIT == "client" then
 		core.show_formspec("__builtin:help_cmds",
-			build_chatcommands_formspec(name))
+			build_chatcommands_formspec(nil, nil, false, ""))
 	else
 		core.show_formspec(name, "__builtin:help_cmds",
-			build_chatcommands_formspec(name))
+			build_chatcommands_formspec(name, nil, false, ""))
 	end
 end
 


### PR DESCRIPTION
- Goal of the PR
  - To improve the built-in /help formspec
- How does the PR work?
  - Add search field and filtering by command
  - When a term is entered only matching commands are shown
  - When selecting a command with search results, show which mod the command is in info (see screenshot)
  - When double clicking a command, show the extended info in the chat
- Does it resolve any reported issue?
  -  Not that i know of
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
  - Possibly UI improvements, but not really.
- If not a bug fix, why is this PR needed? What usecases does it solve?
  - Servers with lots of mods may have a lot of commands, making it hard to find any help
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  Please refer to the [AI policy](https://github.com/luanti-org/luanti/blob/master/doc/developing/ai_policy.md).
  - All code written by me. Used Claude to double check my logic on some things + to find bugs. 

## To do

This PR is a Ready for Review.

## How to test
- Start a game (preferably with a lot of mods)
- Type `/help` in chat to see new formspec
- Test it out

## Screenshots

<details>

<summary>No search term</summary>


<img width="962" height="722" alt="26-08-27-17-26-31-Luanti_5 17 0-dev-d17bfd815-dirty_ Singleplayer _" src="https://github.com/user-attachments/assets/2bb709ed-d829-49ae-a1c1-9adda51da8aa" />

</details>

<details>

<summary>With a search term and command selected</summary>

<img width="962" height="722" alt="26-08-27-17-26-37-Luanti_5 17 0-dev-d17bfd815-dirty_ Singleplayer _" src="https://github.com/user-attachments/assets/79a79a5a-f2fd-4821-b96a-daf37ad14eeb" />

</details>


<details>

<summary>Large screen appearance</summary>

<img width="2560" height="1369" alt="26-08-27-17-26-42-Luanti_5 17 0-dev-d17bfd815-dirty_ Singleplayer _" src="https://github.com/user-attachments/assets/46ebf683-e232-4c99-95bd-19ae92a4cd5f" />

</details>