### PR TITLE
Cache vcpkg builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,11 +117,13 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup vcpkg
+        id: setup-vcpkg
         shell: pwsh
         run: |
           Remove-Item -Recurse -Force C:\vcpkg -ErrorAction Continue
           $baseline = (Get-Content -Raw vcpkg.json | ConvertFrom-Json).'builtin-baseline'
           Write-Host "builtin-baseline: $baseline"
+          "VCPKG_BASELINE=$baseline" >> $env:GITHUB_OUTPUT
           New-Item -ItemType Directory -Force vcpkg_cache | Out-Null
           git clone --filter=blob:none --no-checkout https://github.com/microsoft/vcpkg.git vcpkg
           git -C vcpkg checkout $baseline
@@ -134,8 +136,9 @@ jobs:
           path: &vcpkg_cache_paths |
             ${{ github.workspace }}\vcpkg\downloads
             ${{ github.workspace }}\vcpkg_cache
-          key: &vcpkg_cache_key ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
+          key: &vcpkg_cache_key ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ steps.setup-vcpkg.outputs.VCPKG_BASELINE }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
+            ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ steps.setup-vcpkg.outputs.VCPKG_BASELINE }}-
             ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-
 
       - name: CMake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,6 +96,8 @@ jobs:
     runs-on: windows-2025-vs2026
     env:
       VCPKG_DEFAULT_TRIPLET: ${{matrix.config.vcpkg_triplet}}
+      VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg_cache
+      VCPKG_DISABLE_METRICS: 1
     strategy:
       fail-fast: false
       matrix:
@@ -114,10 +116,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Restore from cache and run vcpkg
-        uses: lukka/run-vcpkg@v11
+      - name: Setup vcpkg
+        shell: pwsh
+        run: |
+          $baseline = (Get-Content -Raw vcpkg.json | ConvertFrom-Json).'builtin-baseline'
+          Write-Host "builtin-baseline: $baseline"
+          New-Item -ItemType Directory -Force vcpkg_cache | Out-Null
+          git clone --filter=blob:none --no-checkout https://github.com/microsoft/vcpkg.git vcpkg
+          git -C vcpkg checkout $baseline
+          .\vcpkg\bootstrap-vcpkg.bat
+
+      - name: Setup vcpkg cache
+        uses: actions/cache@v6
         with:
-          vcpkgDirectory: '${{ github.workspace }}\vcpkg'
+          path: |
+            ${{ github.workspace }}\vcpkg\downloads
+            ${{ github.workspace }}\vcpkg_cache
+          key: ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-
 
       - name: CMake
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -119,6 +119,7 @@ jobs:
       - name: Setup vcpkg
         shell: pwsh
         run: |
+          Remove-Item -Recurse -Force C:\vcpkg -ErrorAction Continue
           $baseline = (Get-Content -Raw vcpkg.json | ConvertFrom-Json).'builtin-baseline'
           Write-Host "builtin-baseline: $baseline"
           New-Item -ItemType Directory -Force vcpkg_cache | Out-Null
@@ -126,17 +127,19 @@ jobs:
           git -C vcpkg checkout $baseline
           .\vcpkg\bootstrap-vcpkg.bat
 
-      - name: Setup vcpkg cache
-        uses: actions/cache@v6
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: actions/cache/restore@v6
         with:
-          path: |
+          path: &vcpkg_cache_paths |
             ${{ github.workspace }}\vcpkg\downloads
             ${{ github.workspace }}\vcpkg_cache
-          key: ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
+          key: &vcpkg_cache_key ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-
 
       - name: CMake
+        id: cmake
         run: |
           cmake ${{matrix.config.generator}}  `
           -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `
@@ -161,6 +164,13 @@ jobs:
           cpack -G ZIP -B "$env:GITHUB_WORKSPACE\Package"
           rm -r $env:GITHUB_WORKSPACE\Package\_CPack_Packages
           Get-ChildItem "$env:GITHUB_WORKSPACE\Package\*.zip" | Rename-Item -NewName { $_.Name -replace '\.zip$', '-msvc.zip' }
+
+      - name: Save vcpkg cache
+        uses: actions/cache/save@v6
+        if: always() && steps.cmake.outcome == 'success' && steps.vcpkg-cache.outputs.cache-hit != 'true'
+        with:
+          path: *vcpkg_cache_paths
+          key: *vcpkg_cache_key
 
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -139,7 +139,6 @@ jobs:
           key: &vcpkg_cache_key ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ steps.setup-vcpkg.outputs.VCPKG_BASELINE }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-${{ steps.setup-vcpkg.outputs.VCPKG_BASELINE }}-
-            ${{ runner.os }}-vcpkg-${{ matrix.config.vcpkg_triplet }}-
 
       - name: CMake
         id: cmake


### PR DESCRIPTION
- Goal of the PR Cache vcpkg
- How does the PR work? by using github actions cache directly instead of a questionably maintained third party action
- Does it resolve any reported issue? Windows CI being horribly slow for MSVC
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)? Probably not
- If not a bug fix, why is this PR needed? What usecases does it solve? Making CI less painful for everyone
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  Please refer to the [AI policy](https://github.com/luanti-org/luanti/blob/master/doc/developing/ai_policy.md).
Yes to update the yaml file and write some of the powershell, the code is very simple however so if it works it's probably correct and it appears to work fine after testing.

## How to test

- Verify on your own repo the workflow caches
- (optional) verify vcpkg gracefully handles a stale cache when the manifest changes (time consuming + low priority since the cache can be manually invalidated by a maintainer if the logic here is flawed), it should be fine I think, this shouldn't be any different from changing the manifest locally.
- verify opening a PR does not create a new cache if one already exists in the repo (important, these caches are ~1GB and github has limit of 10GB) 

Proof it pulls in the cache when merging onto a branch that has one, and doesn't write a new cache: https://github.com/red-001/minetest/actions/runs/32250676954/job/96060695457?pr=4
