### PR TITLE
[no-sq] Merge and harden the two CSM sandboxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ find_package(Lua REQUIRED)
 if(NOT USE_LUAJIT)
 	add_subdirectory(lib/bitop)
 endif()
+add_subdirectory(lib/lua_puclibs)
 add_subdirectory(lib/lstrpack)
 add_subdirectory(lib/sha256)
 

--- a/clientmods/preview/init.lua
+++ b/clientmods/preview/init.lua
@@ -237,3 +237,16 @@ core.register_chatcommand("test_hud", {
 		return false, "Unknown command?"
 	end
 })
+
+core.register_chatcommand("test_sandbox", {
+	func = function(param)
+		core.display_chat_message("tostring(core) = "..tostring(core))
+		core.display_chat_message("tostring({}) = "..tostring({}))
+		core.display_chat_message("tostring(core.localplayer) = "..tostring(core.localplayer))
+		core.display_chat_message("os.time() = "..dump(os.time()))
+		core.display_chat_message("os.date() = "..dump(os.date()))
+		core.display_chat_message("os = "..dump(os))
+		print("test")
+		return true, string.format("%s -> %s", "core", tostring(core))
+	end,
+})

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -41,6 +41,7 @@ setting to anything higher than `localhost`.
  * Scripts cannot control GC (Garbage Collector), since this is a common primitive
    used in Lua sandbox escapes in order to get a desired heap layout, this a defense
    in depth measure to make escapes harder.
+ * No backup globals is retain, and we explicitly clear entries from old _G.
  * jit.* methods are not available so mods can't as easily tamper with LuaJIT
   * TODO: should LuaJIT be ran with the JIT engine disabled?
 

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -43,6 +43,7 @@ setting to anything higher than `localhost`.
    in depth measure to make escapes harder.
  * Scripts should not know the heap or static address of objects, this is to
    make it more difficult to construct attacks based around fake objects.
+ * OS and IO libraries are not opened so their tables should not be in the Lua state.
  * No backup globals is retain, and we explicitly clear entries from old _G.
  * jit.* methods are not available so mods can't as easily tamper with LuaJIT
   * TODO: should LuaJIT be ran with the JIT engine disabled?

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -41,6 +41,8 @@ setting to anything higher than `localhost`.
  * Scripts cannot control GC (Garbage Collector), since this is a common primitive
    used in Lua sandbox escapes in order to get a desired heap layout, this a defense
    in depth measure to make escapes harder.
+ * Scripts should not know the heap or static address of objects, this is to
+   make it more difficult to construct attacks based around fake objects.
  * No backup globals is retain, and we explicitly clear entries from old _G.
  * jit.* methods are not available so mods can't as easily tamper with LuaJIT
   * TODO: should LuaJIT be ran with the JIT engine disabled?

--- a/doc/sscsm_security.md
+++ b/doc/sscsm_security.md
@@ -35,12 +35,14 @@ setting to anything higher than `localhost`.
 ## Lua sandbox
 
 * We execute only Lua scripts, in a Lua sandbox.
-* See also `initializeSecuritySSCSM()`.
-* We do not trust the Lua implementation to not have bugs. => Additional process
-  isolation layer as fallback.
+* See also `initializeSecurityClient()`.
+ * We do not trust the Lua implementation to not have bugs. => Additional process
+   isolation layer as fallback.
  * Scripts cannot control GC (Garbage Collector), since this is a common primitive
    used in Lua sandbox escapes in order to get a desired heap layout, this a defense
    in depth measure to make escapes harder.
+ * jit.* methods are not available so mods can't as easily tamper with LuaJIT
+  * TODO: should LuaJIT be ran with the JIT engine disabled?
 
 ## Process isolation
 

--- a/lib/lua_puclibs/CMakeLists.txt
+++ b/lib/lua_puclibs/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(lua_puclibs STATIC
+	lstrlib.c
+	loslib.c
+)
+
+get_target_property(LUA_SOURCES lua_puclibs SOURCES)
+set_source_files_properties(${LUA_SOURCES} PROPERTIES LANGUAGE CXX)
+target_compile_definitions(lua_puclibs PRIVATE LUAEXP_API=)
+target_include_directories(lua_puclibs
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+	PRIVATE
+		${LUA_INCLUDE_DIR}
+)

