### PR TITLE
Fix a typo in profiling.md

### DIFF
--- a/doc/developing/profiling.md
+++ b/doc/developing/profiling.md
@@ -72,7 +72,7 @@ Install the server, e.g. using your package manager.
 
 ### Building
 
-Build Luanti with `-DDBUILD_WITH_TRACY=1`, this will fetch Tracy for building
+Build Luanti with `-DBUILD_WITH_TRACY=1`, this will fetch Tracy for building
 the Tracy client. And use `FETCH_TRACY_GIT_TAG` to get a version matching your
 Tracy server, e.g. `-DFETCH_TRACY_GIT_TAG=v0.11.0` if it's `0.11.0`.
 
@@ -83,7 +83,7 @@ See Tracy's documentation for more build options.
 
 TL;DR:
 ```
--DDBUILD_WITH_TRACY=1 -DFETCH_TRACY_GIT_TAG=<your_version> -DTRACY_ENABLE=1 -DTRACY_ONLY_LOCALHOST=1
+-DBUILD_WITH_TRACY=1 -DFETCH_TRACY_GIT_TAG=<your_version> -DTRACY_ENABLE=1 -DTRACY_ONLY_LOCALHOST=1
 ```
 
 ### Using in C++


### PR DESCRIPTION
This PR fixes a minor but significant typo in `doc/developing/profiling.md` where the CMake flag is documented as `-DDBUILD_WITH_TRACY=1` (an extra D in the prefix). Correcting this means developers won't have issues when copy-pasting the Tracy profiler setup commands verbatim. It doesn't resolve a currently-tracked issue or tie into the roadmap. Developer documentation improvement only. 

## To do

This PR is Ready for Review.

## How to test

Confirm by build config familiarity or reference.