### PR TITLE
Add automatic world screenshots

### DIFF
--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -156,12 +156,15 @@ local function file_exists(path)
 end
 
 local function get_world_screenshot(world)
-	local path = world.path .. DIR_DELIM .. "exit_screenshot.png"
+	local path = world.path .. DIR_DELIM .. "screenshot.png"
 	if file_exists(path) then
 		return path
-	else
-		return defaulttexturedir .. "no_screenshot.png"
 	end
+	path = world.path .. DIR_DELIM .. "exit_screenshot.png"
+	if file_exists(path) then
+		return path
+	end
+	return defaulttexturedir .. "no_screenshot.png"
 end
 
 local function get_formspec(tabview, name, tabdata)
@@ -280,7 +283,7 @@ local function get_formspec(tabview, name, tabdata)
 
 		retval = retval .. "container_end[]"
 	elseif world then
-		local screenshot = world.screenshot or defaulttexturedir .. "no_screenshot.png"
+		local screenshot = get_world_screenshot(world)
 		retval = retval ..
 				"image[10,2.09167;5.25,3.58333;" .. core.formspec_escape(screenshot) .. "]"
 

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -205,46 +205,45 @@ local function get_formspec(tabview, name, tabdata)
 		end
 	end
 
-	retval = retval .. "container[5.25,4.875]"
+	retval = retval .. "container[0.25,5.925]"
 	if world then
 		retval = retval ..
-				"button[0,0;3.225,0.8;world_delete;".. fgettext("Delete") .. "]" ..
-				"button[3.325,0;3.225,0.8;world_configure;".. fgettext("Select Mods") .. "]"
+				"button[0,0;2.916,0.8;world_delete;".. fgettext("Delete") .. "]" ..
+				"button[3.166,0;2.916,0.8;world_configure;".. fgettext("Select Mods") .. "]"
 	end
 	retval = retval ..
-			"button[6.65,0;3.225,0.8;world_create;".. fgettext("New") .. "]" ..
+			"button[6.332,0;2.916,0.8;world_create;".. fgettext("New") .. "]" ..
 			"container_end[]" ..
-			"container[0.375,0.375]" ..
+			"container[0.25,0.25]" ..
+			"label[0,0.2;".. fgettext("Select World:") .. "]"..
+			"textlist[0,0.5;9.25,4.925;sp_worlds;" ..
+			menu_render_worldlist() ..
+			";" .. index .. "]" ..
+			"container_end[]"..
+			"container[10,0.375]" ..
+			"box[-0.25,-0.375;5.75,7.1;#666666]" ..
 			creative ..
 			damage ..
 			host ..
-			"container_end[]" ..
-			"container[5.25,0.375]" ..
-			"label[0,0.2;".. fgettext("Select World:") .. "]"..
-			"textlist[0,0.5;9.875,3.9;sp_worlds;" ..
-			menu_render_worldlist() ..
-			";" .. index .. "]" ..
 			"container_end[]"
 
 	if core.settings:get_bool("enable_server") and disabled_settings["enable_server"] == nil then
 		retval = retval ..
-				"button[10.1875,5.925;4.9375,0.8;play;".. fgettext("Host Game") .. "]" ..
-				"container[0.375,0.375]" ..
+				"container[10,0.375]" ..
+				"button[0,5.55;5.25,0.8;play;".. fgettext("Host Game") .. "]" ..
 				"checkbox[0,"..y..";cb_server_announce;" .. fgettext("Announce Server") .. ";" ..
 				dump(core.settings:get_bool("server_announce")) .. "]"
 
 		-- Reset y so that the text fields always start at the same position,
 		-- regardless of whether some of the checkboxes are hidden.
-		y = 0.2 + 4 * yo + 0.35
+		y = 0.2 + 4 * yo + 0.1
 
-		retval = retval .. "field[0," .. y .. ";4.5,0.75;te_playername;" .. fgettext("Name") .. ";" ..
+		retval = retval .. "field[0," .. y .. ";2.625,0.75;te_playername;" .. fgettext("Name") .. ";" ..
 				core.formspec_escape(current_name) .. "]"
 
-		y = y + 1.15 + 0.25
+		retval = retval .. "pwdfield[2.625," .. y .. ";2.625,0.755;te_passwd;" .. fgettext("Password") .. "]"
 
-		retval = retval .. "pwdfield[0," .. y .. ";4.5,0.75;te_passwd;" .. fgettext("Password") .. "]"
-
-		y = y + 1.15 + 0.25
+		y = y + 1.15
 
 		local bind_addr = core.settings:get("bind_address")
 		if bind_addr ~= nil and bind_addr ~= "" then
