### PR TITLE
Optimize isBlockInSight

### DIFF
--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -251,7 +251,7 @@ void RemoteClient::GetNextBlocks (
 
 	// Calculate FOV attributes here, once per call
 	// see numeric.h for details
-	const f32 target_cos = getFovCos(camera_fov);
+	const f32 target_cos_sq = getFovCosSq(camera_fov);
 	const f32 adjdist = getFovAdj(camera_fov);
 
 	s16 d;
@@ -296,7 +296,7 @@ void RemoteClient::GetNextBlocks (
 				(0.1 is about 5 degrees)
 			*/
 			f32 dist;
-			if (!(isBlockInSight_ex(p, camera_pos, camera_dir, target_cos, adjdist,
+			if (!(isBlockInSight_ex(p, camera_pos, camera_dir, target_cos_sq, adjdist,
 						d_blocks_in_sight, &dist) ||
 					(playerspeed.getLength() > 1.0f * BS &&
 					isBlockInSight(p, camera_pos, playerspeeddir, 0.1f,

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -296,7 +296,7 @@ void RemoteClient::GetNextBlocks (
 				(0.1 is about 5 degrees)
 			*/
 			f32 dist;
-			if (!(isBlockInSight_ex(p, camera_pos, camera_dir, target_cos_sq, adjdist,
+			if (!(isBlockInSightEx(p, camera_pos, camera_dir, target_cos_sq, adjdist,
 						d_blocks_in_sight, &dist) ||
 					(playerspeed.getLength() > 1.0f * BS &&
 					isBlockInSight(p, camera_pos, playerspeeddir, 0.1f,

--- a/src/server/clientiface.cpp
+++ b/src/server/clientiface.cpp
@@ -249,6 +249,11 @@ void RemoteClient::GetNextBlocks (
 
 	const v3s16 cam_pos_nodes = floatToInt(camera_pos, BS);
 
+	// Calculate FOV attributes here, once per call
+	// see numeric.h for details
+	const f32 target_cos = getFovCos(camera_fov);
+	const f32 adjdist = getFovAdj(camera_fov);
+
 	s16 d;
 	for (d = d_start; d <= d_max; d++) {
 		/*
@@ -291,7 +296,7 @@ void RemoteClient::GetNextBlocks (
 				(0.1 is about 5 degrees)
 			*/
 			f32 dist;
-			if (!(isBlockInSight(p, camera_pos, camera_dir, camera_fov,
+			if (!(isBlockInSight_ex(p, camera_pos, camera_dir, target_cos, adjdist,
 						d_blocks_in_sight, &dist) ||
 					(playerspeed.getLength() > 1.0f * BS &&
 					isBlockInSight(p, camera_pos, playerspeeddir, 0.1f,

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -86,9 +86,14 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed)
 	return h;
 }
 
-
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr)
+{
+	return isBlockInSight_ex(blockpos_b, camera_pos, camera_dir, getFovAdj(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
+}
+
+bool isBlockInSight_ex(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
+		f32 target_cos, f32 adjdist, f32 range, f32 *distance_ptr)
 {
 	// Block center position
 	v3f blockpos(
@@ -115,12 +120,6 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		return true;
 	}
 
-	// Adjust camera position, for purposes of computing the angle,
-	// such that a block that has any portion visible with the
-	// current camera position will have the center visible at the
-	// adjusted position
-	f32 adjdist = BLOCK_MAX_RADIUS / std::sin(camera_fov * 0.5f);
-
 	// Block position relative to adjusted camera
 	v3f blockpos_adj = blockpos - (camera_pos - camera_dir * adjdist);
 
@@ -133,14 +132,8 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 
 	f32 len_adj_sq = blockpos_adj.getLengthSQ();
 
-	// If block is not in the field of view, skip it
-	// HOTFIX: use slightly increased angle (+10%) to fix too aggressive
-	// culling. Somebody has to find out what's wrong with the math here.
-	// Previous value: camera_fov / 2
-	f32 target_cos = std::cos(camera_fov * 0.55f);
-
 	// do check with squared values
-	if ((dforward * dforward) < (target_cos * target_cos * len_adj_sq))
+	if (dforward * dforward < target_cos * target_cos * len_adj_sq)
 		return false;
 
 	// calculate the actual distance only if the block is visible

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -90,34 +90,36 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed)
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr)
 {
-	v3s16 blockpos_nodes = blockpos_b * MAP_BLOCKSIZE;
-
 	// Block center position
-	v3f blockpos = v3f::from(blockpos_nodes + MAP_BLOCKSIZE / 2) * BS;
+	v3f blockpos(
+			(f32) (blockpos_b.X * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS,
+			(f32) (blockpos_b.Y * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS,
+			(f32) (blockpos_b.Z * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS);
 
-	// Block position relative to camera
-	v3f blockpos_relative = blockpos - camera_pos;
+	if (distance_ptr) {
+		*distance_ptr = 0.0f;
+	}
 
-	// Total distance
-	f32 d = std::max(0.0f, blockpos_relative.getLength() - BLOCK_MAX_RADIUS);
-
-	if (distance_ptr)
-		*distance_ptr = d;
+	// Square distance
+	f32 len_sq = blockpos.getDistanceFromSQ(camera_pos);
 
 	// If block is far away, it's not in sight
-	if (d > range)
+	f32 max_reach = range + BLOCK_MAX_RADIUS;
+	if (len_sq > max_reach * max_reach)
 		return false;
 
 	// If block is (nearly) touching the camera, don't
 	// bother validating further (that is, render it anyway)
-	if (d == 0)
+	if (len_sq <= BLOCK_MAX_RADIUS * BLOCK_MAX_RADIUS) {
+		// this means distance in blocks is 0
 		return true;
+	}
 
 	// Adjust camera position, for purposes of computing the angle,
 	// such that a block that has any portion visible with the
 	// current camera position will have the center visible at the
 	// adjusted position
-	f32 adjdist = BLOCK_MAX_RADIUS / cos((M_PI - camera_fov) / 2);
+	f32 adjdist = BLOCK_MAX_RADIUS / std::sin(camera_fov * 0.5f);
 
 	// Block position relative to adjusted camera
 	v3f blockpos_adj = blockpos - (camera_pos - camera_dir * adjdist);
@@ -125,17 +127,26 @@ bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	// Distance in camera direction (+=front, -=back)
 	f32 dforward = blockpos_adj.dotProduct(camera_dir);
 
-	// Cosine of the angle between the camera direction
-	// and the block direction (camera_dir is an unit vector)
-	f32 cosangle = dforward / blockpos_adj.getLength();
+	// If the block is behind the adjusted camera position, cull it instantly
+	if (dforward <= 0.0f)
+		return false;
+
+	f32 len_adj_sq = blockpos_adj.getLengthSQ();
 
 	// If block is not in the field of view, skip it
 	// HOTFIX: use slightly increased angle (+10%) to fix too aggressive
 	// culling. Somebody has to find out what's wrong with the math here.
 	// Previous value: camera_fov / 2
-	if (cosangle < std::cos(camera_fov * 0.55f))
+	f32 target_cos = std::cos(camera_fov * 0.55f);
+
+	// do check with squared values
+	if ((dforward * dforward) < (target_cos * target_cos * len_adj_sq))
 		return false;
 
+	// calculate the actual distance only if the block is visible
+	if (distance_ptr) {
+		*distance_ptr = std::max(0.0f, std::sqrt(len_sq) - BLOCK_MAX_RADIUS);
+	}
 	return true;
 }
 

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -89,10 +89,10 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed)
 bool isBlockInSight(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
 		const f32 camera_fov, const f32 range, f32 *distance_ptr)
 {
-	return isBlockInSight_ex(blockpos_b, camera_pos, camera_dir, getFovCosSq(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
+	return isBlockInSightEx(blockpos_b, camera_pos, camera_dir, getFovCosSq(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
 }
 
-bool isBlockInSight_ex(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+bool isBlockInSightEx(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
 		const f32 target_cos_sq, const f32 adjdist, f32 range, f32 *distance_ptr)
 {
 	// Block center position relative to camera
@@ -132,7 +132,11 @@ bool isBlockInSight_ex(const v3s16 blockpos_b, const v3f& camera_pos, const v3f&
 
 	const f32 len_adj_sq = blockpos_adj.getLengthSQ();
 
-	// do check with squared values
+	// do angle check with squared values
+	// This is a transformation of the previous
+	//   dForward/blockpos_adj.getLength() < target_cos
+	// This is safe because of the (dforward <= 0.0f) check above
+	// (and the fact that fov <= 160 degrees)
 	if (dforward * dforward < target_cos_sq * len_adj_sq)
 		return false;
 

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -96,10 +96,9 @@ bool isBlockInSightEx(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& 
 		const f32 target_cos_sq, const f32 adjdist, f32 range, f32 *distance_ptr)
 {
 	// Block center position relative to camera
-	const v3f blockpos_relative(
-			(f32) (blockpos_b.X * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS - camera_pos.X,
-			(f32) (blockpos_b.Y * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS - camera_pos.Y,
-			(f32) (blockpos_b.Z * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS - camera_pos.Z);
+	const v3f blockpos_relative =
+			intToFloat(blockpos_b * MAP_BLOCKSIZE + v3s16(MAP_BLOCKSIZE / 2), BS) -
+			camera_pos;
 
 	if (distance_ptr) {
 		*distance_ptr = 0.0f;

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -89,7 +89,7 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed)
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr)
 {
-	return isBlockInSight_ex(blockpos_b, camera_pos, camera_dir, getFovAdj(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
+	return isBlockInSight_ex(blockpos_b, camera_pos, camera_dir, getFovCos(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
 }
 
 bool isBlockInSight_ex(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -86,13 +86,13 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed)
 	return h;
 }
 
-bool isBlockInSight(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+bool isBlockInSight(const v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		const f32 camera_fov, const f32 range, f32 *distance_ptr)
 {
 	return isBlockInSightEx(blockpos_b, camera_pos, camera_dir, getFovCosSq(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
 }
 
-bool isBlockInSightEx(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+bool isBlockInSightEx(const v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		const f32 target_cos_sq, const f32 adjdist, f32 range, f32 *distance_ptr)
 {
 	// Block center position relative to camera

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -86,30 +86,30 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed)
 	return h;
 }
 
-bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
-		f32 camera_fov, f32 range, f32 *distance_ptr)
+bool isBlockInSight(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+		const f32 camera_fov, const f32 range, f32 *distance_ptr)
 {
-	return isBlockInSight_ex(blockpos_b, camera_pos, camera_dir, getFovCos(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
+	return isBlockInSight_ex(blockpos_b, camera_pos, camera_dir, getFovCosSq(camera_fov), getFovAdj(camera_fov), range, distance_ptr);
 }
 
-bool isBlockInSight_ex(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
-		f32 target_cos, f32 adjdist, f32 range, f32 *distance_ptr)
+bool isBlockInSight_ex(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+		const f32 target_cos_sq, const f32 adjdist, f32 range, f32 *distance_ptr)
 {
-	// Block center position
-	v3f blockpos(
-			(f32) (blockpos_b.X * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS,
-			(f32) (blockpos_b.Y * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS,
-			(f32) (blockpos_b.Z * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS);
+	// Block center position relative to camera
+	const v3f blockpos_relative(
+			(f32) (blockpos_b.X * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS - camera_pos.X,
+			(f32) (blockpos_b.Y * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS - camera_pos.Y,
+			(f32) (blockpos_b.Z * MAP_BLOCKSIZE + MAP_BLOCKSIZE / 2) * BS - camera_pos.Z);
 
 	if (distance_ptr) {
 		*distance_ptr = 0.0f;
 	}
 
 	// Square distance
-	f32 len_sq = blockpos.getDistanceFromSQ(camera_pos);
+	const f32 len_sq = blockpos_relative.getLengthSQ();
 
 	// If block is far away, it's not in sight
-	f32 max_reach = range + BLOCK_MAX_RADIUS;
+	const f32 max_reach = range + BLOCK_MAX_RADIUS;
 	if (len_sq > max_reach * max_reach)
 		return false;
 
@@ -121,19 +121,19 @@ bool isBlockInSight_ex(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 	}
 
 	// Block position relative to adjusted camera
-	v3f blockpos_adj = blockpos - (camera_pos - camera_dir * adjdist);
+	const v3f blockpos_adj = blockpos_relative + camera_dir * adjdist;
 
 	// Distance in camera direction (+=front, -=back)
-	f32 dforward = blockpos_adj.dotProduct(camera_dir);
+	const f32 dforward = blockpos_adj.dotProduct(camera_dir);
 
 	// If the block is behind the adjusted camera position, cull it instantly
 	if (dforward <= 0.0f)
 		return false;
 
-	f32 len_adj_sq = blockpos_adj.getLengthSQ();
+	const f32 len_adj_sq = blockpos_adj.getLengthSQ();
 
 	// do check with squared values
-	if (dforward * dforward < target_cos * target_cos * len_adj_sq)
+	if (dforward * dforward < target_cos_sq * len_adj_sq)
 		return false;
 
 	// calculate the actual distance only if the block is visible

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -316,10 +316,10 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed);
  * @param range viewing range
  * @param distance_ptr return location for distance from the camera
  */
-bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
-		f32 camera_fov, f32 range, f32 *distance_ptr=nullptr);
-bool isBlockInSight_ex(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
-		f32 target_cos, f32 adjdist, f32 range, f32 *distance_ptr);
+bool isBlockInSight(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+		const f32 camera_fov, const f32 range, f32 *distance_ptr=nullptr);
+bool isBlockInSight_ex(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+		const f32 target_cos_sq, const f32 adjdist, const f32 range, f32 *distance_ptr);
 
 s16 adjustDist(s16 dist, float zoom_fov);
 
@@ -333,13 +333,14 @@ inline f32 getFovAdj(f32 camera_fov)
 	return BLOCK_MAX_RADIUS / std::sin(camera_fov * 0.5f);
 }
 
-inline f32 getFovCos(f32 camera_fov)
+inline f32 getFovCosSq(f32 camera_fov)
 {
 	// If block is not in the field of view, skip it
 	// HOTFIX: use slightly increased angle (+10%) to fix too aggressive
 	// culling. Somebody has to find out what's wrong with the math here.
 	// Previous value: camera_fov / 2
-	return std::cos(camera_fov * 0.55f);
+	const f32 target_cos =  std::cos(camera_fov * 0.55f);
+	return target_cos * target_cos;
 }
 
 /*

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -318,8 +318,29 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed);
  */
 bool isBlockInSight(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		f32 camera_fov, f32 range, f32 *distance_ptr=nullptr);
+bool isBlockInSight_ex(v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
+		f32 target_cos, f32 adjdist, f32 range, f32 *distance_ptr);
 
 s16 adjustDist(s16 dist, float zoom_fov);
+
+
+inline f32 getFovAdj(f32 camera_fov)
+{
+	// Adjust camera position, for purposes of computing the angle,
+	// such that a block that has any portion visible with the
+	// current camera position will have the center visible at the
+	// adjusted position
+	return BLOCK_MAX_RADIUS / std::sin(camera_fov * 0.5f);
+}
+
+inline f32 getFovCos(f32 camera_fov)
+{
+	// If block is not in the field of view, skip it
+	// HOTFIX: use slightly increased angle (+10%) to fix too aggressive
+	// culling. Somebody has to find out what's wrong with the math here.
+	// Previous value: camera_fov / 2
+	return std::cos(camera_fov * 0.55f);
+}
 
 /*
 	Returns nearest 32-bit integer for given floating point number.

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -317,7 +317,7 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed);
  * @param range viewing range
  * @param distance_ptr return location for distance from the camera
  */
-bool isBlockInSight(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+bool isBlockInSight(const v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		const f32 camera_fov, const f32 range, f32 *distance_ptr=nullptr);
 
 /**
@@ -329,7 +329,7 @@ bool isBlockInSight(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& ca
  * @param range viewing range
  * @param distance_ptr return location for distance from the camera
  */
-bool isBlockInSightEx(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+bool isBlockInSightEx(const v3s16 blockpos_b, v3f camera_pos, v3f camera_dir,
 		const f32 target_cos_sq, const f32 adjdist, const f32 range, f32 *distance_ptr);
 
 s16 adjustDist(s16 dist, float zoom_fov);

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -313,12 +313,23 @@ u64 murmur_hash_64_ua(const void *key, size_t len, unsigned int seed);
  * @param blockpos_b position of block in block coordinates
  * @param camera_pos position of camera in nodes
  * @param camera_dir an unit vector pointing to camera direction
+ * @param camera_fov in rad
  * @param range viewing range
  * @param distance_ptr return location for distance from the camera
  */
 bool isBlockInSight(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
 		const f32 camera_fov, const f32 range, f32 *distance_ptr=nullptr);
-bool isBlockInSight_ex(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
+
+/**
+ * @param blockpos_b position of block in block coordinates
+ * @param camera_pos position of camera in nodes
+ * @param camera_dir an unit vector pointing to camera direction
+ * @param target_cos_sq pre-computed adjusted cos^2(camera fov) (use getFovCosSq(...))
+ * @param adjdist pre-computed camera distance adjustment (use getFovAdj(...))
+ * @param range viewing range
+ * @param distance_ptr return location for distance from the camera
+ */
+bool isBlockInSightEx(const v3s16 blockpos_b, const v3f& camera_pos, const v3f& camera_dir,
 		const f32 target_cos_sq, const f32 adjdist, const f32 range, f32 *distance_ptr);
 
 s16 adjustDist(s16 dist, float zoom_fov);
@@ -339,7 +350,7 @@ inline f32 getFovCosSq(f32 camera_fov)
 	// HOTFIX: use slightly increased angle (+10%) to fix too aggressive
 	// culling. Somebody has to find out what's wrong with the math here.
 	// Previous value: camera_fov / 2
-	const f32 target_cos =  std::cos(camera_fov * 0.55f);
+	const f32 target_cos = std::cos(camera_fov * 0.55f);
 	return target_cos * target_cos;
 }
 


### PR DESCRIPTION
 I noticed that especially with large distance a lot of time is spent in `isBlockInSight`. The problem is of course that we are enumerating every block of "d-radiused" box and then pass with through `isBlockInSight`.

I tried various things, such as projecting the view cone onto the box to reduce the number of blocks to iterate. And while that lead to reall perf improvements at very large zooms (like 5x or 10x) it got  _very_ complex quickly, and had many corner condition issues.

Instead I decided to just optimize `isBlockInSight`. As is, this improves zoomed block loading by 1.5-2x.

- If you have used an LLM/AI to help with code or assets, you must disclose this.

AI helped verify some of the math. Code is mine.

## To do

This PR is Ready for Review.

## How to test

Load any world, make sure no blocks are missing from view.
To perf test, set viewing range to a large value, then zoom in, verify it loads faster.
