### PR TITLE
Fix serverside raycasts for rotated selection boxes

### DIFF
--- a/src/client/clientenvironment.cpp
+++ b/src/client/clientenvironment.cpp
@@ -459,7 +459,7 @@ void ClientEnvironment::getSelectedActiveObjects(
 		if (gcao != nullptr && gcao->getProperties().rotate_selectionbox) {
 			gcao->getSceneNode()->updateAbsolutePosition();
 			const v3f rad = obj->getSceneNode()->getAbsoluteTransformation().getRotationRadians();
-			collision = boxLineCollision(selection_box, rad,
+			collision = boxLineCollision(selection_box, core::quaternion(rad),
 				rel_pos, line_vector, &current_intersection, &current_normal, &current_raw_normal);
 		} else {
 			collision = boxLineCollision(selection_box, rel_pos, line_vector,

--- a/src/raycast.cpp
+++ b/src/raycast.cpp
@@ -124,23 +124,22 @@ bool boxLineCollision(const aabb3f &box, const v3f start,
 	return false;
 }
 
-bool boxLineCollision(const aabb3f &box, v3f rotation_radians,
+bool boxLineCollision(const aabb3f &box, core::quaternion rotation,
 	v3f start, v3f dir,
 	v3f *collision_point, v3f *collision_normal, v3f *raw_collision_normal)
 {
 	// Inversely transform the ray rather than rotating the box faces;
 	// this allows us to continue using a simple ray - AABB intersection
-	core::quaternion rot(rotation_radians);
-	rot.makeInverse();
+	rotation.makeInverse();
 
-	bool collision = boxLineCollision(box, rot * start, rot * dir, collision_point, collision_normal);
+	bool collision = boxLineCollision(box, rotation * start, rotation * dir, collision_point, collision_normal);
 	if (!collision)
 		return collision;
 
 	// Transform the results back
-	rot.makeInverse();
-	*collision_point = rot * *collision_point;
+	rotation.makeInverse();
+	*collision_point = rotation * *collision_point;
 	*raw_collision_normal = *collision_normal;
-	*collision_normal = rot * *collision_normal;
+	*collision_normal = rotation * *collision_normal;
 	return collision;
 }

--- a/src/raycast.h
+++ b/src/raycast.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <queue>
+#include <quaternion.h>
 #include "voxelalgorithms.h"
 #include "util/pointedthing.h"
 
@@ -63,6 +64,6 @@ public:
 bool boxLineCollision(const aabb3f &box, v3f start, v3f dir,
 	v3f *collision_point, v3f *collision_normal);
 
-bool boxLineCollision(const aabb3f &box, v3f box_rotation,
+bool boxLineCollision(const aabb3f &box, core::quaternion box_rotation,
 	v3f start, v3f dir,
 	v3f *collision_point, v3f *collision_normal, v3f *raw_collision_normal);

--- a/src/server/unit_sao.cpp
+++ b/src/server/unit_sao.cpp
@@ -14,6 +14,16 @@ UnitSAO::UnitSAO(ServerEnvironment *env, v3f pos) : ServerActiveObject(env, pos)
 	m_armor_groups["fleshy"] = 100;
 }
 
+core::quaternion UnitSAO::getTotalRotation() const
+{
+	// This replicates what happens clientside serverside, except for attachments
+	core::matrix4 rot;
+	setPitchYawRoll(rot, -m_rotation);
+	// First rotate by m_rotation, then rotate by the automatic rotate yaw
+	return core::quaternion(v3f(0, -m_rotation_add_yaw * core::DEGTORAD, 0))
+			* core::quaternion(rot.getRotationRadians());
+}
+
 ServerActiveObject *UnitSAO::getParent() const
 {
 	if (!m_attachment_parent_id)

--- a/src/server/unit_sao.h
+++ b/src/server/unit_sao.h
@@ -40,17 +40,7 @@ public:
 	// Rotation
 	void setRotation(v3f rotation) { m_rotation = rotation; }
 	const v3f &getRotation() const { return m_rotation; }
-	const v3f getTotalRotation() const {
-		// This replicates what happens clientside serverside
-		core::matrix4 rot;
-		setPitchYawRoll(rot, -m_rotation);
-		v3f res;
-		// First rotate by m_rotation, then rotate by the automatic rotate yaw
-		(core::quaternion(v3f(0, -m_rotation_add_yaw * core::DEGTORAD, 0))
-				* core::quaternion(rot.getRotationRadians()))
-				.toEuler(res);
-		return res * core::RADTODEG;
-	}
+	core::quaternion getTotalRotation() const;
 	v3f getRadRotation() { return m_rotation * core::DEGTORAD; }
 
 	// Deprecated


### PR DESCRIPTION
Fixes #17477

Regression from d74af2f1a: `boxLineCollision` expects radians, but `getTotalRotation` still produced degrees.

The fix gets rid of the degree/radians problem entirely by switching to quaternions. (The diff could have been kept more minimal but I think preventing any kind of radians/degree confusion in the future is worth it. The cleanup is still fairly local.)

Claude Fable spotted the bug while I was using it to assist in a refactor of the affected code (not included in this PR) and was also used for review.