--- a/lib/lua_puclibs/loslib.c
+++ b/lib/lua_puclibs/loslib.c
@@ -1,0 +1,201 @@
+/*
+** $Id: loslib.c,v 1.19.1.3 2008/01/18 16:38:18 roberto Exp $
+** Standard Operating System library
+** See Copyright Notice in lua.h
+*/
+
+
+#include <errno.h>
+#include <locale.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define loslib_c
+#define LUA_LIB
+
+extern "C" {
+#include "lua.h"
+
+#include "lauxlib.h"
+#include "lualib.h"
+}
+
+/* from Lua 5.2 */
+/*
+** list of valid conversion specifiers for the 'strftime' function
+*/
+#if !defined(LUA_STRFTIMEOPTIONS)
+
+#if !defined(LUA_USE_POSIX)
+#define LUA_STRFTIMEOPTIONS     { "aAbBcdHIjmMpSUwWxXyYz%", "" }
+#else
+#define LUA_STRFTIMEOPTIONS \
+        { "aAbBcCdDeFgGhHIjmMnprRStTuUVwWxXyYzZ%", "" \
+          "", "E", "cCxXyY",  \
+          "O", "deHImMSuUVwWy" }
+#endif
+
+#endif
+
+static int os_pushresult (lua_State *L, int i, const char *filename) {
+  int en = errno;  /* calls to Lua API may change this value */
+  if (i) {
+    lua_pushboolean(L, 1);
+    return 1;
+  }
+  else {
+    lua_pushnil(L);
+    lua_pushfstring(L, "%s: %s", filename, strerror(en));
+    lua_pushinteger(L, en);
+    return 3;
+  }
+}
+
+#if !LUANTI_EXPORTS_ONLY
+#endif
+
+/*
+** {======================================================
+** Time/Date operations
+** { year=%Y, month=%m, day=%d, hour=%H, min=%M, sec=%S,
+**   wday=%w+1, yday=%j, isdst=? }
+** =======================================================
+*/
+
+static void setfield (lua_State *L, const char *key, int value) {
+  lua_pushinteger(L, value);
+  lua_setfield(L, -2, key);
+}
+
+static void setboolfield (lua_State *L, const char *key, int value) {
+  if (value < 0)  /* undefined? */
+    return;  /* does not set field */
+  lua_pushboolean(L, value);
+  lua_setfield(L, -2, key);
+}
+
+static int getboolfield (lua_State *L, const char *key) {
+  int res;
+  lua_getfield(L, -1, key);
+  res = lua_isnil(L, -1) ? -1 : lua_toboolean(L, -1);
+  lua_pop(L, 1);
+  return res;
+}
+
+
+static int getfield (lua_State *L, const char *key, int d) {
+  int res;
+  lua_getfield(L, -1, key);
+  if (lua_isnumber(L, -1))
+    res = (int)lua_tointeger(L, -1);
+  else {
+    if (d < 0)
+      return luaL_error(L, "field " LUA_QS " missing in date table", key);
+    res = d;
+  }
+  lua_pop(L, 1);
+  return res;
+}
+
+/* backported from Lua 5.2, to avoid os.date crashing
+   https://www.lua.org/source/5.2/loslib.c.html#checkoption */
+static const char *checkoption (lua_State *L, const char *conv, char *buff) {
+  static const char *const options[] = LUA_STRFTIMEOPTIONS;
+  unsigned int i;
+  for (i = 0; i < sizeof(options)/sizeof(options[0]); i += 2) {
+    if (*conv != '\0' && strchr(options[i], *conv) != NULL) {
+      buff[1] = *conv;
+      if (*options[i + 1] == '\0') {  /* one-char conversion specifier? */
+        buff[2] = '\0';  /* end buffer */
+        return conv + 1;
+      }
+      else if (*(conv + 1) != '\0' &&
+               strchr(options[i + 1], *(conv + 1)) != NULL) {
+        buff[2] = *(conv + 1);  /* valid two-char conversion specifier */
+        buff[3] = '\0';  /* end buffer */
+        return conv + 2;
+      }
+    }
+  }
+  luaL_argerror(L, 1,
+    lua_pushfstring(L, "invalid conversion specifier '%%%s'", conv));
+  return conv;  /* to avoid warnings */
+}
+
+/* 5.2 version */
+LUAEXP_API int luaEos_date (lua_State *L) {
+  const char *s = luaL_optstring(L, 1, "%c");
+  time_t t = luaL_opt(L, (time_t)luaL_checknumber, 2, time(NULL));
+  struct tm *stm;
+  if (*s == '!') {  /* UTC? */
+    stm = gmtime(&t);
+    s++;  /* skip `!' */
+  }
+  else
+    stm = localtime(&t);
+  if (stm == NULL)  /* invalid date? */
+    lua_pushnil(L);
+  else if (strcmp(s, "*t") == 0) {
+    lua_createtable(L, 0, 9);  /* 9 = number of fields */
+    setfield(L, "sec", stm->tm_sec);
+    setfield(L, "min", stm->tm_min);
+    setfield(L, "hour", stm->tm_hour);
+    setfield(L, "day", stm->tm_mday);
+    setfield(L, "month", stm->tm_mon+1);
+    setfield(L, "year", stm->tm_year+1900);
+    setfield(L, "wday", stm->tm_wday+1);
+    setfield(L, "yday", stm->tm_yday+1);
+    setboolfield(L, "isdst", stm->tm_isdst);
+  }
+  else {
+    char cc[4];
+    luaL_Buffer b;
+    cc[0] = '%';
+    luaL_buffinit(L, &b);
+    for (; *s; s++) {
+      if (*s != '%' || *(s + 1) == '\0')  /* no conversion specifier? */
+        luaL_addchar(&b, *s);
+      else {
+        size_t reslen;
+        char buff[200];  /* should be big enough for any conversion result */
+        s = checkoption(L, s + 1, cc);
+        reslen = strftime(buff, sizeof(buff), cc, stm);
+        luaL_addlstring(&b, buff, reslen);
+      }
+    }
+    luaL_pushresult(&b);
+  }
+  return 1;
+}
+
+LUAEXP_API int luaEos_time (lua_State *L) {
+  time_t t;
+  if (lua_isnoneornil(L, 1))  /* called without args? */
+    t = time(NULL);  /* get current time */
+  else {
+    struct tm ts;
+    luaL_checktype(L, 1, LUA_TTABLE);
+    lua_settop(L, 1);  /* make sure table is at the top */
+    ts.tm_sec = getfield(L, "sec", 0);
+    ts.tm_min = getfield(L, "min", 0);
+    ts.tm_hour = getfield(L, "hour", 12);
+    ts.tm_mday = getfield(L, "day", -1);
+    ts.tm_mon = getfield(L, "month", -1) - 1;
+    ts.tm_year = getfield(L, "year", -1) - 1900;
+    ts.tm_isdst = getboolfield(L, "isdst");
+    t = mktime(&ts);
+  }
+  if (t == (time_t)(-1))
+    lua_pushnil(L);
+  else
+    lua_pushnumber(L, (lua_Number)t);
+  return 1;
+}
+
+
+LUAEXP_API int luaEos_difftime (lua_State *L) {
+  lua_pushnumber(L, difftime((time_t)(luaL_checknumber(L, 1)),
+                             (time_t)(luaL_optnumber(L, 2, 0))));
+  return 1;
+}

