### PR TITLE
sky.cpp: Remove unnecessary helper

### DIFF
--- a/src/client/sky.cpp
+++ b/src/client/sky.cpp
@@ -705,25 +705,6 @@ void Sky::place_sky_body(
 	}
 }
 
-// FIXME: stupid helper that does a pointless texture upload/download
-static void getTextureAsImage(video::IImage *&dst, const std::string &name, ITextureSource *tsrc)
-{
-	if (dst) {
-		dst->drop();
-		dst = nullptr;
-	}
-	if (tsrc->isKnownSourceImage(name)) {
-		infostream << "Sky: loading image " << name << std::endl;
-		auto *texture = tsrc->getTexture(name);
-		assert(texture);
-		auto *driver = RenderingEngine::get_video_driver();
-		dst = driver->createImageFromData(
-			texture->getColorFormat(), texture->getSize(),
-			texture->lock(video::ETLM_READ_ONLY));
-		texture->unlock();
-	}
-}
-
 void Sky::setSunTexture(const std::string &sun_texture,
 		const std::string &sun_tonemap, ITextureSource *tsrc)
 {
@@ -731,7 +712,7 @@ void Sky::setSunTexture(const std::string &sun_texture,
 	// but lets at least update the tonemap before hand.
 	if (m_sun_params.tonemap != sun_tonemap || m_first_update) {
 		m_sun_params.tonemap = sun_tonemap;
-		getTextureAsImage(m_sun_tonemap, sun_tonemap, tsrc);
+		m_sun_tonemap.reset(tsrc->getImage(sun_tonemap));
 	}
 
 	if (m_sun_params.texture == sun_texture && !m_first_update)
@@ -774,7 +755,7 @@ void Sky::setMoonTexture(const std::string &moon_texture,
 	// but lets at least update the tonemap before hand.
 	if (m_moon_params.tonemap != moon_tonemap || m_first_update) {
 		m_moon_params.tonemap = moon_tonemap;
-		getTextureAsImage(m_moon_tonemap, moon_tonemap, tsrc);
+		m_moon_tonemap.reset(tsrc->getImage(moon_tonemap));
 	}
 
 	if (m_moon_params.texture == moon_texture && !m_first_update)

--- a/src/client/sky.h
+++ b/src/client/sky.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "irrlichttypes_bloated.h"
+#include <IImage.h>
 #include <ISceneNode.h>
 #include <CMeshBuffer.h>
 #include <array>
@@ -17,7 +18,6 @@
 namespace video
 {
 	class IVideoDriver;
-	class IImage;
 }
 
 class IShaderSource;
@@ -213,8 +213,8 @@ private:
 
 	video::ITexture *m_sun_texture = nullptr;
 	video::ITexture *m_moon_texture = nullptr;
-	video::IImage *m_sun_tonemap = nullptr;
-	video::IImage *m_moon_tonemap = nullptr;
+	irr_ptr<video::IImage> m_sun_tonemap;
+	irr_ptr<video::IImage> m_moon_tonemap;
 
 	void updateStars();
 

--- a/src/client/texturesource.cpp
+++ b/src/client/texturesource.cpp
@@ -73,6 +73,8 @@ public:
 	TextureSource();
 	virtual ~TextureSource();
 
+	video::IImage* getImage(const std::string &name);
+
 	u32 getTextureId(const std::string &name);
 
 	std::string getTextureName(u32 id);
@@ -245,6 +247,15 @@ video::IImage *TextureSource::getOrGenerateImage(const std::string &name,
 	}
 	source_image_names.merge(tmp);
 	return img;
+}
+
+video::IImage *TextureSource::getImage(const std::string &name)
+{
+	if (name.empty())
+		return nullptr;
+	assert(std::this_thread::get_id() == m_main_thread);
+	std::set<std::string> source_image_names;
+	return getOrGenerateImage(name, source_image_names);
 }
 
 u32 TextureSource::processRequestQueued(const TextureRequest &req)

--- a/src/client/texturesource.h
+++ b/src/client/texturesource.h
@@ -49,6 +49,9 @@ public:
 
 	using ISimpleTextureSource::getTexture;
 
+	/// @brief Returns an image from a texture string.
+	virtual video::IImage *getImage(const std::string &image)=0;
+
 	/// @brief Generates a texture string into a standard texture
 	/// @return its ID
 	virtual u32 getTextureId(const std::string &image)=0;


### PR DESCRIPTION
This patch addresses a nearly three-year-old issue raised at #13398. In addition to `sky.h`, `texturesource.cpp`, and `texturesource.h`, the patch modifies `sky.cpp` by removing a helper that reads `Sky::m_sun_tonemap` and `Sky::m_moon_tonemap` into the CPU in favor of a plain image approach, which is a `getImage()` method defined in the `texturesource` files. It reinterprets the tone maps as Irrlicht pointer objects, rather than raw `video::IImage`, inside `sky.h`.

For transparency's sake, the patch was created with the assistance of AI, specifically ChatGPT 5.6. It likely complies with this project's AI policy, because it is merely a small patch intended to address a simple bug, and hours were spent manually studying the code to determine the best way to create the patch. It compiles and runs successfully and should make reading the tone maps more efficient. If it does not, I will see how I can fix it.