### PR TITLE
[CI] Make VCPKG ABI hash more stable

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -128,6 +128,7 @@ jobs:
           git clone --filter=blob:none --no-checkout https://github.com/microsoft/vcpkg.git vcpkg
           git -C vcpkg checkout $baseline
           .\vcpkg\bootstrap-vcpkg.bat
+          Add-Content -Path "${{ github.workspace }}\vcpkg\triplets\${{ matrix.config.vcpkg_triplet }}.cmake" -Value "`nset(VCPKG_DISABLE_COMPILER_TRACKING ON)"
 
       - name: Restore vcpkg cache
         id: vcpkg-cache
@@ -144,6 +145,7 @@ jobs:
         id: cmake
         run: |
           cmake ${{matrix.config.generator}}  `
+          -DVCPKG_INSTALL_OPTIONS="--x-abi-tools-use-exact-versions"  `
           -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake"  `
           -DCMAKE_BUILD_TYPE=Release  `
           -DENABLE_POSTGRESQL=OFF  `


### PR DESCRIPTION
Missed this in #17470 but vcpkg hashes in everything it can think of into the ABI hash, this disables the MSVC build version and the powershell build version from being hashed in. MSVC should have a stable ABI for how we are using it, the JSONCPP is the only C++ dependency we have with it as far as I can tell.

# How to test

Merge it and see if cache works in 2 months time still, who knows.