--- a/lib/lua_puclibs/lstrlib.c
+++ b/lib/lua_puclibs/lstrlib.c
@@ -1,0 +1,168 @@
+/*
+** $Id: lstrlib.c,v 1.132.1.5 2010/05/14 15:34:19 roberto Exp $
+** Standard library for string operations and pattern-matching
+** See Copyright Notice in lua.h
+*/
+
+
+#include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define lstrlib_c
+#define LUA_LIB
+
+extern "C" {
+#include "lua.h"
+
+#include "lauxlib.h"
+#include "lualib.h"
+}
+
+/* macro to `unsign' a character */
+#define uchar(c)        ((unsigned char)(c))
+
+/* maximum size of each formatted item (> len(format('%99.99f', -1e308))) */
+#define MAX_ITEM	512
+/* valid flags in a format specification */
+#define FLAGS	"-+ #0"
+/*
+** maximum size of each format specification (such as '%-099.99d')
+** (+10 accounts for %99.99x plus margin of error)
+*/
+#define MAX_FORMAT	(sizeof(FLAGS) + sizeof(LUA_INTFRMLEN) + 10)
+
+#define L_ESC           '%'
+#define SPECIALS        "^$*+?.([%-"
+
+static void addquoted (lua_State *L, luaL_Buffer *b, int arg) {
+  size_t l;
+  const char *s = luaL_checklstring(L, arg, &l);
+  luaL_addchar(b, '"');
+  while (l--) {
+    switch (*s) {
+      case '"': case '\\': case '\n': {
+        luaL_addchar(b, '\\');
+        luaL_addchar(b, *s);
+        break;
+      }
+      case '\r': {
+        luaL_addlstring(b, "\\r", 2);
+        break;
+      }
+      case '\0': {
+        luaL_addlstring(b, "\\000", 4);
+        break;
+      }
+      default: {
+        luaL_addchar(b, *s);
+        break;
+      }
+    }
+    s++;
+  }
+  luaL_addchar(b, '"');
+}
+
+static const char *scanformat (lua_State *L, const char *strfrmt, char *form) {
+  const char *p = strfrmt;
+  while (*p != '\0' && strchr(FLAGS, *p) != NULL) p++;  /* skip flags */
+  if ((size_t)(p - strfrmt) >= sizeof(FLAGS))
+    luaL_error(L, "invalid format (repeated flags)");
+  if (isdigit(uchar(*p))) p++;  /* skip width */
+  if (isdigit(uchar(*p))) p++;  /* (2 digits at most) */
+  if (*p == '.') {
+    p++;
+    if (isdigit(uchar(*p))) p++;  /* skip precision */
+    if (isdigit(uchar(*p))) p++;  /* (2 digits at most) */
+  }
+  if (isdigit(uchar(*p)))
+    luaL_error(L, "invalid format (width or precision too long)");
+  *(form++) = '%';
+  strncpy(form, strfrmt, p - strfrmt + 1);
+  form += p - strfrmt + 1;
+  *form = '\0';
+  return p;
+}
+
+static void addintlen (char *form) {
+  size_t l = strlen(form);
+  char spec = form[l - 1];
+  strcpy(form + l - 1, LUA_INTFRMLEN);
+  form[l + sizeof(LUA_INTFRMLEN) - 2] = spec;
+  form[l + sizeof(LUA_INTFRMLEN) - 1] = '\0';
+}
+
+/* Luanti modification: exported to replace the LuaJIT version
+   in some sandboxes, as that leaks addresses */
+LUAEXP_API int luaEstr_format (lua_State *L) {
+  int top = lua_gettop(L);
+  int arg = 1;
+  size_t sfl;
+  const char *strfrmt = luaL_checklstring(L, arg, &sfl);
+  const char *strfrmt_end = strfrmt+sfl;
+  luaL_Buffer b;
+  luaL_buffinit(L, &b);
+  while (strfrmt < strfrmt_end) {
+    if (*strfrmt != L_ESC)
+      luaL_addchar(&b, *strfrmt++);
+    else if (*++strfrmt == L_ESC)
+      luaL_addchar(&b, *strfrmt++);  /* %% */
+    else { /* format item */
+      char form[MAX_FORMAT];  /* to store the format (`%...') */
+      char buff[MAX_ITEM];  /* to store the formatted item */
+      if (++arg > top)
+        luaL_argerror(L, arg, "no value");
+      strfrmt = scanformat(L, strfrmt, form);
+      switch (*strfrmt++) {
+        case 'c': {
+          sprintf(buff, form, (int)luaL_checknumber(L, arg));
+          break;
+        }
+        case 'd':  case 'i': {
+          addintlen(form);
+          sprintf(buff, form, (LUA_INTFRM_T)luaL_checknumber(L, arg));
+          break;
+        }
+        case 'o':  case 'u':  case 'x':  case 'X': {
+          addintlen(form);
+          sprintf(buff, form, (unsigned LUA_INTFRM_T)luaL_checknumber(L, arg));
+          break;
+        }
+        case 'e':  case 'E': case 'f':
+        case 'g': case 'G': {
+          sprintf(buff, form, (double)luaL_checknumber(L, arg));
+          break;
+        }
+        case 'q': {
+          addquoted(L, &b, arg);
+          continue;  /* skip the 'addsize' at the end */
+        }
+        case 's': {
+          size_t l;
+          const char *s = luaL_checklstring(L, arg, &l);
+          if (!strchr(form, '.') && l >= 100) {
+            /* no precision and string is too long to be formatted;
+               keep original string */
+            lua_pushvalue(L, arg);
+            luaL_addvalue(&b);
+            continue;  /* skip the `addsize' at the end */
+          }
+          else {
+            sprintf(buff, form, s);
+            break;
+          }
+        }
+        default: {  /* also treat cases `pnLlh' */
+          return luaL_error(L, "invalid option " LUA_QL("%%%c") " to "
+                               LUA_QL("format"), *(strfrmt - 1));
+        }
+      }
+      luaL_addlstring(&b, buff, strlen(buff));
+    }
+  }
+  luaL_pushresult(&b);
+  return 1;
+}

