### PR TITLE
Formspec: Add optional show_tooltip parameter to item_image_button[]

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3489,12 +3489,13 @@ Elements
 * `drawborder`: draw button border or not
 * `pressed texture name` is the filename of an image on pressed state
 
-### `item_image_button[<X>,<Y>;<W>,<H>;<item name>;<name>;<label>]`
+### `item_image_button[<X>,<Y>;<W>,<H>;<item name>;<name>;<label>;show_tooltip]`
 
 * `item name` is the registered name of an item/node
 * `name` is non-optional and must be unique, or else tooltips are broken.
 * The item description will be used as the tooltip. This can be overridden with
   a tooltip element.
+* `show_tooltip` (optional): if false, the tooltip will not be shown.
 
 ### `button_exit[<X>,<Y>;<W>,<H>;<name>;<label>]`
 

--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -3495,6 +3495,7 @@ Elements
 * `name` is non-optional and must be unique, or else tooltips are broken.
 * The item description will be used as the tooltip. This can be overridden with
   a tooltip element.
+* `label` is the text on the button
 * `show_tooltip` (optional): if false, the tooltip will not be shown.
 
 ### `button_exit[<X>,<Y>;<W>,<H>;<name>;<label>]`

--- a/games/devtest/mods/testformspec/formspec.lua
+++ b/games/devtest/mods/testformspec/formspec.lua
@@ -362,6 +362,12 @@ local tooltip_fs = [[
 	button[4,2;1,1;tt_btn;Button]
 	tooltip[tt_btn;Normal tooltip on a button]
 
+	item_image_button[5.5,2;1,1;testformspec:node;testformspec_item_tooltip;]
+	item_image_button[7,2;1,1;testformspec:node;testformspec_item_hypertip;;false]
+	style_type[hypertip;bgcolor=#0000ff99]
+	hypertip[7,2;1,1;;15;testformspec_item_hypertip_test;<global valign=center halign=center><b>Custom hypertip with item_image_button</b>]
+	style_type[hypertip;bgcolor=]
+
 	box[1,3.5;1,1;#ffff0080]
 	box[2.8,3.9;0.4,0.2;#ffffff80]
 	hypertip[1,3.5;1,1;3,4;20;hypertip_static;<big>Simple hypertip (<i>static</i>)</big>

--- a/src/gui/guiFormSpecMenu.cpp
+++ b/src/gui/guiFormSpecMenu.cpp
@@ -2337,7 +2337,7 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 	MY_CHECKCLIENT("item_image_button");
 
 	std::vector<std::string> parts;
-	if (!precheckElement("item_image_button", element, 5, 5, parts))
+	if (!precheckElement("item_image_button", element, 5, 6, parts))
 		return;
 
 	std::vector<std::string> v_pos = split(parts[0],',');
@@ -2345,6 +2345,10 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 	std::string item_name = parts[2];
 	std::string name = parts[3];
 	std::string label = parts[4];
+
+	bool show_tooltip = true;
+	if (parts.size() >= 6)
+		show_tooltip = is_yes(parts[5]);
 
 	label = unescape_string(label);
 	item_name = unescape_string(item_name);
@@ -2373,10 +2377,12 @@ void GUIFormSpecMenu::parseItemImageButton(parserData* data, const std::string &
 	ItemStack item;
 	item.deSerialize(item_name, idef);
 
-	m_tooltips[name] =
-		TooltipSpec(utf8_to_wide(item.getDefinition(idef).description),
-					m_default_tooltip_bgcolor,
-					m_default_tooltip_color);
+	if (show_tooltip) {
+		m_tooltips[name] =
+			TooltipSpec(utf8_to_wide(item.getDefinition(idef).description),
+						m_default_tooltip_bgcolor,
+						m_default_tooltip_color);
+	}
 
 	// the spec for the button
 	FieldSpec spec_btn(


### PR DESCRIPTION
Currently you can not disable showing a tooltip for an `item_image_button[]` element. This prevents modders from using `hypertip[]` elements with an `item_image_button[]`. This PR adds an optional parameter `show_tooltip` to the syntax for `item_image_button[]`.

- **Goal of the PR**
  Allow the option to not show a hardcoded tooltip in `item_image_button[]`

- **How does the PR work?**
  It adds an optional parameter to `item_image_button[]`

- **Does it resolve any reported issue?**
 No

- **Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?**
  [UI Improvements](https://github.com/luanti-org/luanti/blob/master/doc/direction.md#23-ui-improvements)

- **If not a bug fix, why is this PR needed?**
  To preserve the sanity of people like me who make formspecs

- **If you have used an LLM/AI to help with code or assets, you must disclose this.**
  Nope.

## To do

This PR is Ready for Review.

## How to test

Open Devtest -> run `/test_formspec` -> Tooltip tab -> hover the item buttons

**Before:**
<img width="456" height="150" alt="Screenshot From 2026-08-22 16-32-35" src="https://github.com/user-attachments/assets/61eb2415-9585-45b8-81c4-779ac4eca64f" />

**After:**
<img width="456" height="150" alt="Screenshot From 2026-08-22 16-26-19" src="https://github.com/user-attachments/assets/62ee8547-75b6-4791-8ae9-c0ab9e691496" />