@@ -256,14 +255,18 @@ local function get_formspec(tabview, name, tabdata)
 				core.formspec_escape(current_port) .. "]"
 		else
 			retval = retval ..
-				"field[0," .. y .. ";4.5,0.75;te_serverport;" .. fgettext("Server Port") .. ";" ..
+				"field[0," .. y .. ";5.25,0.75;te_serverport;" .. fgettext("Server Port") .. ";" ..
 				core.formspec_escape(current_port) .. "]"
 		end
 
 		retval = retval .. "container_end[]"
 	elseif world then
+		local screenshot = world.screenshot or defaulttexturedir .. "no_screenshot.png"
 		retval = retval ..
-				"button[10.1875,5.925;4.9375,0.8;play;" .. fgettext("Play Game") .. "]"
+				"image[10,2.09167;5.25,3.58333;" .. core.formspec_escape(screenshot) .. "]"
+
+		retval = retval ..
+				"button[10,5.925;5.25,0.8;play;" .. fgettext("Play Game") .. "]"
 	end
 
 	return retval

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -147,12 +147,11 @@ end
 
 local function file_exists(path)
 	local f = io.open(path, "r")
-	if f ~= nil then
-		io.close(f)
+	if f then
+		f:close()
 		return true
-	else
-		return false
 	end
+	return false
 end
 
 local function get_world_screenshot(world)

--- a/builtin/mainmenu/tab_local.lua
+++ b/builtin/mainmenu/tab_local.lua
@@ -145,6 +145,25 @@ local function get_disabled_settings(game)
 	return disabled_settings
 end
 
+local function file_exists(path)
+	local f = io.open(path, "r")
+	if f ~= nil then
+		io.close(f)
+		return true
+	else
+		return false
+	end
+end
+
+local function get_world_screenshot(world)
+	local path = world.path .. DIR_DELIM .. "exit_screenshot.png"
+	if file_exists(path) then
+		return path
+	else
+		return defaulttexturedir .. "no_screenshot.png"
+	end
+end
+
 local function get_formspec(tabview, name, tabdata)
 
 	-- Point the player to ContentDB when no games are found

--- a/doc/world_format.md
+++ b/doc/world_format.md
@@ -21,16 +21,18 @@ Currently, the authentication and ban data is stored on a per-world basis.
 It can be copied over from an old world to a newly created world.
 
     World
