### PR TITLE
[no squash] Formspec: Refactor HyperTip handling

### DIFF
--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -3739,19 +3739,6 @@ void GUIFormSpecMenu::drawMenu()
 		}
 	}
 
-	/*
-		Draw rect_mode hypertip
-	*/
-	for (const auto &pair : m_hypertips) {
-		if (m_hypertip_map.count(pair.second.parent_name) == 0) {
-			const auto &hover_rect = pair.second.hover_rect;
-			if (hover_rect.getArea() > 0 && hover_rect.isPointInside(m_pointer)) {
-				showHyperTip(pair.first, pair.second);
-				break;
-			}
-		}
-	}
-
 	// Some elements are only visible while being drawn
 	for (gui::IGUIElement *e : m_clickthrough_elements)
 		e->setVisible(true);
@@ -3768,6 +3755,19 @@ void GUIFormSpecMenu::drawMenu()
 	for (gui::IGUIElement *e : m_clickthrough_elements)
 		e->setVisible(false);
 
+	/*
+		Mark rect_mode hypertips visible
+	*/
+	for (const auto &pair : m_hypertips) {
+		if (m_hypertip_map.count(pair.second.parent_name) == 0) {
+			const auto &hover_rect = pair.second.hover_rect;
+			if (hover_rect.getArea() > 0 && hover_rect.isPointInside(m_pointer)) {
+				showHyperTip(pair.first, pair.second);
+				break;
+			}
+		}
+	}
+
 	// Draw hovered item tooltips
 	for (const std::string &tooltip : m_hovered_item_tooltips) {
 		showTooltip(utf8_to_wide(tooltip), m_default_tooltip_color,
@@ -3780,10 +3780,6 @@ void GUIFormSpecMenu::drawMenu()
 			core::rect<s32>(v2s32(0, 0), v2s32(0, 0)),
 			NULL, m_client, IT_ROT_HOVERED);
 	}
