### PR TITLE
Make media progress text position depend on bar image size 

### DIFF
--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -303,14 +303,6 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 			gui::StaticText::add(guienv, text, textrect, false, false);
 	guitext->setTextAlignment(gui::EGUIA_CENTER, gui::EGUIA_UPPERLEFT);
 
-	gui::IGUIStaticText *gui_bottom_text = nullptr;
-	if (!bottom_text.empty()) {
-		v2s32 size(240, g_fontengine->getLineHeight()*2);
-		v2s32 pos = center + v2s32{-120, 32};
-		core::rect<s32> rect(pos, pos + size);
-		gui_bottom_text = gui::StaticText::add(guienv, bottom_text, rect, false, false);
-	}
-
 	auto *driver = get_video_driver();
 
 	driver->setFog(m_menu_sky_color);
@@ -329,6 +321,7 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 		percent_min = std::max((int) *indef_pos - 40, 0);
 	}
 	// draw progress bar
+	u32 imgW = 0, imgH = 0;
 	if ((percent_min >= 0) && (percent_max <= 100)) {
 		video::ITexture *progress_img = tsrc->getTexture("progress_bar.png");
 		video::ITexture *progress_img_bg =
@@ -340,13 +333,13 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 					progress_img_bg->getSize();
 			float density = g_settings->getFloat("gui_scaling", 0.5f, 20.0f) *
 					getDisplayDensity();
-			u32 imgW = rangelim(img_size.Width, 200, 600) * density;
-			u32 imgH = rangelim(img_size.Height, 24, 72) * density;
+			imgW = rangelim(img_size.Width, 200, 600) * density;
+			imgH = rangelim(img_size.Height, 24, 72) * density;
 #else
 			const core::dimension2d<u32> img_size(256, 48);
 			float imgRatio = (float)img_size.Height / img_size.Width;
-			u32 imgW = screensize.X / 2.2f;
-			u32 imgH = floor(imgW * imgRatio);
+			imgW = screensize.X / 2.2f;
+			imgH = floor(imgW * imgRatio);
 #endif
 			v2s32 img_pos((screensize.X - imgW) / 2,
 					(screensize.Y - imgH) / 2);
@@ -368,6 +361,22 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 							img_size.Height),
 					0, 0, true);
 		}
+	}
+
+	gui::IGUIStaticText *gui_bottom_text = nullptr;
+	if (!bottom_text.empty()) {
+		v2s32 bottom_textsize(g_fontengine->getTextWidth(bottom_text),
+				g_fontengine->getTextWidth(bottom_text));
+		s32 padding = g_fontengine->getLineHeight() * 0.5f;
+
+		v2s32 offset(
+			imgW == 0 ? bottom_textsize.X * -0.5f : imgW * -0.5f + padding,
+			std::max<s32>(imgH, textsize.Y) * 0.5f + padding
+		);
+		v2s32 pos = center + offset;
+
+		core::rect<s32> rect(pos, pos + bottom_textsize);
+		gui_bottom_text = gui::StaticText::add(guienv, bottom_text, rect, false, false);
 	}
 
 	guienv->drawAll();

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -366,7 +366,8 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 	gui::IGUIStaticText *gui_bottom_text = nullptr;
 	if (!bottom_text.empty()) {
 		auto line_height = g_fontengine->getLineHeight();
-		v2s32 bottom_textsize(g_fontengine->getTextWidth(bottom_text), line_height * 2);
+		const v2s32 bottom_textsize = v2s32::from(v2u32(
+				g_fontengine->getFont()->getDimension(bottom_text.c_str())));
 		s32 padding = line_height * 0.5f;
 
 		v2s32 offset(

--- a/src/client/renderingengine.cpp
+++ b/src/client/renderingengine.cpp
@@ -365,9 +365,9 @@ void RenderingEngine::draw_load_screen(const std::wstring &text,
 
 	gui::IGUIStaticText *gui_bottom_text = nullptr;
 	if (!bottom_text.empty()) {
-		v2s32 bottom_textsize(g_fontengine->getTextWidth(bottom_text),
-				g_fontengine->getTextWidth(bottom_text));
-		s32 padding = g_fontengine->getLineHeight() * 0.5f;
+		auto line_height = g_fontengine->getLineHeight();
+		v2s32 bottom_textsize(g_fontengine->getTextWidth(bottom_text), line_height * 2);
+		s32 padding = line_height * 0.5f;
 
 		v2s32 offset(
 			imgW == 0 ? bottom_textsize.X * -0.5f : imgW * -0.5f + padding,


### PR DESCRIPTION
Fixes #17476

Haven't built and tested it on an android device.

## To do

Ready for Review.

## How to test

Change the `gui_scaling` setting to 2.

Connect to a server and look at the progress bar