-    ├── auth.txt ───── Authentication data
-    ├── auth.sqlite ── Authentication data (SQLite alternative)
-    ├── env_meta.txt ─ Environment metadata
-    ├── ipban.txt ──── Banned IPs/users
-    ├── map_meta.txt ─ Map metadata
-    ├── map.sqlite ─── Map data
-    ├── players ────── Player directory
-    │   │── player1 ── Player file
-    │   └── Foo ────── Player file
-    └── world.mt ───── World metadata
+    ├── auth.txt ──────────── Authentication data
+    ├── auth.sqlite ───────── Authentication data (SQLite alternative)
+    ├── env_meta.txt ──────── Environment metadata
+    ├── ipban.txt ─────────── Banned IPs/users
+    ├── map_meta.txt ──────── Map metadata
+    ├── map.sqlite ────────── Map data
+    ├── screenshot.png ────── Manual world screenshot, takes priority
+    ├── exit_screenshot.png ─ Automatic screenshot
+    ├── players ───────────── Player directory
+    │   │── player1 ───────── Player file
+    │   └── Foo ───────────── Player file
+    └── world.mt ──────────── World metadata
 
 ## `auth.txt`
 

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -2004,7 +2004,7 @@ void Client::makeScreenshot()
 {
 	video::IVideoDriver *driver = m_rendering_engine->get_video_driver();
 	std::string filename;
-	if (takeScreenshot(driver, filename)) {
+	if (takeScreenshotAutoName(driver, filename)) {
 		std::string msg = fmtgettext("Saved screenshot to \"%s\"", filename.c_str());
 		pushToChatQueue(new ChatMessage(CHATMESSAGE_TYPE_SYSTEM,
 				utf8_to_wide(msg)));

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -44,6 +44,8 @@
 #include "util/basic_macros.h"
 #include "util/directiontables.h"
 #include "util/quicktune_shortcutter.h"
+#include "util/screenshot.h"
+#include "filesys.h"
 #include "version.h"
 #include "script/scripting_client.h"
 #include "hud.h"
@@ -600,6 +602,8 @@ void Game::run()
 
 	framemarker.end();
 
+	takeWorldScreenshotOnExit();
+
 #ifdef __ANDROID__
 	porting::setPlayingNowNotification(false);
 #endif
@@ -674,6 +678,36 @@ void Game::shutdown()
 	stop_thread->rethrow();
 
 	// to be continued in Game::~Game
+}
+
+void Game::takeWorldScreenshotOnExit()
+{
+	if (!server)
+		return;
+
+	const std::string world_path = server->getWorldPath();
+	if (world_path.empty())
+		return;
+
+	auto *gui_root = guienv ? guienv->getRootGUIElement() : nullptr;
+	const bool gui_was_visible = gui_root ? gui_root->isVisible() : false;
+	if (gui_root)
+		gui_root->setVisible(false);
+
+	const std::string screenshot_path = world_path + DIR_DELIM + "exit_screenshot.png";
+	m_game_ui->m_flags.show_hud = false;
+	m_game_ui->m_flags.show_profiler_graph = false;
+	runData.damage_flash = 0.0f;
+
+	ProfilerGraph graph;
+	RunStats stats = {};
+	// For some reason, this needs to draw twice to not get a stale frame
+	drawScene(&graph, &stats);
+	drawScene(&graph, &stats);
+	takeScreenshotToPath(driver, screenshot_path);
+
+	if (gui_root)
+		gui_root->setVisible(gui_was_visible);
 }
 
 

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -224,6 +224,7 @@ protected:
 	// Misc
 	void showOverlayMessage(const char *msg, float dtime, int percent,
 			float *indef_pos = nullptr);
+	void takeWorldScreenshotOnExit();
 
 	inline bool fogEnabled()
 	{

--- a/src/gui/guiEngine.cpp
+++ b/src/gui/guiEngine.cpp
@@ -383,7 +383,7 @@ void GUIEngine::run()
 			if (m_take_screenshot) {
 				m_take_screenshot = false;
 				std::string filename;
-				if (takeScreenshot(driver, filename)) {
+				if (takeScreenshotAutoName(driver, filename)) {
 					std::string msg = fmtgettext("Saved screenshot to \"%s\"", filename.c_str());
 					m_status_text->showStatusText(utf8_to_wide(msg));
 				}

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -306,13 +306,6 @@ int ModApiMainMenu::l_get_worlds(lua_State *L)
 		lua_pushstring(L, world.gameid.c_str());
 		lua_settable(L, top_lvl2);
 
-		std::string screenshot_path = world.path + DIR_DELIM "exit_screenshot.png";
-		if (fs::PathExists(screenshot_path)) {
-			lua_pushstring(L,"screenshot");
-			lua_pushstring(L, screenshot_path.c_str());
-			lua_settable(L, top_lvl2);
-		}
-
 		lua_settable(L, top);
 		index++;
 	}

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -306,6 +306,13 @@ int ModApiMainMenu::l_get_worlds(lua_State *L)
 		lua_pushstring(L, world.gameid.c_str());
 		lua_settable(L, top_lvl2);
 
+		std::string screenshot_path = world.path + DIR_DELIM "exit_screenshot.png";
+		if (fs::PathExists(screenshot_path)) {
+			lua_pushstring(L,"screenshot");
+			lua_pushstring(L, screenshot_path.c_str());
+			lua_settable(L, top_lvl2);
+		}
+
 		lua_settable(L, top);
 		index++;
 	}

--- a/src/util/screenshot.cpp
+++ b/src/util/screenshot.cpp
@@ -17,7 +17,7 @@
 
 #define SCREENSHOT_MAX_SERIAL_TRIES 1000
 
-bool takeScreenshot(video::IVideoDriver *driver, std::string &filename_out)
+static bool saveScreenshot(video::IVideoDriver *driver, const std::string &filename)
 {
 	sanity_check(driver);
 
@@ -28,6 +28,37 @@ bool takeScreenshot(video::IVideoDriver *driver, std::string &filename_out)
 		return false;
 	}
 
+	video::IImage* const image =
+			driver->createImage(video::ECF_R8G8B8, raw_image->getDimension());
+
+	if (!image) {
+		errorstream << "Could not create image for screenshot" << std::endl;
+		raw_image->drop();
+		return false;
+	}
+
+	raw_image->copyTo(image);
+
+	u32 quality = (u32)g_settings->getS32("screenshot_quality");
+	quality = rangelim(quality, 0, 100) / 100.0f * 255;
+
+	bool success = driver->writeImageToFile(image, filename.c_str(), quality);
+
+	if (success) {
+		std::string msg = fmtgettext("Saved screenshot to \"%s\"", filename.c_str());
+		infostream << msg << std::endl;
+	} else {
+		std::string msg = fmtgettext("Failed to save screenshot to \"%s\"", filename.c_str());
+		errorstream << msg << std::endl;
+	}
+
+	image->drop();
+	raw_image->drop();
+	return success;
+}
+
+bool takeScreenshotAutoName(video::IVideoDriver *driver, std::string &filename_out)
+{
 	const struct tm tm = mt_localtime();
 
 	char timestamp_c[64];
@@ -47,9 +78,6 @@ bool takeScreenshot(video::IVideoDriver *driver, std::string &filename_out)
 	// Otherwise, saving the screenshot would fail.
 	fs::CreateAllDirs(screenshot_dir);
 
-	u32 quality = (u32)g_settings->getS32("screenshot_quality");
-	quality = rangelim(quality, 0, 100) / 100.0f * 255;
-
 	// Try to find a unique filename
 	std::string filename;
 	unsigned serial = 0;
@@ -63,34 +91,24 @@ bool takeScreenshot(video::IVideoDriver *driver, std::string &filename_out)
 
 	if (serial == SCREENSHOT_MAX_SERIAL_TRIES) {
 		errorstream << "Could not find suitable filename for screenshot" << std::endl;
-		raw_image->drop();
 		return false;
 	}
 
-	video::IImage* const image =
-			driver->createImage(video::ECF_R8G8B8, raw_image->getDimension());
-
-	if (!image) {
-		errorstream << "Could not create image for screenshot" << std::endl;
-		raw_image->drop();
-		return false;
-	}
-
-	raw_image->copyTo(image);
-
-	bool success = driver->writeImageToFile(image, filename.c_str(), quality);
-
-	if (success) {
+	if (saveScreenshot(driver, filename)) {
 		filename_out = filename;
-		std::string msg = fmtgettext("Saved screenshot to \"%s\"", filename.c_str());
-		infostream << msg << std::endl;
-	} else {
-		std::string msg = fmtgettext("Failed to save screenshot to \"%s\"", filename.c_str());
-		errorstream << msg << std::endl;
+		return true;
 	}
 
-	image->drop();
-	raw_image->drop();
-	return success;
+	return false;
 }
 
+bool takeScreenshotToPath(video::IVideoDriver *driver, const std::string &filepath)
+{
+	if (filepath.empty())
+		return false;
+
+	std::string parent = fs::RemoveLastPathComponent(filepath);
+	if (!parent.empty())
+		fs::CreateAllDirs(parent);
+	return saveScreenshot(driver, filepath);
+}

--- a/src/util/screenshot.h
+++ b/src/util/screenshot.h
@@ -16,5 +16,12 @@ namespace video {
  * @param filename_out Output parameter that receives the path to the saved screenshot
  * @return true if the screenshot was saved successfully, false otherwise
  */
-bool takeScreenshot(video::IVideoDriver *driver, std::string &filename_out);
+bool takeScreenshotAutoName(video::IVideoDriver *driver, std::string &filename_out);
 
+/**
+ * Take a screenshot and save it to an explicit path.
+ * @param driver Video driver to use for the screenshot
+ * @param filepath Output path, including extension
+ * @return true if the screenshot was saved successfully, false otherwise
+ */
+bool takeScreenshotToPath(video::IVideoDriver *driver, const std::string &filepath);


### PR DESCRIPTION
Adds world screenshots, taken on exit. This is a prerequisite for #6733. The screenshot is shown in the place of "host server" when not enabled

Luanti will automatically take a screenshot to `exit_screenshot.png` in the world folder.

A user can manually add a `screenshot.png` in the world folder, this takes priority over the exit screenshot. Not sure whether this is a good idea to support or not, but it's cheap

<img width="1205" height="755" alt="image" src="https://github.com/user-attachments/assets/71509b08-b3d2-402e-9c46-98aa8bc96051" />

-  #12362
- Roadmap: UI improvements/mainmenu
- If you have used an LLM/AI to help with code or assets, you must disclose this. GitHub copilot was used as a guide and autocomplete, but all lines were worked on by hand

## To do

This PR is Ready for Review.

There's a bit of a freeze when taking a screenshot, idk if there's a better way to do this

Need some way to crop the screenshot to fit in the box without stretching

## How to test

<!-- Example code or instructions -->
