### PR TITLE
Take player height into account when restricting building nodes into yourself

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -122,7 +122,7 @@ camera_smoothing (Camera smoothing) float 0.0 0.0 100.0
 #    Requires: keyboard_mouse
 cinematic_camera_smoothing (Camera smoothing in cinematic mode) float 0.05 0.0 100.0
 
-#    If enabled, you can place nodes at the position (feet + eye level) where you stand.
+#    If enabled, you can place nodes at the position(s) your body occupies.
 #    This is helpful when working with nodeboxes in small areas.
 enable_build_where_you_stand (Build inside player) bool false
 

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -3179,14 +3179,32 @@ bool Game::nodePlacement(const ItemDefinition &selected_def,
 	try {
 		LocalPlayer *player = client->getEnv().getLocalPlayer();
 
+		bool build_where_you_stand = g_settings->getBool("enable_build_where_you_stand");
+		bool stands_inside = false;
+		if (!build_where_you_stand) {
+			// Check if attempting to place a node that player stands inside,
+			// depending on the player's height
+			aabb3f collisionbox = player->getCollisionbox();
+			u16 player_height = ceilf((collisionbox.MaxEdge.Y - collisionbox.MinEdge.Y) / BS);
+			// Check 5 nodes at most so we don't check a huge number of nodes
+			// in case of faulty collisionboxes
+			player_height = MYMIN(player_height, 5);
+			// Always check at least 1 node
+			player_height = MYMAX(player_height, 1);
+			for (int y=1; y<=player_height; y++) {
+				if (neighborpos == player->getStandingNodePos() + v3s16(0, y, 0)) {
+					stands_inside = true;
+					break;
+				}
+			}
+		}
+
 		// Don't place node when player would be inside new node
 		// NOTE: This is to be eventually implemented by a mod as client-side Lua
-		if (!predicted_f.walkable ||
-				g_settings->getBool("enable_build_where_you_stand") ||
+		if ((!predicted_f.walkable ||
+				build_where_you_stand) ||
 				(client->checkPrivilege("noclip") && g_settings->getBool("noclip")) ||
-				(predicted_f.walkable &&
-					neighborpos != player->getStandingNodePos() + v3s16(0, 1, 0) &&
-					neighborpos != player->getStandingNodePos() + v3s16(0, 2, 0))) {
+				(predicted_f.walkable && !stands_inside)) {
 			// This triggers the required mesh update too
 			client->addNode(p, predicted_node);
 			// Report to server


### PR DESCRIPTION
This PR fixes #17483.

Luanti restricts the placing of blocks into yourself. Previously, this only checked two nodes: Feet pos + the pos above. This was a problem because it assumed a player height of roughly 2 blocks. But players can be taller or shorter thanks to object properties.

This PR will change the number of nodes it checks, from the hardcoded two, to between 1 and 5 nodes, depending on the player’s height. Player height is derived from the collisionbox height: max. Y minus min. Y.

The maximum number of nodes to check is capped at 5 to prevent the node checking from going on forever in case of player collisionboxes that are absurdly high. The number 5 is completely arbitrary and if you know a more reasonable cap, please let me know. I don’t know which is the max. height that the engine still (reasonably) supports.

The rule is simple:

* Height 1 or below: Check 1 node
* Height 2 or below: Check 2 nodes
* Height 3 or below: Check 3 nodes
* Height 4 or below: Check 4 nodes
* Greater height: Check 5 nodes

## Q&A

- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)? It is a bugfix.

## To do

This PR is ready for review.

## How to test

First, make sure that `enable_build_where_you_stand = false`.

In DevTest, use the object property editor and punch in the air to edit your own selectionbox. Edit the upper Y bound. Try values 0.5, 1.5, 1.77, 2.5, 3.5, 4.5 and 5.5. Try whole numbers.

Then build blocks and try to place them inside of you. You should never be able to place blocks at your feet. At heights 1.1 to 2.0 (and the default height of 1.77), you should be blocked from placing blocks at your feet and the one node above. Note this is the current hardcoded behavior. At height 2.1 to 3.0, one additional node above that should be blocked. Repeat the test until you reach 6 nodes. (one extra node to test that the cap at 5 nodes works)

Finally, check if `enable_build_where_you_stand = true` works.