--- a/lib/lua_puclibs/lua_puclibs.h
+++ b/lib/lua_puclibs/lua_puclibs.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "lua.h"
+#include "lauxlib.h""
+
+#define LUAEXP_API
+
+/// PUC version of string.format
+LUAEXP_API int luaEstr_format(lua_State *L);
+
+/// PUC Lua os.date
+LUAEXP_API int luaEos_date (lua_State *L);
+/// PUC Lua os.time
+LUAEXP_API int luaEos_time(lua_State *L);
+/// PUC Lua os.difftime
+LUAEXP_API int luaEos_difftime(lua_State *L);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -718,6 +718,7 @@ if(BUILD_CLIENT)
 		${GMP_LIBRARY}
 		${JSON_LIBRARY}
 		${LUA_BIT_LIBRARY}
+		lua_puclibs
 		lstrpack
 		sha256
 		${FREETYPE_LIBRARY}
@@ -809,6 +810,7 @@ if(BUILD_SERVER)
 		${JSON_LIBRARY}
 		${LUA_LIBRARY}
 		${LUA_BIT_LIBRARY}
+		lua_puclibs
 		lstrpack
 		sha256
 		${GMP_LIBRARY}

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -187,10 +187,10 @@ int ScriptApiBase::luaPanic(lua_State *L)
 #if CHECK_CLIENT_BUILD()
 void ScriptApiBase::clientOpenLibs(lua_State *L)
 {
+	// TODO: should the JIT compiler be disabled for SSCSM?
 	static const std::vector<std::pair<std::string, lua_CFunction>> m_libs = {
 		{ "", luaopen_base },
 		{ LUA_TABLIBNAME,  luaopen_table   },
-		{ LUA_OSLIBNAME,   luaopen_os      },
 		{ LUA_STRLIBNAME,  luaopen_string  },
 		{ LUA_MATHLIBNAME, luaopen_math    },
 		{ LUA_DBLIBNAME,   luaopen_debug   },

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -16,11 +16,13 @@
 #include "content/mods.h" // ModSpec
 #include "settings.h"
 #include "constants.h"
+#include "porting.h"
 
 #include <cerrno>
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <cinttypes>
 
 
 #define SECURE_API(lib, name) \
@@ -203,6 +205,8 @@ void ScriptApiSecurity::initializeSecurity()
 	};
 
 	m_secure = true;
+	// not critical on server
+	std::ignore = porting::secure_rand_fill_buf(m_pointer_key, sizeof(m_pointer_key));
 
 	lua_State *L = getStack();
 	const int sanity_check_top = lua_gettop(L);
@@ -361,7 +365,6 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"getmetatable",
 		"setmetatable",
 		"tonumber",
-		"tostring",
 		"type",
 		"unpack",
 		"_VERSION",
@@ -417,6 +420,8 @@ void ScriptApiSecurity::initializeSecurityClient()
 #endif
 
 	m_secure = true;
+	if (!porting::secure_rand_fill_buf(m_pointer_key, sizeof(m_pointer_key)))
+		throw LuaError("Unable to setup pointer key");
 
 	lua_State *L = getStack();
 	const int thread = getThread(L);
@@ -455,6 +460,7 @@ void ScriptApiSecurity::initializeSecurityClient()
 	SECURE_API(g, loadstring);
 	SECURE_API(g, require);
 	SECURE_API(g, collectgarbage);
+	SECURE_API(g, tostring);
 	lua_pop(L, 2);
 
 
@@ -879,6 +885,63 @@ bool ScriptApiSecurity::checkPathWithGamedef(lua_State *L,
 
 #undef RETURN_WRITE_ALLOWED
 
+// TODO; replace these when switching to C++20
+static inline uint32_t SPECK_rotl(uint32_t v, int shift)
+{
+	return (v << shift) | (v >> (sizeof(v)*8 - shift));
+}
+
+static inline uint32_t SPECK_rotr(uint32_t v, int shift)
+{
+	return (v >> shift) | (v << (sizeof(v)*8 - shift));
+}
+
+static void SPECK_round(const uint32_t key, uint32_t &x, uint32_t &y)
+{
+	constexpr int a = 8;
+	constexpr int b = 3;
+
+	x = (SPECK_rotr(x, a) + y) ^ key;
+	y = SPECK_rotl(y, b) ^ x;
+}
+
+// uses SPECK as a light weight scrambling primitive
+// https://eprint.iacr.org/2013/404.pdf
+uint64_t ScriptApiSecurity::scramblePointer(unsigned char type, const void *ptr) const
+{
+	// round count: 27
+	// key size: 4*32 = 128
+	// SPECK 64/128
+
+	// we discard the upper byte of the pointer and use this for type
+	// upper byte isn't meaningful on any target platforms
+	// this hides from the sandbox if two objects of different types
+	// end up getting the same address
+	const uint64_t input = static_cast<uint64_t>(reinterpret_cast<size_t>(ptr));
+	const auto &key = m_pointer_key;
+
+	uint32_t x = (static_cast<uint32_t>(input >> 32) << 8) | type;
+	uint32_t y = static_cast<uint32_t>(input & ~uint32_t(0));
+
+	uint32_t b = key[0];
+	uint32_t a[3] = {key[1], key[2], key[3]};
+
+	for (int i = 0; i < 27; i++) {
+		SPECK_round(b, x, y);
+		SPECK_round(i, a[i%3], b);
+	}
+
+	return (uint64_t(x) << 32) | y;
+}
+
+uint64_t ScriptApiSecurity::toScrambledPointer(lua_State *L, int index)
+{
+	const void *ptr = lua_topointer(L, index);
+	unsigned char type = static_cast<unsigned char>(lua_type(L, index));
+	const auto *sec = ModApiBase::getScriptApi<ScriptApiSecurity>(L);
+	return sec->scramblePointer(type, ptr);
+}
+
 int ScriptApiSecurity::sl_g_dofile(lua_State *L)
 {
 	int nret = sl_g_loadfile(L);
@@ -1015,6 +1078,35 @@ int ScriptApiSecurity::sl_g_collectgarbage(lua_State *L)
 	}
 	// do nothing instead of throwing so mods can more easily re-use code between server and client
 	return 0;
+}
+
+// copied from bundled Lua
+int ScriptApiSecurity::sl_g_tostring(lua_State *L)
+{
+	luaL_checkany(L, 1);
+	if (luaL_callmeta(L, 1, "__tostring"))  // is there a metafield?
+		return 1;  // use its value
+	switch (lua_type(L, 1)) {
+	case LUA_TNUMBER:
+		lua_pushstring(L, lua_tostring(L, 1));
+		break;
+	case LUA_TSTRING:
+		lua_pushvalue(L, 1);
+		break;
+	case LUA_TBOOLEAN:
+		lua_pushstring(L, (lua_toboolean(L, 1) ? "true" : "false"));
+		break;
+	case LUA_TNIL:
+		lua_pushliteral(L, "nil");
+		break;
+	default:
+		// mod security, avoid leaking the raw object pointer here
+		char buf[0x200];
+		snprintf(buf, sizeof(buf), "%s: 0x%016" PRIx64, luaL_typename(L, 1), toScrambledPointer(L, 1));
+		lua_pushstring(L, buf);
+		break;
+	}
+	return 1;
 }
 
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -353,7 +353,6 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"next",
 		"pairs",
 		"pcall",
-		"print",
 		"rawequal",
 		"rawget",
 		"rawset",
@@ -369,143 +368,23 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"xpcall",
 		// Completely safe libraries
 		"coroutine",
-		"string",
 		"table",
 		"math",
 		"bit",
+	};
+#if BUILD_WITH_TRACY
+	static const char *whitelist_cscsm_only[] = {
 		// Not sure if completely safe. But if someone enables tracy, they'll
 		// know what they do.
-#if BUILD_WITH_TRACY
 		"tracy",
-#endif
 	};
