### PR TITLE
Fix minimap zoom displayed as 0 in surface mode with size > 256

### DIFF
--- a/src/client/minimap.cpp
+++ b/src/client/minimap.cpp
@@ -286,7 +286,7 @@ void Minimap::addMode(MinimapModeDef mode)
 			mode.scale = 1;
 	}
 
-	int zoom = -1;
+	float zoom = -1.0f;
 
 	// Build a default standard label
 	if (mode.label.empty()) {
@@ -295,14 +295,14 @@ void Minimap::addMode(MinimapModeDef mode)
 				mode.label = gettext("Minimap hidden");
 				break;
 			case MINIMAP_TYPE_SURFACE:
-				mode.label = gettext("Minimap in surface mode, Zoom x%d");
 				if (mode.map_size > 0)
-					zoom = 256 / mode.map_size;
+					zoom = 256.0f / ((float) mode.map_size);
+				mode.label = gettext("Minimap in surface mode, Zoom x%.*f");
 				break;
 			case MINIMAP_TYPE_RADAR:
-				mode.label = gettext("Minimap in radar mode, Zoom x%d");
 				if (mode.map_size > 0)
-					zoom = 512 / mode.map_size;
+					zoom = 512.0f / ((float) mode.map_size);
+				mode.label = gettext("Minimap in radar mode, Zoom x%.*f");
 				break;
 			case MINIMAP_TYPE_TEXTURE:
 				mode.label = gettext("Minimap in texture mode");
@@ -313,10 +313,15 @@ void Minimap::addMode(MinimapModeDef mode)
 	}
 	// else: Custom labels need mod-provided client-side translation
 
-	if (zoom >= 0) {
+	if (zoom >= 0.0f) {
 		char label_buf[1024];
+		int precision = 0;
+		if (zoom < 2.0f && std::floor(zoom) != zoom) {
+			precision = 1;
+		}
 		porting::mt_snprintf(label_buf, sizeof(label_buf),
-			mode.label.c_str(), zoom);
+			mode.label.c_str(), zoom, precision
+		);
 		mode.label = label_buf;
 	}
 


### PR DESCRIPTION
This PR fixes the default status text when changing the minimap mode to a minimap with a high size by displaying a false "x0" zoom of the minimap.

The bug it fixes is the following:

When you switch the minimap mode to a mode with a high size, so that the calculated zoom becomes smaller than 1, the message will display something like "Minimap in surface mode, zoom x0". This can happen in surface mode with size above 256.
This is obviously false, so this PR wants to fix this.

Yes, mods can always override this status text manually, but that’s no excuse for outright bugs in the default text.

This PR does the following:

* `zoom` var conveted to float
* If `zoom` is calculated to be lower than 2, displays one additional digit after the decimal point (exception: If `zoom` is exactly 1, so the default minimap modes still cleanly render as "x4", "x2" and "x1", rather than an awkward "x4", "x2" and "x1.0") (Comparing a float to *exactly* 1 without using epsilon should be OK since 1 has an exact float representation, right?)

## To do

This PR is ready for review.

## How to test

You can use this test mod code snippet to activate many minimap modes. Cycle through then in-game with the minimap key. Pay attention when the zoom approaches 2 or lower.

```
	player:set_minimap_modes({
		{ type = "off" },
		{ type = "surface", size = 1 },
		{ type = "surface", size = 2 },
		{ type = "surface", size = 3 },
		{ type = "surface", size = 4 },
		{ type = "surface", size = 5 },
		{ type = "surface", size = 6 },
		{ type = "surface", size = 7 },
		{ type = "surface", size = 8 },
		{ type = "surface", size = 9 },
		{ type = "surface", size = 10 },
		{ type = "surface", size = 11 },
		{ type = "surface", size = 12 },
		{ type = "surface", size = 13 },
		{ type = "surface", size = 14 },
		{ type = "surface", size = 15 },
		{ type = "surface", size = 16 },
		{ type = "surface", size = 32 },
		{ type = "surface", size = 64 },
		{ type = "surface", size = 128 },
		{ type = "surface", size = 156 },
		{ type = "surface", size = 192 },
		{ type = "surface", size = 250 },
		{ type = "surface", size = 255 },
		{ type = "surface", size = 256 },
		{ type = "surface", size = 257 },
		{ type = "surface", size = 287 },
		{ type = "surface", size = 300 },
		{ type = "surface", size = 384 },
		{ type = "surface", size = 400 },
		{ type = "surface", size = 425 },
		{ type = "surface", size = 450 },
		{ type = "surface", size = 475 },
		{ type = "surface", size = 500 },
		{ type = "surface", size = 512 },
		{ type = "radar", size = 64 },
		{ type = "radar", size = 128 },
		{ type = "radar", size = 256 },
		{ type = "radar", size = 300 },
		{ type = "radar", size = 350 },
		{ type = "radar", size = 400 },
		{ type = "radar", size = 450 },
		{ type = "radar", size = 512 },
	}, 1)
```

The final surface mode zoom level should be x0.5. It’s OK when a few zoom levels repeat close to zoom 1, this is just due to rounding and expected (I don’t want to add super precision to the status text).

It seems the minimap size is capped at 512 for some reason in both surface and radar mode, this is why I didn’t add higher values.