### PR TITLE
Main menu: Facilitate activating optional dependencies

### DIFF
--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -402,9 +402,9 @@ function pkgmgr.enable_mod(this, toset)
 	pkgmgr.enable_mod_by_id(this, this.data.selected_mod, toset)
 end
 
-function pkgmgr.enable_mod_by_id(this, id, toset)
+function pkgmgr.enable_mod_by_id(this, mod_id, toset)
 	local list = this.data.list:get_list()
-	local mod = list[id]
+	local mod = list[mod_id]
 
 	if mod.always_on then
 		return

--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -399,7 +399,7 @@ local function toggle_mod_or_modpack(list, toggled_mods, enabled_mods, toset, mo
 end
 
 function pkgmgr.enable_mod(this, toset)
-    pkgmgr.enable_mod_by_id(this, this.data.selected_mod, toset)
+	pkgmgr.enable_mod_by_id(this, this.data.selected_mod, toset)
 end
 
 function pkgmgr.enable_mod_by_id(this, id, toset)

--- a/builtin/mainmenu/content/pkgmgr.lua
+++ b/builtin/mainmenu/content/pkgmgr.lua
@@ -399,8 +399,12 @@ local function toggle_mod_or_modpack(list, toggled_mods, enabled_mods, toset, mo
 end
 
 function pkgmgr.enable_mod(this, toset)
+    pkgmgr.enable_mod_by_id(this, this.data.selected_mod, toset)
+end
+
+function pkgmgr.enable_mod_by_id(this, id, toset)
 	local list = this.data.list:get_list()
-	local mod = list[this.data.selected_mod]
+	local mod = list[id]
 
 	if mod.always_on then
 		return

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -137,27 +137,27 @@ local function get_formspec(data)
 				end
 			end
 		end
-        for i, dep_name in ipairs(soft_deps) do
-            local dep = enabled_mods_by_name[dep_name]
+		for i, dep_name in ipairs(soft_deps) do
+			local dep = enabled_mods_by_name[dep_name]
 
-            local is_installed = false
-            for _, m in pairs(all_mods) do
-                if m.name == dep_name then
-                    is_installed = true
-                    break
-                end
-            end
+			local is_installed = false
+			for _, m in pairs(all_mods) do
+				if m.name == dep_name then
+					is_installed = true
+					break
+				end
+			end
 
-            if dep and with_error[dep.virtual_path] then
-                soft_deps[i] = mt_color_orange .. "," .. dep_name .. " " .. fgettext("(Enabled, has error)")
-            elseif dep then
-                soft_deps[i] = mt_color_green .. "," .. dep_name
-            elseif is_installed then
-                soft_deps[i] = "," .. dep_name
-            else
-                soft_deps[i] = mt_color_grey .. "," .. dep_name
-            end
-        end
+			if dep and with_error[dep.virtual_path] then
+				soft_deps[i] = mt_color_orange .. "," .. dep_name .. " " .. fgettext("(Enabled, has error)")
+			elseif dep then
+				soft_deps[i] = mt_color_green .. "," .. dep_name
+			elseif is_installed then
+				soft_deps[i] = "," .. dep_name
+			else
+				soft_deps[i] = mt_color_grey .. "," .. dep_name
+			end
+		end
 
 		local hard_deps_str = table.concat(hard_deps, ",")
 		local soft_deps_str = table.concat(soft_deps, ",")
@@ -180,8 +180,8 @@ local function get_formspec(data)
 					-- TRANSLATORS: About mod dependencies
 					"label[0,1.75;" .. fgettext("Optional dependencies:") ..
 					"]" ..
-	                "tablecolumns[color;text]" ..
-	                "table[0,2.25;5,4;world_config_optdepends;" .. soft_deps_str .. ";]"
+					"tablecolumns[color;text]" ..
+					"table[0,2.25;5,4;world_config_optdepends;" .. soft_deps_str .. ";]"
 			end
 		else
 			if soft_deps_str == "" then
@@ -201,8 +201,8 @@ local function get_formspec(data)
 					-- TRANSLATORS: About mod dependencies
 					"label[0,3.9;" .. fgettext("Optional dependencies:") ..
 					"]" ..
-	                "tablecolumns[color;text]" ..
-	                "table[0,4.375;5,1.8;world_config_optdepends;" .. soft_deps_str .. ";]"
+					"tablecolumns[color;text]" ..
+					"table[0,4.375;5,1.8;world_config_optdepends;" .. soft_deps_str .. ";]"
 			end
 		end
 	end
@@ -270,7 +270,7 @@ local function handle_buttons(this, fields)
 		local event = core.explode_table_event(fields.world_config_optdepends)
 
 		if event.type == "DCL" then
-		    local list = this.data.list:get_list()
+			local list = this.data.list:get_list()
 			local mod = list[this.data.selected_mod]
 			local _, soft_deps = pkgmgr.get_dependencies(mod.path)
 			local dep_name = soft_deps[event.row]

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -272,15 +272,15 @@ local function handle_buttons(this, fields)
 		if event.type == "DCL" then
 		    local list = this.data.list:get_list()
 			local mod = list[this.data.selected_mod]
-            local _, soft_deps = pkgmgr.get_dependencies(mod.path)
-            local dep_name = soft_deps[event.row]
+			local _, soft_deps = pkgmgr.get_dependencies(mod.path)
+			local dep_name = soft_deps[event.row]
 
-            for i, dep in ipairs(list) do
-                if dep.name == dep_name then
-                    pkgmgr.enable_mod_by_id(this, i)
-                    break
-                end
-            end
+			for i, dep in ipairs(list) do
+				if dep.name == dep_name then
+					pkgmgr.enable_mod_by_id(this, i)
+					break
+				end
+			end
 		end
 
 		return true

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -136,32 +136,28 @@ local function get_formspec(data)
 					hard_deps[i] = mt_color_green .. dep_name
 				end
 			end
-			for i, dep_name in ipairs(soft_deps) do
-				local dep = enabled_mods_by_name[dep_name]
-
-				local is_installed = false
-				for _, m in pairs(all_mods) do
-                    if m.name == dep_name then
-                        is_installed = true
-                        break
-                    end
-                end
-
-				if dep and with_error[dep.virtual_path] then
-					soft_deps[i] = mt_color_orange .. "," .. dep_name .. " " .. fgettext("(Enabled, has error)")
-				elseif dep then
-					soft_deps[i] = mt_color_green .. "," .. dep_name
-				elseif is_installed then
-					soft_deps[i] = "," .. dep_name
-				else
-				    soft_deps[i] = mt_color_grey .. "," .. dep_name
-				end
-			end
-        else
-			for i, dep_name in ipairs(soft_deps) do
-			    soft_deps[i] = mt_color_grey .. "," .. dep_name
-			end
 		end
+        for i, dep_name in ipairs(soft_deps) do
+            local dep = enabled_mods_by_name[dep_name]
+
+            local is_installed = false
+            for _, m in pairs(all_mods) do
+                if m.name == dep_name then
+                    is_installed = true
+                    break
+                end
+            end
+
+            if dep and with_error[dep.virtual_path] then
+                soft_deps[i] = mt_color_orange .. "," .. dep_name .. " " .. fgettext("(Enabled, has error)")
+            elseif dep then
+                soft_deps[i] = mt_color_green .. "," .. dep_name
+            elseif is_installed then
+                soft_deps[i] = "," .. dep_name
+            else
+                soft_deps[i] = mt_color_grey .. "," .. dep_name
+            end
+        end
 
 		local hard_deps_str = table.concat(hard_deps, ",")
 		local soft_deps_str = table.concat(soft_deps, ",")

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -138,11 +138,28 @@ local function get_formspec(data)
 			end
 			for i, dep_name in ipairs(soft_deps) do
 				local dep = enabled_mods_by_name[dep_name]
+
+				local is_installed = false
+				for _, m in pairs(all_mods) do
+                    if m.name == dep_name then
+                        is_installed = true
+                        break
+                    end
+                end
+
 				if dep and with_error[dep.virtual_path] then
-					soft_deps[i] = mt_color_orange .. dep_name .. " " .. fgettext("(Enabled, has error)")
+					soft_deps[i] = mt_color_orange .. "," .. dep_name .. " " .. fgettext("(Enabled, has error)")
 				elseif dep then
-					soft_deps[i] = mt_color_green .. dep_name
+					soft_deps[i] = mt_color_green .. "," .. dep_name
+				elseif is_installed then
+					soft_deps[i] = "," .. dep_name
+				else
+				    soft_deps[i] = mt_color_grey .. "," .. dep_name
 				end
+			end
+        else
+			for i, dep_name in ipairs(soft_deps) do
+			    soft_deps[i] = mt_color_grey .. "," .. dep_name
 			end
 		end
 
@@ -167,8 +184,8 @@ local function get_formspec(data)
 					-- TRANSLATORS: About mod dependencies
 					"label[0,1.75;" .. fgettext("Optional dependencies:") ..
 					"]" ..
-					"textlist[0,2.25;5,4;world_config_optdepends;" ..
-					soft_deps_str .. ";0]"
+	                "tablecolumns[color;text]" ..
+	                "table[0,4.375;5,1.8;world_config_optdepends;" .. soft_deps_str .. ";]"
 			end
 		else
 			if soft_deps_str == "" then
@@ -188,8 +205,8 @@ local function get_formspec(data)
 					-- TRANSLATORS: About mod dependencies
 					"label[0,3.9;" .. fgettext("Optional dependencies:") ..
 					"]" ..
-					"textlist[0,4.375;5,1.8;world_config_optdepends;" ..
-					soft_deps_str .. ";0]"
+	                "tablecolumns[color;text]" ..
+	                "table[0,4.375;5,1.8;world_config_optdepends;" .. soft_deps_str .. ";]"
 			end
 		end
 	end
@@ -248,6 +265,26 @@ local function handle_buttons(this, fields)
 
 		if event.type == "DCL" then
 			pkgmgr.enable_mod(this)
+		end
+
+		return true
+	end
+
+	if fields.world_config_optdepends then
+		local event = core.explode_table_event(fields.world_config_optdepends)
+
+		if event.type == "DCL" then
+		    local list = this.data.list:get_list()
+			local mod = list[this.data.selected_mod]
+            local _, soft_deps = pkgmgr.get_dependencies(mod.path)
+            local dep_name = soft_deps[event.row]
+
+            for i, dep in ipairs(list) do
+                if dep.name == dep_name then
+                    pkgmgr.enable_mod_by_id(this, i)
+                    break
+                end
+            end
 		end
 
 		return true

--- a/builtin/mainmenu/dlg_config_world.lua
+++ b/builtin/mainmenu/dlg_config_world.lua
@@ -185,7 +185,7 @@ local function get_formspec(data)
 					"label[0,1.75;" .. fgettext("Optional dependencies:") ..
 					"]" ..
 	                "tablecolumns[color;text]" ..
-	                "table[0,4.375;5,1.8;world_config_optdepends;" .. soft_deps_str .. ";]"
+	                "table[0,2.25;5,4;world_config_optdepends;" .. soft_deps_str .. ";]"
 			end
 		else
 			if soft_deps_str == "" then


### PR DESCRIPTION
Attempts to solve issue https://github.com/luanti-org/luanti/issues/17487

> It is currently pretty tedious enabling optional dependencies of a mod. Enabling a mod does not automatically enable the optional dependencies, even when theyre installed. But if a player wishes to enable them as well, they now have to manually search through the list on the right.

Double clicking on the optional dependencies of a selected mod now toggles that dependency just the same as if it were double clicked in the main mod list on the right. So if a player enables a mod, they can easily also enabled the optional dependencies that they want to without having to hunt them down in the main list.

Just like before, enabled mods will be displayed in green, while disabled ones are white. Unlike before, it is now important to know if a mod is installed or not, so the not-installed mods are displayed in grey.

Toggling mods in the optional dependencies list behaves exactly the same, regardless whether or not the parent mod is enabled or disabled.

Here is a screenshot showing all 3 different types of optional dependencies of a mod:
<img width="798" height="515" alt="image" src="https://github.com/user-attachments/assets/0d088e89-d36b-4261-b590-5c14236562bf" />

# How to test:
- select a world
- select "select mods"
- select a mod with optional dependencies
- double click on the dependencies and observe them being toggled
- the whole process should feel intuitive

# Things intentionally left out:

There is no "enable all" checkbox for the optional dependencies because i could not think of a design that sufficiently communicates its more specific purpose when compared to the regular "enable all" checkbox. Also, since more granular control will always be necessary, adding such a checkbox later on would not retroactively make this pr obsolete.

I also considered sorting the dependencies so installed mods are at the top of the list, making them easier to install. However, I did not do that for now, because I could not see any instances of mod listing order being dynamic anywhere else and i did not want to introduce new complexities that dont align with other existing components' behavior.

Thanks for your time :)