-
-	for (const auto &pair : m_hypertips)
-		if (pair.first->isVisible())
-			pair.first->setVisible(false);
 
 	/*
 		Draw fields/buttons tooltips and update the mouse cursor
@@ -3910,6 +3906,13 @@ void GUIFormSpecMenu::drawMenu()
 		driver->draw2DRectangle(white,
 			core::rect<s32>(rect.LowerRightCorner.X - border, rect.UpperLeftCorner.Y,
 				rect.LowerRightCorner.X, rect.LowerRightCorner.Y), nullptr);
+	}
+
+	for (const auto &pair : m_hypertips) {
+		if (pair.first->isVisible()) {
+			pair.first->draw();
+			pair.first->setVisible(false);
+		}
 	}
 
 	m_tooltip_element->draw();

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1902,6 +1902,11 @@ void GUIFormSpecMenu::parseHyperTip(parserData *data, const std::string &element
 
 		rect = core::recti(pos, pos + geom);
 	} else {
+		if (spec.parent_name.empty()) {
+			// Invalid use. No formspec element name provided
+			return;
+		}
+
 		for (const auto &f : m_fields) {
 			if (f.fname == spec.parent_name) {
 				auto *e = getElementFromId(f.fid, true);

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -1844,33 +1844,42 @@ void GUIFormSpecMenu::parseHyperTip(parserData *data, const std::string &element
 
 	// get staticPos argument
 	std::vector<std::string> v_stpos;
-	size_t static_pos_index = arg_cursor;
-	arg_cursor += 2;
+	const std::string &static_pos = parts[arg_cursor++];
 
-	if (parts[static_pos_index] != "") {
-		v_stpos = split(parts[static_pos_index], ',');
+	if (!static_pos.empty()) {
+		v_stpos = split(static_pos, ',');
 		if (v_stpos.size() != 2) {
 			errorstream << "Invalid staticPos in hypertip element(" << parts.size() <<
-				"): \"" << parts[static_pos_index] << "\"" << std::endl;
+				"): \"" << static_pos << "\"" << std::endl;
 			return;
 		}
 		floating = false;
 	}
 
-	std::string name = parts[arg_cursor++];
-	std::string text = parts[arg_cursor++];
 
-	if (m_form_src)
-		text = m_form_src->resolveText(text);
+	// Tooltip width is defined in em units of the default font
+	const s32 width = stof(parts[arg_cursor++]) * g_fontengine->getFontSize(FM_Standard);
 
-	FieldSpec spec(
-		name,
-		translate_string(utf8_to_wide(unescape_string(text))),
-		L"",
-		258 + m_fields.size()
+	const std::string &name = parts[arg_cursor++];
+	const std::string &text = parts[arg_cursor++];
+
+	HyperTipSpec spec(
+			name,
+			rect_mode ? "" : parts[0],
+			unescape_string(text),
+			core::recti(),
+			std::nullopt,
+			width
 	);
 
-	m_fields.push_back(spec);
+	if (!floating) {
+		if (data->real_coordinates)
+			spec.stpos = getRealCoordinateBasePos(v_stpos);
+		else
+			spec.stpos = getElementBasePos(&v_stpos);
+	}
+
+	core::recti rect;
 
 	if (rect_mode) {
 		std::vector<std::string> v_pos = split(parts[0], ',');
@@ -1879,74 +1888,54 @@ void GUIFormSpecMenu::parseHyperTip(parserData *data, const std::string &element
 		MY_CHECKPOS("hypertip", 0);
 		MY_CHECKGEOM("hypertip", 1);
 
-		// Tooltip width is defined in em units of the default font
-		s32 em = g_fontengine->getFontSize(FM_Standard);
-		s32 width = stof(parts[3]) * em;
-
 		v2s32 pos;
 		v2s32 geom;
-		v2s32 stpos;
 
 		if (data->real_coordinates) {
 			pos = getRealCoordinateBasePos(v_pos);
 			geom = getRealCoordinateGeometry(v_geom);
-
-			if (!floating)
-				stpos = getRealCoordinateBasePos(v_stpos);
 		} else {
 			pos = getElementBasePos(&v_pos);
 			geom.X = stof(v_geom[0]) * spacing.X;
 			geom.Y = stof(v_geom[1]) * spacing.Y;
-
-			if (!floating)
-				stpos = getElementBasePos(&v_stpos);
 		}
 
-		core::rect<s32> rect(pos, pos + geom);
+		rect = core::recti(pos, pos + geom);
+	} else {
+		for (const auto &f : m_fields) {
+			if (f.fname == spec.parent_name) {
+				auto *e = getElementFromId(f.fid, true);
+				rect = e->getAbsoluteClippingRect();
+				break;
+			}
+		}
 
-		GUIHyperText *e = new GUIHyperText(spec.flabel.c_str(), Environment,
-				data->current_parent, spec.fid, rect, m_client, m_tsrc,
-				m_default_tooltip_bgcolor,
-				m_default_tooltip_color,
-				true);
-
-		auto style = getStyleForElement("hypertip", spec.fname);
-		e->setStyles(style);
-
-		HyperTipSpec geospec(name, "", text, e->getAbsoluteClippingRect(), stpos, width, floating);
-
-		m_hypertips.emplace_back(e, geospec);
-
-		e->setVisible(false);
-		e->drop();
-		return;
-	}
-
-	std::string fieldname = parts[0];
-	core::rect<s32> rect;
-
-	for (const auto &f : m_fields) {
-		if (f.fname == fieldname) {
-			auto *e = getElementFromId(f.fid, true);
-			rect = e->getAbsoluteClippingRect();
-			break;
+		// Max. 1 HyperTip for each formspec element
+		for (auto it = m_hypertips.begin(); it != m_hypertips.end(); ) {
+			bool remove = (it->parent_name == spec.parent_name);
+			if (remove) {
+				it->element->remove();
+				it = m_hypertips.erase(it);
+			} else {
+				++it;
+			}
 		}
 	}
 
-	// Tooltip width is defined in em units of the default font
-	s32 em = g_fontengine->getFontSize(FM_Standard);
-	s32 width = stof(parts[2]) * em;
+	GUIHyperText *e = new GUIHyperText(L"", Environment,
+			data->current_parent, -1, rect, m_client, m_tsrc,
+			m_default_tooltip_bgcolor,
+			m_default_tooltip_color,
+			true);
+	auto style = getStyleForElement("hypertip", spec.name);
+	e->setStyles(style);
 
-	v2s32 stpos;
+	spec.element.reset(e);
+	assert(e->getReferenceCount() == 2);
+	e->setVisible(false);
 
-	if (!floating) {
-		if (data->real_coordinates)
-			stpos = getRealCoordinateBasePos(v_stpos);
-		else
-			stpos = getElementBasePos(&v_stpos);
-	}
-
-	m_hypertip_map[fieldname] = HyperTipSpec(name, fieldname, text, rect, stpos, width, floating);
+	spec.hover_rect = e->getAbsolutePosition(); // to include parent offset
+	m_hypertips.emplace_back(spec);
 }
 
 void GUIFormSpecMenu::parseLabel(parserData* data, const std::string &element)
@@ -3067,18 +3056,43 @@ void GUIFormSpecMenu::removeAll()
 
 	for (auto &table_it : m_tables)
 		table_it.second->drop();
+	m_tables.clear();
+
 	for (auto &inventorylist_it : m_inventorylists)
 		inventorylist_it->drop();
+	m_inventorylists.clear();
+
 	for (auto &checkbox_it : m_checkboxes)
 		checkbox_it.second->drop();
+	m_checkboxes.clear();
+
+	m_hypertips.clear();
+
 	for (auto &scrollbar_it : m_scrollbars)
 		scrollbar_it.second->drop();
+	m_scrollbars.clear();
+
 	for (auto &tooltip_rect_it : m_tooltip_rects)
 		tooltip_rect_it.first->drop();
+	m_tooltips.clear();
+	m_tooltip_rects.clear();
+
 	for (auto &clickthrough_it : m_clickthrough_elements)
 		clickthrough_it->drop();
+	m_clickthrough_elements.clear();
+
 	for (auto &scroll_container_it : m_scroll_containers)
 		scroll_container_it.second->drop();
+	m_scroll_containers.clear();
+
+	m_fields.clear();
+	m_inventory_rings.clear();
+	m_dropdowns.clear();
+	theme_by_name.clear();
+	theme_by_type.clear();
+	field_enter_after_edit.clear();
+	field_close_on_enter.clear();
+	m_dropdown_index_event.clear();
 }
 
 const std::unordered_map<std::string, std::function<void(GUIFormSpecMenu*, GUIFormSpecMenu::parserData *data,
@@ -3221,25 +3235,6 @@ void GUIFormSpecMenu::regenerateGui(v2u32 screensize)
 
 	// the parent for the parsed elements
 	mydata.current_parent = this;
-
-	m_inventorylists.clear();
-	m_tables.clear();
-	m_checkboxes.clear();
-	m_scrollbars.clear();
-	m_fields.clear();
-	m_tooltips.clear();
-	m_hypertips.clear();
-	m_hypertip_map.clear();
-	m_tooltip_rects.clear();
-	m_inventory_rings.clear();
-	m_dropdowns.clear();
-	m_scroll_containers.clear();
-	theme_by_name.clear();
-	theme_by_type.clear();
-	m_clickthrough_elements.clear();
-	field_enter_after_edit.clear();
-	field_close_on_enter.clear();
-	m_dropdown_index_event.clear();
 
 	m_allowclose = m_default_allowclose;
 	m_bgnonfullscreen = true;
@@ -3758,13 +3753,14 @@ void GUIFormSpecMenu::drawMenu()
 	/*
 		Mark rect_mode hypertips visible
 	*/
