### PR TITLE
Restrict (SS)CSM access to `collectgarbage`

### DIFF
--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -160,7 +160,8 @@ Functions that take or return paths always use virtual paths.
 ### Lua standard library
 
 * `assert`
-* `collectgarbage`
+* `collectgarbage("count")`
+  * Other modes are unsupported and will do nothing and return nothing.
 * `error`
 * `ipairs`
 * `next`

--- a/doc/sscsm_api.md
+++ b/doc/sscsm_api.md
@@ -161,7 +161,7 @@ Functions that take or return paths always use virtual paths.
 
 * `assert`
 * `collectgarbage("count")`
-  * Other modes are unsupported and will do nothing and return nothing.
+  * Rounded, other modes are unsupported and will do nothing and return nothing.
 * `error`
 * `ipairs`
 * `next`

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -38,7 +38,9 @@ setting to anything higher than `localhost`.
 * See also `initializeSecuritySSCSM()`.
 * We do not trust the Lua implementation to not have bugs. => Additional process
   isolation layer as fallback.
-
+* Scripts cannot control GC, since this is a common primitive used in Lua
+sandbox escapes in order to get a desired heap layout, this a defense
+in depth measure to make escapes harder.
 
 ## Process isolation
 

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -38,9 +38,9 @@ setting to anything higher than `localhost`.
 * See also `initializeSecuritySSCSM()`.
 * We do not trust the Lua implementation to not have bugs. => Additional process
   isolation layer as fallback.
-* Scripts cannot control GC, since this is a common primitive used in Lua
-sandbox escapes in order to get a desired heap layout, this a defense
-in depth measure to make escapes harder.
+ * Scripts cannot control GC (Garbage Collector), since this is a common primitive
+   used in Lua sandbox escapes in order to get a desired heap layout, this a defense
+   in depth measure to make escapes harder.
 
 ## Process isolation
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -345,7 +345,6 @@ void ScriptApiSecurity::initializeSecurityClient()
 	static const char *whitelist[] = {
 		"assert",
 		"core",
-		"collectgarbage",
 		"DIR_DELIM",
 		"error",
 		"ipairs",
@@ -429,6 +428,7 @@ void ScriptApiSecurity::initializeSecurityClient()
 	SECURE_API(g, loadfile);
 	SECURE_API(g, loadstring);
 	SECURE_API(g, require);
+	SECURE_API(g, collectgarbage);
 	lua_pop(L, 2);
 
 
@@ -473,7 +473,6 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	static const char *whitelist[] = {
 		"assert",
 		"core",
-		"collectgarbage",
 		"DIR_DELIM",
 		"error",
 		"ipairs",
@@ -555,6 +554,7 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	SECURE_API(g, loadfile);
 	SECURE_API(g, loadstring);
 	SECURE_API(g, require);
+	SECURE_API(g, collectgarbage);
 	lua_pop(L, 2);
 
 
@@ -1025,6 +1025,18 @@ int ScriptApiSecurity::sl_g_require(lua_State *L)
 {
 	lua_pushliteral(L, "require() is disabled when mod security is on.");
 	return lua_error(L);
+}
+
+int ScriptApiSecurity::sl_g_collectgarbage(lua_State *L)
+{
+	if (!lua_isnoneornil(L, 1) && readParam<std::string_view>(L, 1) == "count") {
+		const int lo = lua_gc(L, LUA_GCCOUNT,  0);
+		const int hi = lua_gc(L, LUA_GCCOUNTB, 0);
+		lua_pushnumber(L, lo + ((lua_Number)hi/1024));
+		return 1;
+	}
+	// do nothing instead of throwing so mods can more easily re-use code between server and client
+	return 0;
 }
 
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -1030,9 +1030,9 @@ int ScriptApiSecurity::sl_g_require(lua_State *L)
 int ScriptApiSecurity::sl_g_collectgarbage(lua_State *L)
 {
 	if (!lua_isnoneornil(L, 1) && readParam<std::string_view>(L, 1) == "count") {
-		const int hi = lua_gc(L, LUA_GCCOUNT,  0);
-		const int lo = lua_gc(L, LUA_GCCOUNTB, 0);
-		lua_pushnumber(L, hi + ((lua_Number)lo/1024));
+		const int kb = lua_gc(L, LUA_GCCOUNT, 0);
+		const int bytes = lua_gc(L, LUA_GCCOUNTB, 0);
+		lua_pushnumber(L, kb + ((lua_Number)bytes/1024));
 		return 1;
 	}
 	// do nothing instead of throwing so mods can more easily re-use code between server and client

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -1031,8 +1031,7 @@ int ScriptApiSecurity::sl_g_collectgarbage(lua_State *L)
 {
 	if (!lua_isnoneornil(L, 1) && readParam<std::string_view>(L, 1) == "count") {
 		const int kb = lua_gc(L, LUA_GCCOUNT, 0);
-		const int bytes = lua_gc(L, LUA_GCCOUNTB, 0);
-		lua_pushnumber(L, kb + ((lua_Number)bytes/1024));
+		lua_pushinteger(L, kb); // rounded (floor) to a kilobyte
 		return 1;
 	}
 	// do nothing instead of throwing so mods can more easily re-use code between server and client

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -1030,9 +1030,9 @@ int ScriptApiSecurity::sl_g_require(lua_State *L)
 int ScriptApiSecurity::sl_g_collectgarbage(lua_State *L)
 {
 	if (!lua_isnoneornil(L, 1) && readParam<std::string_view>(L, 1) == "count") {
-		const int lo = lua_gc(L, LUA_GCCOUNT,  0);
-		const int hi = lua_gc(L, LUA_GCCOUNTB, 0);
-		lua_pushnumber(L, lo + ((lua_Number)hi/1024));
+		const int hi = lua_gc(L, LUA_GCCOUNT,  0);
+		const int lo = lua_gc(L, LUA_GCCOUNTB, 0);
+		lua_pushnumber(L, hi + ((lua_Number)lo/1024));
 		return 1;
 	}
 	// do nothing instead of throwing so mods can more easily re-use code between server and client

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -111,6 +111,7 @@ private:
 	static int sl_g_loadfile(lua_State *L);
 	static int sl_g_loadstring(lua_State *L);
 	static int sl_g_require(lua_State *L);
+	static int sl_g_collectgarbage(lua_State *L);
 
 	static int sl_io_open(lua_State *L);
 	static int sl_io_input(lua_State *L);


### PR DESCRIPTION
Resolves #17457, related to the roadmap in so far as it's related to SSCSM. Not a bug fix but should make it harder to write sandbox escapes against CSCSM/SSCSM sandbox.

Eventually SSCSM is meant to be put behind an OS level sandbox, but it's best to assume there might be flaws in that and try to keep the in-process sandbox secure.

This change cannot be made for the server environment as mods might already exist that depend on control over the GC for performance, this should be less of an issue for CSM since code there will need to work on a wide range of devices and there isn't pre-existing code for it that depends on manual memory management control. As such it's only been applied to the two CSM sandboxes. 

For the sake of compatibility, using unsupported arguments will just return nil instead of throwing an error, under the assumption most code that does use collectgarbage does not depend on the return value of calls into it.

collectgarbage("count") is retained so mods can still check their memory usage, this is a minor data leak and could be used to detect when a GC occurred but it seems somewhat useful?