+#endif
 	static const char *os_whitelist[] = {
-		"clock",
 		"date",
 		"difftime",
 		"time"
 	};
 	static const char *debug_whitelist[] = {
-		"traceback"
-	};
-
-#if USE_LUAJIT
-	static const char *jit_whitelist[] = {
-		"arch",
-		"flush",
-		"off",
-		"on",
-		"opt",
-		"os",
-		"status",
-		"version",
-		"version_num",
-	};
-#endif
-
-	m_secure = true;
-
-	lua_State *L = getStack();
-	const int thread = getThread(L);
-
-	// Back up selected globals to the registry (needed for push_original)
-	lua_newtable(L);
-	for (const char *name : {"debug"}) {
-		lua_getglobal(L, name);
-		lua_setfield(L, -2, name);
-	}
-	lua_rawseti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
-
-	// create an empty environment
-	createEmptyEnv(L);
-
-	// Copy safe base functions
-	lua_getglobal(L, "_G");
-	lua_getfield(L, -2, "_G");
-	copy_safe(L, whitelist, sizeof(whitelist));
-
-	// And replace unsafe ones
-	SECURE_API(g, dofile);
-	SECURE_API(g, load);
-	SECURE_API(g, loadfile);
-	SECURE_API(g, loadstring);
-	SECURE_API(g, require);
-	SECURE_API(g, collectgarbage);
-	lua_pop(L, 2);
-
-
-
-	// Copy safe OS functions
-	lua_getglobal(L, "os");
-	lua_newtable(L);
-	copy_safe(L, os_whitelist, sizeof(os_whitelist));
-	lua_setfield(L, -3, "os");
-	lua_pop(L, 1);  // Pop old OS
-
-
-	// Copy safe debug functions
-	lua_getglobal(L, "debug");
-	lua_newtable(L);
-	copy_safe(L, debug_whitelist, sizeof(debug_whitelist));
-
-	// And replace unsafe ones
-	SECURE_API(debug, getinfo); // (used by builtin and unset before mods load)
-
-	lua_setfield(L, -3, "debug");
-	lua_pop(L, 1);  // Pop old debug
-
-
-#if USE_LUAJIT
-	// Copy safe jit functions, if they exist
-	lua_getglobal(L, "jit");
-	lua_newtable(L);
-	copy_safe(L, jit_whitelist, sizeof(jit_whitelist));
-	lua_setfield(L, -3, "jit");
-	lua_pop(L, 1);  // Pop old jit
-#endif
-
-	// Set the environment to the one we created earlier
-	setLuaEnv(L, thread);
-
-	replace_string_metatable(L);
-}
-
-void ScriptApiSecurity::initializeSecuritySSCSM()
-{
-	static const char *whitelist[] = {
-		"assert",
-		"core",
-		"DIR_DELIM",
-		"error",
-		"ipairs",
-		"next",
-		"pairs",
-		"pcall",
-		"rawequal",
-		"rawget",
-		"rawset",
-		"select",
-		"setfenv",
-		"getmetatable",
-		"setmetatable",
-		"tonumber",
-		"tostring",
-		"type",
-		"unpack",
-		"_VERSION",
-		"xpcall",
-		// Completely safe libraries
-		"coroutine",
-		"table",
-		"math",
-		"bit",
-	};
-	static const char *os_whitelist[] = {
-		"difftime",
-		"time"
-	};
-	static const char *debug_whitelist[] = {
-		"getinfo", // used by client builtin and unset before mods load
 		"traceback"
 	};
 	static const char *string_whitelist[] = { // all but string.dump
@@ -540,7 +419,23 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	m_secure = true;
 
 	lua_State *L = getStack();
-	int thread = getThread(L);
+	const int thread = getThread(L);
+
+	// Back up debug.getinfo
+	{
+		lua_newtable(L);
+		lua_newtable(L); // copy of debug
+
+		// copy debug.getinfo
+		lua_getglobal(L, "debug");
+		lua_getfield(L, -1, "getinfo");
+		lua_setfield(L, -3, "getinfo");
+		lua_pop(L, 1);
+
+		lua_setfield(L, -2, "debug");
+		lua_rawseti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
+	}
+
 
 	// create an empty environment
 	createEmptyEnv(L);
@@ -549,7 +444,10 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	lua_getglobal(L, "_G");
 	lua_getfield(L, -2, "_G");
 	copy_safe(L, whitelist, sizeof(whitelist));
-
+#if BUILD_WITH_TRACY
+	if (getType() == ScriptingType::Client)
+		copy_safe(L, whitelist_cscsm_only, sizeof(whitelist_cscsm_only));
+#endif
 	// And replace unsafe ones
 	SECURE_API(g, dofile);
 	SECURE_API(g, load);
@@ -577,6 +475,11 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 	lua_getglobal(L, "debug");
 	lua_newtable(L);
 	copy_safe(L, debug_whitelist, sizeof(debug_whitelist));
+
+	// (used by builtin and unset before mods load)
+	// And replace unsafe ones
+	SECURE_API(debug, getinfo);
+
 	lua_setfield(L, -3, "debug");
 	lua_pop(L, 1);  // Pop old debug
 
@@ -590,12 +493,17 @@ void ScriptApiSecurity::initializeSecuritySSCSM()
 
 
 #if USE_LUAJIT
-	// Copy safe jit functions, if they exist
-	lua_getglobal(L, "jit");
-	lua_newtable(L);
-	copy_safe(L, jit_whitelist, sizeof(jit_whitelist));
-	lua_setfield(L, -3, "jit");
-	lua_pop(L, 1);  // Pop old jit
+	// client scripts can have JIT
+	// but server supplied code is not allowed
+	// to inspect or modify jit compiler state
+	if (getType() == ScriptingType::Client) {
+		// Copy safe jit functions, if they exist
+		lua_getglobal(L, "jit");
+		lua_newtable(L);
+		copy_safe(L, jit_whitelist, sizeof(jit_whitelist));
+		lua_setfield(L, -3, "jit");
+		lua_pop(L, 1);  // Pop old jit
+	}
 #endif
 
 	// Set the environment to the one we created earlier

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -24,9 +24,14 @@
 #include <iostream>
 #include <cinttypes>
 
+#include "lua_puclibs.h"
 
 #define SECURE_API(lib, name) \
 	lua_pushcfunction(L, sl_##lib##_##name); \
+	lua_setfield(L, -2, #name);
+
+#define PUC_API(prefix, name) \
+	lua_pushcfunction(L, luaE##prefix##_##name); \
 	lua_setfield(L, -2, #name);
 
 
@@ -174,7 +179,6 @@ void ScriptApiSecurity::initializeSecurity()
 	};
 	static const char *os_whitelist[] = {
 		"clock",
-		"date",
 		"difftime",
 		"getenv",
 		"time",
@@ -297,6 +301,8 @@ void ScriptApiSecurity::initializeSecurity()
 	SECURE_API(os, remove);
 	SECURE_API(os, rename);
 	SECURE_API(os, setlocale);
+	 // LuaJIT version doesn't valid format strings
+	PUC_API(os, date);
 
 	lua_setglobal(L, "os");
 	lua_pop(L, 1);  // Pop old OS
@@ -382,11 +388,6 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"tracy",
 	};
 #endif
-	static const char *os_whitelist[] = {
-		"date",
-		"difftime",
-		"time"
-	};
 	static const char *debug_whitelist[] = {
 		"traceback"
 	};
@@ -394,7 +395,6 @@ void ScriptApiSecurity::initializeSecurityClient()
 		"byte",
 		"char",
 		"find",
-		"format",
 		"gmatch",
 		"gsub",
 		"len",
@@ -465,16 +465,13 @@ void ScriptApiSecurity::initializeSecurityClient()
 
 
 
-	// Copy safe OS functions
-	lua_getglobal(L, "os");
+	// load os functions
 	lua_newtable(L);
-	copy_safe(L, os_whitelist, sizeof(os_whitelist));
-
-	// And replace unsafe ones
+	PUC_API(os, date);
+	PUC_API(os, time);
+	PUC_API(os, difftime);
 	SECURE_API(os, clock);
-
-	lua_setfield(L, -3, "os");
-	lua_pop(L, 1);  // Pop old OS
+	lua_setfield(L, -2, "os");
 
 
 	// Copy safe debug functions
@@ -494,6 +491,11 @@ void ScriptApiSecurity::initializeSecurityClient()
 	lua_getglobal(L, "string");
 	lua_newtable(L);
 	copy_safe(L, string_whitelist, sizeof(string_whitelist));
+
+	// LuaJIT adds %p here
+	// so we use the PUC version instead
+	PUC_API(str, format);
+
 	lua_setfield(L, -3, "string");
 	lua_pop(L, 1);  // Pop old string
 

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -506,6 +506,10 @@ void ScriptApiSecurity::initializeSecurityClient()
 	}
 #endif
 
+	// clear old globals
+	// if the globals leak somehow
+	// this mitigates that
+	clearGlobals(L);
 	// Set the environment to the one we created earlier
 	setLuaEnv(L, thread);
 
@@ -530,6 +534,26 @@ void ScriptApiSecurity::createEmptyEnv(lua_State *L)
 	lua_newtable(L);  // Create new environment
 	lua_pushvalue(L, -1);
 	lua_setfield(L, -2, "_G");  // Create the _G loop
+}
+
+void ScriptApiSecurity::clearGlobals(lua_State *L)
+{
+	// get global table
+	// and clear any metaindex on it
+	lua_pushliteral(L, "_G");
+	lua_rawget(L, LUA_GLOBALSINDEX);
+	lua_newtable(L);
+	lua_setmetatable(L, -2);
+
+	lua_pushnil(L);
+	while (lua_next(L, -2) != 0) {
+		lua_pop(L, 1); // don't care about the value
+		lua_pushvalue(L, -1);
+		lua_pushnil(L);
+		lua_rawset(L, -4); // clear value
+	}
+	// global table should be completely empty now
+	lua_pop(L, 1);
 }
 
 void ScriptApiSecurity::setLuaEnv(lua_State *L, int thread)

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -66,6 +66,11 @@ public:
 	static bool checkPath(lua_State *L, const char *path, bool write_required,
 			bool *write_allowed = nullptr);
 
+	/// Scrambles a pointer returning a unique value, type is lua_type
+	uint64_t scramblePointer(unsigned char type, const void *ptr) const;
+	/// like lua_topointer but returns a scrambled value
+	static uint64_t toScrambledPointer(lua_State *L, int index);
+
 protected:
 	// To be implemented by descendants:
 
@@ -104,6 +109,8 @@ private:
 	void clearGlobals(lua_State *L);
 
 	bool m_secure = false;
+	// scrambling key for the pointers
+	uint32_t m_pointer_key[4];
 
 	// Syntax: "sl_" <Library name or 'g' (global)> '_' <Function name>
 	// (sl stands for Secure Lua)
@@ -114,6 +121,7 @@ private:
 	static int sl_g_loadstring(lua_State *L);
 	static int sl_g_require(lua_State *L);
 	static int sl_g_collectgarbage(lua_State *L);
+	static int sl_g_tostring(lua_State *L);
 
 	static int sl_io_open(lua_State *L);
 	static int sl_io_input(lua_State *L);

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -100,6 +100,8 @@ private:
 	static void createEmptyEnv(lua_State *L);
 	// replace "default files" (io.input/io.output) with /dev/null
 	static void replaceDefaultFiles(lua_State *L);
+	// delete all globals
+	void clearGlobals(lua_State *L);
 
 	bool m_secure = false;
 

--- a/src/script/cpp_api/s_security.h
+++ b/src/script/cpp_api/s_security.h
@@ -31,10 +31,8 @@ public:
 	void initializeSecurity();
 #if CHECK_CLIENT_BUILD()
 	void initializeSecurityClient();
-	void initializeSecuritySSCSM();
 #else
 	void initializeSecurityClient() { assert(0); }
-	void initializeSecuritySSCSM() { assert(0); }
 #endif
 
 	// Checks if the Lua state has been secured

--- a/src/script/lua_api/l_base.h
+++ b/src/script/lua_api/l_base.h
@@ -137,8 +137,7 @@ private:
 	template<typename T>
 	static int defaultToString(lua_State *L)
 	{
-		auto *t = checkObject<T>(L, 1);
-		lua_pushfstring(L, "%s: %p", T::className, t);
+		lua_pushfstring(L, "%s", T::className);
 		return 1;
 	}
 };

--- a/src/script/lua_api/l_object.cpp
+++ b/src/script/lua_api/l_object.cpp
@@ -83,10 +83,10 @@ int ObjectRef::mt_tostring(lua_State *L)
 			lua_pushfstring(L, "ObjectRef (entity): %s (id: %d)",
 					entitysao->getName().c_str(), entitysao->getId());
 		} else {
-			lua_pushfstring(L, "ObjectRef (?): %p", ref);
+			lua_pushstring(L, "ObjectRef (?)");
 		}
 	} else {
-		lua_pushfstring(L, "ObjectRef (invalid): %p", ref);
+		lua_pushstring(L, "ObjectRef (invalid)");
 	}
 	return 1;
 }