-	for (const auto &pair : m_hypertips) {
-		if (m_hypertip_map.count(pair.second.parent_name) == 0) {
-			const auto &hover_rect = pair.second.hover_rect;
-			if (hover_rect.getArea() > 0 && hover_rect.isPointInside(m_pointer)) {
-				showHyperTip(pair.first, pair.second);
-				break;
-			}
+	for (HyperTipSpec &spec : m_hypertips) {
+		if (!spec.parent_name.empty())
+			continue;
+
+		const auto &hover_rect = spec.hover_rect;
+		if (hover_rect.getArea() > 0 && hover_rect.isPointInside(m_pointer)) {
+			showHyperTip(spec);
+			break;
 		}
 	}
 
@@ -3829,45 +3825,27 @@ void GUIFormSpecMenu::drawMenu()
 				if (field.fid != id)
 					continue;
 
-				if (delta >= m_tooltip_show_delay) {
+				do {
+					if (delta < m_tooltip_show_delay)
+						break;
+					if (field.fname.empty())
+						break;
+
 					const std::wstring &text = m_tooltips[field.fname].tooltip;
 					if (!text.empty()) {
 						/* Tooltips get the priority over hypertips */
 						showTooltip(text, m_tooltips[field.fname].color,
 							m_tooltips[field.fname].bgcolor);
-					} else if (m_hypertip_map.count(field.fname) != 0) {
-						auto &spec = m_hypertip_map[field.fname];
+						break;
+					}
 
-						if (!spec.bound) {
-							spec.bound = true;
-							auto *parent_element = getElementFromId(field.fid, true);
-							auto txt = translate_string(utf8_to_wide(unescape_string(spec.text)));
-
-							GUIHyperText *e = new GUIHyperText(
-									txt.c_str(), Environment,
-									parent_element->getParent(), field.fid,
-									spec.hover_rect, m_client, m_tsrc,
-									m_default_tooltip_bgcolor,
-									m_default_tooltip_color,
-									false);
-
-							auto style = getStyleForElement("hypertip", spec.name);
-							e->setStyles(style);
-
-							m_hypertips.emplace_back(e, spec);
-
-							e->setVisible(false);
-							e->drop();
-						} else {
-							for (const auto &pair : m_hypertips) {
-								if (field.fname == pair.second.parent_name) {
-									showHyperTip(pair.first, pair.second);
-									break;
-								}
-							}
+					for (HyperTipSpec &spec : m_hypertips) {
+						if (spec.parent_name == field.fname) {
+							showHyperTip(spec);
+							break;
 						}
 					}
-				}
+				} while (0);
 
 				if (cursor_control &&
 						field.ftype != f_HyperText && // Handled directly in guiHyperText
@@ -3908,10 +3886,11 @@ void GUIFormSpecMenu::drawMenu()
 				rect.LowerRightCorner.X, rect.LowerRightCorner.Y), nullptr);
 	}
 
-	for (const auto &pair : m_hypertips) {
-		if (pair.first->isVisible()) {
-			pair.first->draw();
-			pair.first->setVisible(false);
+	for (HyperTipSpec &spec : m_hypertips) {
+		if (spec.element->isVisible()) {
+			spec.element->draw();
+			// To re-enable where needed in the next frame
+			spec.element->setVisible(false);
 		}
 	}
 
@@ -4079,23 +4058,35 @@ void GUIFormSpecMenu::autoScroll()
 }
 
 
-void GUIFormSpecMenu::showHyperTip(GUIHyperText *e, const HyperTipSpec &spec)
+void GUIFormSpecMenu::showHyperTip(HyperTipSpec &spec)
 {
+	const s32 tooltip_width = spec.width;
+
+	// Create element if needed
+	GUIHyperText *e = spec.element.get();
+	if (!spec.initialized) {
+		core::recti rect;
+		rect.LowerRightCorner.X = tooltip_width;
+		e->setRelativePosition(rect);
+
+		e->setText(translate_string(utf8_to_wide(spec.text)).c_str());
+		spec.initialized = true;
+	}
+
 	// Hypertip size and offset
-	s32 tooltip_width = spec.width;
 	s32 tooltip_height = e->getTextHeight();
 	s32 tooltip_x, tooltip_y;
 
 	v2u32 screenSize = Environment->getVideoDriver()->getScreenSize();
 
 	// Calculate and set the tooltip position
-	if (spec.floating) {
+	if (!spec.stpos) {
 		/* Dynamic tooltip position, relative to cursor */
 		positionTooltip(tooltip_width, tooltip_height, tooltip_x, tooltip_y);
 	} else {
 		/* Static tooltip position, using formspec coordinates */
-		tooltip_x = spec.stpos[0];
-		tooltip_y = spec.stpos[1];
+		tooltip_x = (*spec.stpos)[0];
+		tooltip_y = (*spec.stpos)[1];
 	}
 
 	if (tooltip_x + tooltip_width  > (s32)screenSize.X)
@@ -4103,7 +4094,7 @@ void GUIFormSpecMenu::showHyperTip(GUIHyperText *e, const HyperTipSpec &spec)
 	if (tooltip_y + tooltip_height > (s32)screenSize.Y)
 		tooltip_y = (s32)screenSize.Y - tooltip_height;
 
-	if (spec.floating) {
+	if (!spec.stpos) {
 		v2s32 base_pos = e->getParent()->getAbsolutePosition().UpperLeftCorner;
 		tooltip_x -= base_pos.X;
 		tooltip_y -= base_pos.Y;
@@ -4118,7 +4109,7 @@ void GUIFormSpecMenu::showHyperTip(GUIHyperText *e, const HyperTipSpec &spec)
 
 	// Display the hypertip
 	e->setVisible(true);
-	bringToFront(e);
+	// Drawn manually, see drawMenu()
 }
 
 

--- a/src/gui/guiFormSpecMenu.h
+++ b/src/gui/guiFormSpecMenu.h
@@ -158,27 +158,29 @@ class GUIFormSpecMenu : public GUIModalMenu
 				const std::string &a_parent_name,
 				const std::string &a_text,
 				const core::rect<s32> &a_rect,
-				v2s32 a_stpos,
-				s32 a_width,
-				bool a_floating) :
+				std::optional<v2s32> a_stpos,
+				s32 a_width) :
 			name(a_name),
 			parent_name(a_parent_name),
 			text(a_text),
 			hover_rect(a_rect),
 			stpos(a_stpos),
-			width(a_width),
-			floating(a_floating)
+			width(a_width)
 		{
 		}
 
 		std::string name;
+		/// Optional, name of the element to attach to
 		std::string parent_name;
+		/// HyperText to draw
 		std::string text;
 		core::rect<s32> hover_rect;
-		v2s32 stpos; ///< static tooltip position
+		/// Static tooltip position (=rect_mode), or floating if unset
+		std::optional<v2s32> stpos;
 		s32 width; ///< in pixels
-		bool floating; ///< whether the position is NON-static (i.e. ignore stpos)
-		bool bound = false; ///< whether it's cached
+		/// Creation is expensive, thus keep track here.
+		irr_ptr<GUIHyperText> element;
+		bool initialized = false; ///< whether setText() was called (expensive)
 	};
 
 public:
@@ -375,8 +377,7 @@ protected:
 	std::vector<std::pair<FieldSpec, GUITable *>> m_tables;
 	std::vector<std::pair<FieldSpec, gui::IGUICheckBox *>> m_checkboxes;
 	std::map<std::string, TooltipSpec> m_tooltips;
-	std::vector<std::pair<GUIHyperText *, HyperTipSpec>> m_hypertips;
-	std::map<std::string, HyperTipSpec> m_hypertip_map;
+	std::vector<HyperTipSpec> m_hypertips; ///< all instances
 	std::vector<std::pair<gui::IGUIElement *, TooltipSpec>> m_tooltip_rects;
 	std::vector<std::pair<FieldSpec, GUIScrollBar *>> m_scrollbars;
 	std::vector<std::pair<FieldSpec, std::vector<std::string>>> m_dropdowns;
@@ -536,7 +537,7 @@ private:
 
 	void showTooltip(const std::wstring &text, const video::SColor &color,
 		const video::SColor &bgcolor);
-	void showHyperTip(GUIHyperText *e, const HyperTipSpec &spec);
+	void showHyperTip(HyperTipSpec &spec);
 
 	gui::IGUIStaticText *addLabel(const EnrichedString &text, const core::rect<s32> &rect,
 		gui::IGUIElement *parent, const StyleSpec &style, bool word_wrap = true, s32 id = 0);

--- a/src/gui/guiHyperText.cpp
+++ b/src/gui/guiHyperText.cpp
@@ -622,9 +622,18 @@ TextDrawer::TextDrawer(const wchar_t *text, Client *client,
 		gui::IGUIEnvironment *environment, ISimpleTextureSource *tsrc,
 		video::SColor default_background_color,
 		video::SColor default_color) :
-		m_text(text, default_color), m_client(client), m_tsrc(tsrc), m_guienv(environment),
+		m_client(client), m_tsrc(tsrc), m_guienv(environment),
 		m_default_background_color(default_background_color)
 {
+	setText(text, default_color);
+}
+
+void TextDrawer::setText(const wchar_t *text, video::SColor default_color)
+{
+	// Avoid move constructor (which we do not have).
+	m_text.~ParsedText();
+	new (&m_text) ParsedText(text, default_color);
+
 	// Size all elements
 	for (auto &p : m_text.m_paragraphs) {
 		for (auto &e : p.elements) {
@@ -991,7 +1000,7 @@ void TextDrawer::draw(const core::rect<s32> &clip_rect,
 				video::SColor color = el.color;
 
 				for (auto tag : el.tags)
-					if (&(*tag) == m_hovertag)
+					if (tag == m_hovertag)
 						color = el.hovercolor;
 
 				if (!el.font)
@@ -1075,7 +1084,6 @@ GUIHyperText::GUIHyperText(const wchar_t *text, IGUIEnvironment *environment,
 		m_default_background_color(default_background_color),
 		m_default_color(default_color)
 {
-
 	IGUISkin *skin = nullptr;
 	if (Environment)
 		skin = Environment->getSkin();
@@ -1131,10 +1139,10 @@ void GUIHyperText::checkHover(s32 X, s32 Y)
 void GUIHyperText::setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &styles)
 {
 	StyleSpec::State state = StyleSpec::STATE_DEFAULT;
-	StyleSpec style = StyleSpec::getStyleFromStatePropagation(styles, state);
+	m_style = StyleSpec::getStyleFromStatePropagation(styles, state);
 
-	setNotClipped(style.getBool(StyleSpec::NOCLIP, true));
-	m_drawer.applyStyleSpecToText(style);
+	setNotClipped(m_style.getBool(StyleSpec::NOCLIP, true));
+	m_drawer.applyStyleSpecToText(m_style);
 }
 
 bool GUIHyperText::OnEvent(const SEvent &event)
@@ -1251,4 +1259,10 @@ void GUIHyperText::draw()
 
 	// draw children
 	IGUIElement::draw();
+}
+
+void GUIHyperText::setText(const wchar_t *text)
+{
+	m_drawer.setText(text, m_default_color);
+	m_drawer.applyStyleSpecToText(m_style);
 }

--- a/src/gui/guiHyperText.h
+++ b/src/gui/guiHyperText.h
@@ -20,8 +20,13 @@ class GUIScrollBar;
 class ParsedText
 {
 public:
+	ParsedText() {}
 	ParsedText(const wchar_t *text, video::SColor default_color);
 	~ParsedText();
+
+	DISABLE_CLASS_COPY(ParsedText);
+
+	void setText(const wchar_t *text, video::SColor default_color);
 
 	enum ElementType
 	{
@@ -150,10 +155,10 @@ protected:
 
 	// Current values
 	StyleList m_style;
-	Element *m_element;
-	Paragraph *m_paragraph;
-	bool m_empty_paragraph;
-	EndReason m_end_paragraph_reason;
+	Element *m_element = nullptr;
+	Paragraph *m_paragraph = nullptr;
+	bool m_empty_paragraph = true;
+	EndReason m_end_paragraph_reason = ER_NONE;
 };
 
 class TextDrawer
@@ -164,6 +169,10 @@ public:
 			video::SColor default_background_color,
 			video::SColor default_color);
 
+	DISABLE_CLASS_COPY(TextDrawer);
+
+	void setText(const wchar_t *text, video::SColor default_color);
+
 	void place(const core::rect<s32> &dest_rect);
 	inline s32 getHeight() { return m_height; };
 	void draw(const core::rect<s32> &clip_rect,
@@ -171,7 +180,7 @@ public:
 	void drawBackgroundImage(video::IVideoDriver *driver, const core::rect<s32> &clip_rect);
 	void applyStyleSpecToText(const StyleSpec &style);
 	ParsedText::Element *getElementAt(core::position2d<s32> pos);
-	ParsedText::Tag *m_hovertag;
+	ParsedText::Tag *m_hovertag = nullptr;
 
 protected:
 	struct RectWithMargin
@@ -206,12 +215,14 @@ public:
 	virtual ~GUIHyperText();
 
 	//! draws the element and its children
-	virtual void draw();
+	void draw() override;
+
+	void setText(const wchar_t *text) override;
 
 	//! Returns the height of the text in pixels when it is drawn.
 	s32 getTextHeight() { return m_drawer.getHeight(); }
 
-	bool OnEvent(const SEvent &event);
+	bool OnEvent(const SEvent &event) override;
 
 	void setStyles(const std::array<StyleSpec, StyleSpec::NUM_STATES> &styles);
 
@@ -220,6 +231,7 @@ protected:
 	ISimpleTextureSource *m_tsrc;
 	GUIScrollBar *m_vscrollbar;
 	TextDrawer m_drawer;
+	StyleSpec m_style; /// to reapply to 'm_drawer'
 
 	// Positioning
 	u32 m_scrollbar_width;


### PR DESCRIPTION
1. Initialize the hypertip text only when needed
2. Combine 2 variables into one
3. Add more comments
4. Move all cleanup code to 'removeAll()'
5. Remove unnecessary 'm_fields' entry (the tooltip cannot be interacted with)
6. Fix self-introduced double-free, caused by missing move constructor.
7. Ensures the shown hypertips are always drawn above other elements

Fixes #17463  (see N° 7)


## To do

This PR is Ready for Review.

## How to test

1. Open `/test_formspec` on a `master` build and with this PR
2. Tabs "Tooltip" and "Tooltip+Listcolors" are relevant. Compare them.
3. ??? bring your own code (this is all hypertip code I had at hand)
4. The code is hopefully slightly more comprehensive.