### PR TITLE
[no-sq] Reserve RDIX entries used by the engine + cleanup function dumping

### DIFF
--- a/src/script/common/c_internal.cpp
+++ b/src/script/common/c_internal.cpp
@@ -3,7 +3,6 @@
 // Copyright (C) 2013 celeron55, Perttu Ahola <celeron55@gmail.com>
 
 #include "common/c_internal.h"
-#include "cpp_api/s_security.h"
 #include "util/numeric.h"
 #include "debug.h"
 #include "log.h"
@@ -186,14 +185,19 @@ void log_deprecated(lua_State *L, std::string_view message, int stack_depth, boo
 		infostream << script_get_backtrace(L) << std::endl;
 }
 
-void call_string_dump(lua_State *L, int idx)
+static int dump_helper(lua_State*, const void *p, size_t sz, void *ud)
 {
-	// Retrieve string.dump from untampered env
-	ScriptApiSecurity::getGlobalsBackup(L);
-	lua_getfield(L, -1, "string");
-	lua_getfield(L, -1, "dump");
-	lua_remove(L, -2); // remove _G
-	lua_remove(L, -2); // remove 'string' table
+	std::string *result = static_cast<std::string*>(ud);
+	result->append(static_cast<const char*>(p), sz);
+	return 0;
+}
+
+std::string dump_function_to_string(lua_State *L, int idx)
+{
+	std::string result;
 	lua_pushvalue(L, idx);
-	lua_call(L, 1, 1);
+	if (lua_dump(L, &dump_helper, &result) != 0)
+		throw LuaError("Unable to dump function");
+	lua_pop(L, 1);
+	return result;
 }

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -27,17 +27,17 @@ extern "C" {
 	Lua 5.2 and above define the LUA_RIDX_LAST macro. Only numbers above that
 	may be used for custom indices, anything else is reserved.
 
-	Lua 5.1 / LuaJIT do not use any numeric indices (only string indices),
-	so we can use numeric indices freely.
+	Lua 5.1 / LuaJIT only hardcode the 0 numerical index (FREELIST_REF)
+	but will use free numerical indices at runtime (luaL_ref)
 */
 enum {
 #ifdef LUA_RIDX_LAST
-	CUSTOM_RIDX_BEFORE_ = LUA_RIDX_LAST,
+	CUSTOM_RIDX_FIRST = LUA_RIDX_LAST + 1,
 #else
-	CUSTOM_RIDX_BEFORE_ = 0,
+	CUSTOM_RIDX_FIRST = 1,
 #endif
 
-	CUSTOM_RIDX_SCRIPTAPI,
+	CUSTOM_RIDX_SCRIPTAPI = CUSTOM_RIDX_FIRST,
 	/// @warning don't use directly, `ScriptApiSecurity` has wrappers
 	CUSTOM_RIDX_GLOBALS_BACKUP,
 	CUSTOM_RIDX_CURRENT_MOD_NAME,
@@ -54,6 +54,8 @@ enum {
 	CUSTOM_RIDX_READ_NODE,
 	CUSTOM_RIDX_PUSH_NODE,
 	CUSTOM_RIDX_PUSH_MOVERESULT1,
+
+	CUSTOM_RIDX_LAST,
 };
 
 

--- a/src/script/common/c_internal.h
+++ b/src/script/common/c_internal.h
@@ -145,7 +145,10 @@ DeprecatedHandlingMode get_deprecated_handling_mode();
  */
 void log_deprecated(lua_State *L, std::string_view message,
 	int stack_depth = 1, bool once = false);
-
-// Safely call string.dump on a function value
-// (does not pop, leaves one value on stack)
-void call_string_dump(lua_State *L, int idx);
+/**
+ * @brief Dumps a function at index to a string
+ *
+ * @throws LuaError if it's unable to dump the function
+ *         the Lua stack state is not defined if this happens.
+ */
+std::string dump_function_to_string(lua_State *L, int idx);

--- a/src/script/common/c_packer.cpp
+++ b/src/script/common/c_packer.cpp
@@ -200,7 +200,7 @@ void script_register_packer(lua_State *L, const char *regname,
 
 	// Save metatable so we can identify instances later
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_METATABLE_MAP);
-	if (lua_isnil(L, -1)) {
+	if (lua_islightuserdata(L, -1)) { // when uninitialized
 		lua_newtable(L);
 		lua_pushvalue(L, -1);
 		lua_rawseti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_METATABLE_MAP);

--- a/src/script/common/c_packer.cpp
+++ b/src/script/common/c_packer.cpp
@@ -372,12 +372,7 @@ static VectorRef<PackedInstr> pack_inner(lua_State *L, int idx, int vidx, Packed
 			if (r)
 				return r;
 			r = emplace(pv, LUA_TFUNCTION);
-			call_string_dump(L, idx);
-			size_t len;
-			const char *str = lua_tolstring(L, -1, &len);
-			assert(str);
-			r->sdata.assign(str, len);
-			lua_pop(L, 1);
+			r->sdata = dump_function_to_string(L, idx);
 			return r;
 		}
 		case LUA_TUSERDATA: {

--- a/src/script/cpp_api/s_base.cpp
+++ b/src/script/cpp_api/s_base.cpp
@@ -73,6 +73,12 @@ ScriptApiBase::ScriptApiBase(ScriptingType type):
 
 	lua_atpanic(m_luastack, &luaPanic);
 
+	// reserve r-indices for the engine
+	for (int i = CUSTOM_RIDX_FIRST; i < CUSTOM_RIDX_LAST; i++) {
+		lua_pushlightuserdata(m_luastack, nullptr);
+		lua_rawseti(m_luastack, LUA_REGISTRYINDEX, i);
+	}
+
 	if (m_type == ScriptingType::Client || m_type == ScriptingType::SSCSM)
 		clientOpenLibs(m_luastack);
 	else

--- a/src/script/cpp_api/s_security.cpp
+++ b/src/script/cpp_api/s_security.cpp
@@ -687,7 +687,7 @@ void ScriptApiSecurity::getGlobalsBackup(lua_State *L)
 	}
 	lua_rawgeti(L, LUA_REGISTRYINDEX, CUSTOM_RIDX_GLOBALS_BACKUP);
 	// We cannot fulfill the callers wish securely if they don't exist.
-	FATAL_ERROR_IF(lua_isnil(L, -1), "Globals backup requested, but it is not available. Cannot proceed securely.");
+	FATAL_ERROR_IF(!lua_istable(L, -1), "Globals backup requested, but it is not available. Cannot proceed securely.");
 }
 
 bool ScriptApiSecurity::safeLoadString(lua_State *L, std::string_view code, const char *chunk_name)

--- a/src/script/lua_api/l_async.cpp
+++ b/src/script/lua_api/l_async.cpp
@@ -5,27 +5,17 @@
 #include "lua_api/l_async.h"
 #include "cpp_api/s_async.h"
 
-static std::string get_serialized_function(lua_State *L, int index)
-{
-	luaL_checktype(L, index, LUA_TFUNCTION);
-	call_string_dump(L, index);
-	size_t func_length;
-	const char *serialized_func_raw = lua_tolstring(L, -1, &func_length);
-	std::string serialized_func(serialized_func_raw, func_length);
-	lua_pop(L, 1);
-	return serialized_func;
-}
-
 // do_async_callback(func, params, mod_origin)
 int ModApiAsync::l_do_async_callback(lua_State *L)
 {
 	NO_MAP_LOCK_REQUIRED;
 	ScriptApiAsync *script = getScriptApi<ScriptApiAsync>(L);
 
+	luaL_checktype(L, 1, LUA_TFUNCTION);
 	luaL_checktype(L, 2, LUA_TTABLE);
 	luaL_checktype(L, 3, LUA_TSTRING);
 
-	auto serialized_func = get_serialized_function(L, 1);
+	auto serialized_func = dump_function_to_string(L, 1);
 	PackedValue *param = script_pack(L, 2);
 	std::string mod_origin = readParam<std::string>(L, 3);
 

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -1102,18 +1102,10 @@ int ModApiMainMenu::l_do_async_callback(lua_State *L)
 	MainMenuScripting *script = getScriptApi<MainMenuScripting>(L);
 
 	luaL_checktype(L, 1, LUA_TFUNCTION);
-	call_string_dump(L, 1);
-	size_t func_length;
-	const char *serialized_func_raw = lua_tolstring(L, -1, &func_length);
-
-	size_t param_length;
-	const char* serialized_param_raw = luaL_checklstring(L, 2, &param_length);
-
 	u32 jobId = script->queueAsync(
-		std::string(serialized_func_raw, func_length),
-		std::string(serialized_param_raw, param_length));
+		dump_function_to_string(L, 1),
+		readParam<std::string>(L, 2));
 
-	lua_settop(L, 0);
 	lua_pushinteger(L, jobId);
 	return 1;
 }


### PR DESCRIPTION
This makes sure luaL_ref generated keys never overlap with well-defined numerical indicies used by the game engine. Not currently an issue as far as I know but could easily become a difficult to debug crash in the future.

## How to test

See the game starts I guess, not really much to test
