### PR TITLE
Node placement prediction light workaround

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -176,10 +176,9 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 	// Remove node metadata
 	if (remove_metadata) {
 		removeNodeMetadata(p);
+	} else if (n == oldnode) {
+		return; // Nothing changed
 	}
-
-	if (n == oldnode)
-		return;
 
 	// Set the node on the map
 	ContentLightingFlags f = m_nodedef->getLightingFlags(n);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -178,6 +178,9 @@ void Map::addNodeAndUpdate(v3s16 p, MapNode n,
 		removeNodeMetadata(p);
 	}
 
+	if (n == oldnode)
+		return;
+
 	// Set the node on the map
 	ContentLightingFlags f = m_nodedef->getLightingFlags(n);
 	ContentLightingFlags oldf = m_nodedef->getLightingFlags(oldnode);

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1224,19 +1224,21 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 
 		getClient(peer_id)->m_time_from_building = 0;
 
-		// If item has node placement prediction, always send the
-		// blocks to make sure the client knows what exactly happened
-		RemoteClient *client = getClient(peer_id);
-		v3s16 blockpos = getNodeBlockPos(pointed.node_abovesurface);
-		v3s16 blockpos2 = getNodeBlockPos(pointed.node_undersurface);
+		// If item has node placement prediction, always send a swap node event,
+		// since the client can never be sure that the prediction was right.
+		// It will trigger Client::addNode to fully revert the prediction if needed.
 		if (had_prediction) {
-			client->SetBlockNotSent(blockpos);
-			if (blockpos2 != blockpos)
-				client->SetBlockNotSent(blockpos2);
-		} else {
-			client->ResendBlockIfOnWire(blockpos);
-			if (blockpos2 != blockpos)
-				client->ResendBlockIfOnWire(blockpos2);
+			auto &map = m_env->getMap();
+			MapEditEvent event_above;
+			event_above.type = MEET_SWAPNODE;
+			event_above.p = pointed.node_abovesurface;
+			event_above.n = map.getNode(pointed.node_abovesurface);
+			map.dispatchEvent(event_above);
+			MapEditEvent event_under;
+			event_under.type = MEET_SWAPNODE;
+			event_under.p = pointed.node_undersurface;
+			event_under.n = map.getNode(pointed.node_undersurface);
+			map.dispatchEvent(event_under);
 		}
 
 		return;

--- a/src/network/serverpackethandler.cpp
+++ b/src/network/serverpackethandler.cpp
@@ -1224,21 +1224,11 @@ void Server::handleCommand_Interact(NetworkPacket *pkt)
 
 		getClient(peer_id)->m_time_from_building = 0;
 
-		// If item has node placement prediction, always send a swap node event,
-		// since the client can never be sure that the prediction was right.
-		// It will trigger Client::addNode to fully revert the prediction if needed.
+		// If item has node placement prediction, always re-send the two affected nodes,
+		// since we (the server) can never be sure that the prediction was right.
 		if (had_prediction) {
-			auto &map = m_env->getMap();
-			MapEditEvent event_above;
-			event_above.type = MEET_SWAPNODE;
-			event_above.p = pointed.node_abovesurface;
-			event_above.n = map.getNode(pointed.node_abovesurface);
-			map.dispatchEvent(event_above);
-			MapEditEvent event_under;
-			event_under.type = MEET_SWAPNODE;
-			event_under.p = pointed.node_undersurface;
-			event_under.n = map.getNode(pointed.node_undersurface);
-			map.dispatchEvent(event_under);
+			sendNodePredictionFixup(peer_id, pointed.node_abovesurface);
+			sendNodePredictionFixup(peer_id, pointed.node_undersurface);
 		}
 
 		return;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2464,6 +2464,15 @@ void Server::sendAddNode(v3s16 p, MapNode n, std::unordered_set<u16> *far_player
 	sendNodeChangePkt(pkt, block_pos, p_f, far_d_nodes, far_players);
 }
 
+void Server::sendNodePredictionFixup(session_t peer_id, v3s16 pos)
+{
+	MapNode n = m_env->getMap().getNode(pos);
+	NetworkPacket pkt(TOCLIENT_ADDNODE, 6 + 2 + 1 + 1 + 1);
+	pkt << pos << n.param0 << n.param1 << n.param2
+			<< (u8) 1; // keep metadata
+	Send(peer_id, &pkt);
+}
+
 void Server::sendNodeChangePkt(NetworkPacket &pkt, v3s16 block_pos,
 		v3f p, float far_d_nodes, std::unordered_set<u16> *far_players)
 {

--- a/src/server.h
+++ b/src/server.h
@@ -591,6 +591,9 @@ private:
 	// Sends blocks to clients (locks env and con on its own)
 	void SendBlocks(float dtime);
 
+	// Re-sends a single node to a single client
+	void sendNodePredictionFixup(session_t peer_id, v3s16 pos);
+
 	bool addMediaFile(const std::string &filename, const std::string &filepath,
 			std::string *filedata = nullptr, std::string *digest = nullptr);
 	void fillMediaCache();


### PR DESCRIPTION
Closes #17497

If the node placement prediction is wrong the updated light does not get reverted for bordering mapblocks.
To reproduce the bug see "How to test".

This PR fixes the bug and is needed to make #17407 work on node placements too. (Without getting the modified block information from elsewhere.)

~It triggers swap node events instead of resending the mapblocks.~ Just sends `TOCLIENT_ADDNODE`.  This may also have other benefits, like less data to send over the network.

### Screenshot of the bug

<img width="1920" height="1021" alt="Bildschirmfoto_2026-08-16_18-26-25" src="https://github.com/user-attachments/assets/295535f0-97cd-4b89-856c-4832c48d1811" />

## To do

Ready for Review.

## How to test

Try to place this node in a dark area next to a mapblock border.

``` Lua
minetest.register_node(":default:cobble2", {
	description = "Cobblestone2",
	tiles = {"default_cobble.png"},
	paramtype = "light",
	light_source = 15,
	is_ground_content = false,
	groups = {cracky = 3, stone = 2},
	on_place = function(itemstack, placer, pointed_thing)
		return itemstack
	end
})
```