--- a/src/script/scripting_sscsm.cpp
+++ b/src/script/scripting_sscsm.cpp
@@ -15,7 +15,7 @@ SSCSMScripting::SSCSMScripting(SSCSMEnvironment *env) :
 
 	SCRIPTAPI_PRECHECKHEADER
 
-	initializeSecuritySSCSM();
+	initializeSecurityClient();
 
 	lua_getglobal(L, "core");
 	int top = lua_gettop(L);


### PR DESCRIPTION
- SSCSM can no longer control the jit.* library
- Both sandboxes always use the PUC Lua version of string.format to avoid leaking memory addresses
- OS library is no longer loaded into either
- Old globals table is cleared of values, so that if it leaks out it should be empty
- debug.getinfo sandboxing no longer depends on Lua builtin correctness on SSCSM
- Backup globals only include debug.getinfo, not the whole debug library
- CSCSM sandbox no longer copies over print, bultin should overwrite it in any case
- CSCSM no longer has string.dump
- tostring now obfuscates the pointer, using SPECK 64/128

Sandboxing string.format in any sane way is not possible  without duplicating most of the code, there doesn't seem to be a strong case for vendoring in yet another implementation of this, decided to solve this by
 modifying the already vendored in
Lua 5.1 to export some `os` and `string` library functions as symbols so that the game engine can link against them directly.

If linking against LuaJIT we instead compile,
a minimal version of those libraries and link against those instead, Lua was designed such that the libraries
should only depend on the public C API so this is fine to do and the linker should throw away any symbols we don't use.

Pointer obfuscation is applied to heap addresses being printed into Lua, the type of the object is used when constructing the 64-bit input into the light-weight cipher used, so Lua scripts cannot detect when a different object type reclaims a memory address.
They can still however detect basic reclaims, this seems to be the best we can do without somehow pulling in something from the object header like a generation counter.

SPECK 64/128 is used with a random per session key, this is overkill, but it's a debug output, so it seems fine, if it's too slow for actual realistic code this can be replaced.
SPECK is just nice since it's so short and trivial.

Add compact, short information about your PR for easier understanding:

- Goal of the PR Defense in depth for the SSCSM sandbox + merging the two CSM sandboxes to reduce code duplication
- How does the PR work? Pointer obfuscation + replacing or removing dangerous functions
- Does it resolve any reported issue? #17451 partially testing it in the CSM sandbox first since that's lower impact if it breaks something
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?  Yes, SSCSM.
- If not a bug fix, why is this PR needed? What usecases does it solve? Increasing resistance to info leaks and attacks on the Lua sandbox
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  Please refer to the [AI policy](https://github.com/luanti-org/luanti/blob/master/doc/developing/ai_policy.md). Nope! So far no, unless you could google search while looking at 64-bit block cipher options.

## To do

This PR is a Ready for Review.


## How to test

Test in CSCSM by enabling the preview mod and running `.test_sandbox`
