### PR TITLE
Bind to socket before starting server

### DIFF
--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -414,7 +414,7 @@ void Client::connect(const Address &address, const std::string &address_name)
 	}
 
 	m_address_name = address_name;
-	m_con.reset(con::createMTP(CONNECTION_TIMEOUT, address.isIPv6(), this));
+	m_con.reset(con::createMTP(/*is_server=*/false, UDPSocket(address.isIPv6()), this));
 
 	infostream << "Connecting to server at ";
 	address.print(infostream);

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -414,7 +414,8 @@ void Client::connect(const Address &address, const std::string &address_name)
 	}
 
 	m_address_name = address_name;
-	m_con.reset(con::createMTP(/*is_server=*/false, UDPSocket(address.isIPv6()), this));
+	m_con.reset(con::createMTP(/*is_server=*/false,
+			UDPSocket::CreateEphemeral(address.isIPv6()), this));
 
 	infostream << "Connecting to server at ";
 	address.print(infostream);

--- a/src/client/clientlauncher.cpp
+++ b/src/client/clientlauncher.cpp
@@ -469,7 +469,8 @@ bool ClientLauncher::launch_game(GameErrorData &errordata, GameStartData &start_
 	if (start_data.isSinglePlayer()) {
 		start_data.name = "singleplayer";
 		start_data.password = "";
-		start_data.socket_port = myrand_range(49152, 65535);
+		// let the OS pick one for us
+		start_data.socket_port = 0;
 	} else {
 		g_settings->set("name", start_data.name);
 	}

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -421,7 +421,7 @@ Game::~Game()
 bool Game::startup(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		const GameStartData &start_data,
+		GameStartData &start_data,
 		GameErrorData &errordata,
 		ChatBackend *chat_backend)
 {
@@ -456,8 +456,7 @@ bool Game::startup(volatile std::sig_atomic_t *kill,
 
 	g_client_translations->clear();
 
-	if (!init(start_data.world_spec.path, start_data.address,
-			start_data.socket_port, start_data.game_spec))
+	if (!init(start_data))
 		return false;
 
 	if (!createClient(start_data))
@@ -683,11 +682,7 @@ void Game::shutdown()
  ****************************************************************************/
 /****************************************************************************/
 
-bool Game::init(
-		const std::string &map_dir,
-		const std::string &address,
-		u16 port,
-		const SubgameSpec &gamespec)
+bool Game::init(GameStartData &start_data)
 {
 	texture_src = createTextureSource();
 
@@ -711,8 +706,8 @@ bool Game::init(
 		return false;
 
 	// Create a server if not connecting to an existing one
-	if (address.empty()) {
-		if (!createServer(map_dir, gamespec, port))
+	if (start_data.address.empty()) {
+		if (!createServer(start_data))
 			return false;
 	}
 
@@ -744,8 +739,7 @@ bool Game::initSound()
 	return true;
 }
 
-bool Game::createServer(const std::string &map_dir,
-		const SubgameSpec &gamespec, u16 port)
+bool Game::createServer(GameStartData &start_data)
 {
 	showOverlayMessage(N_("Creating server..."), 0, 5);
 
@@ -758,7 +752,7 @@ bool Game::createServer(const std::string &map_dir,
 		bind_str = g_settings->get("bind_address");
 	}
 
-	Address bind_addr(0, 0, 0, 0, port);
+	Address bind_addr(0, 0, 0, 0, start_data.socket_port);
 
 	if (g_settings->getBool("ipv6_server"))
 		bind_addr.setAddress(static_cast<IPv6AddressBytes*>(nullptr));
@@ -775,8 +769,13 @@ bool Game::createServer(const std::string &map_dir,
 		return false;
 	}
 
-	server = new Server(map_dir, gamespec, simple_singleplayer_mode, bind_addr,
-			false, nullptr, &(errordata->message));
+	UDPSocket server_socket(bind_addr);
+	// in singleplayer mode the OS assigns us the port in bind
+	start_data.socket_port = server_socket.GetBindAddress().getPort();
+
+	server = new Server(start_data.world_spec.path, start_data.game_spec,
+		simple_singleplayer_mode, std::move(server_socket),
+		false, nullptr, &(errordata->message));
 
 	auto start_thread = runInThread([=] {
 		server->start();
@@ -3777,12 +3776,12 @@ void Game::readSettings()
 void the_game(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		const GameStartData &start_data,
+		GameStartData &start_data,
 		GameErrorData &errordata,
 		ChatBackend &chat_backend)
 {
 	Game game;
-	std::string &error_message = errordata.message;
+	std::string error_message;
 
 	try {
 
@@ -3795,21 +3794,24 @@ void the_game(volatile std::sig_atomic_t *kill,
 		const std::string ver_err = fmtgettext("The server is probably running a different version of %s.", PROJECT_NAME_C);
 		error_message = strgettext("A serialization error occurred:") +"\n"
 				+ e.what() + "\n\n" + ver_err;
-		errorstream << error_message << std::endl;
 	} catch (ServerError &e) {
-		error_message = e.what();
-		errorstream << "ServerError: " << error_message << std::endl;
+		error_message = "ServerError: ";
+		error_message.append(e.what());
 	} catch (ModError &e) {
 		// DO NOT TRANSLATE the `ModError`, it's used by `ui.lua`
 		error_message = std::string("ModError: ") + e.what() +
 				strgettext("\nCheck debug.txt for details.");
-		errorstream << error_message << std::endl;
 	} catch (con::PeerNotFoundException &e) {
 		error_message = gettext("Connection error (timed out?)");
-		errorstream << error_message << std::endl;
 	} catch (ShaderException &e) {
 		error_message = e.what();
+	} catch (SocketException &e) {
+		error_message = e.what();
+	}
+
+	if (!error_message.empty()) {
 		errorstream << error_message << std::endl;
+		errordata.message = std::move(error_message);
 	}
 
 	game.shutdown();

--- a/src/client/game.cpp
+++ b/src/client/game.cpp
@@ -769,9 +769,9 @@ bool Game::createServer(GameStartData &start_data)
 		return false;
 	}
 
-	UDPSocket server_socket(bind_addr);
+	UDPSocket server_socket = UDPSocket::Create(bind_addr);
 	// in singleplayer mode the OS assigns us the port in bind
-	start_data.socket_port = server_socket.GetBindAddress().getPort();
+	start_data.socket_port = server_socket.GetLocalAddress().getPort();
 
 	server = new Server(start_data.world_spec.path, start_data.game_spec,
 		simple_singleplayer_mode, std::move(server_socket),

--- a/src/client/game.h
+++ b/src/client/game.h
@@ -40,6 +40,6 @@ struct CameraOrientation {
 void the_game(volatile std::sig_atomic_t *kill,
 		InputHandler *input,
 		RenderingEngine *rendering_engine,
-		const GameStartData &start_data,
+		GameStartData &start_data,
 		GameErrorData &errordata,
 		ChatBackend &chat_backend);

--- a/src/client/game_internal.h
+++ b/src/client/game_internal.h
@@ -110,7 +110,7 @@ public:
 	bool startup(volatile std::sig_atomic_t *kill,
 			InputHandler *input,
 			RenderingEngine *rendering_engine,
-			const GameStartData &game_params,
+			GameStartData &game_params,
 			GameErrorData &errordata,
 			ChatBackend *chat_backend);
 
@@ -125,11 +125,9 @@ public:
 protected:
 
 	// Basic initialisation
-	bool init(const std::string &map_dir, const std::string &address,
-			u16 port, const SubgameSpec &gamespec);
+	bool init(GameStartData &start_data);
 	bool initSound();
-	bool createServer(const std::string &map_dir,
-			const SubgameSpec &gamespec, u16 port);
+	bool createServer(GameStartData &start_data);
 	void copyServerClientCache();
 
 	// Client creation

--- a/src/gameparams.h
+++ b/src/gameparams.h
@@ -14,10 +14,10 @@ struct GameParams
 {
 	GameParams() = default;
 
-	u16 socket_port;
 	std::string world_path;
 	SubgameSpec game_spec;
 	bool is_dedicated_server;
+	u16 socket_port;
 };
 
 enum class ELoginRegister {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1213,7 +1213,7 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 
 		try {
 			Server server(game_params.world_path, game_params.game_spec,
-					false, UDPSocket(bind_addr), true, &iface);
+					false, UDPSocket::Create(bind_addr), true, &iface);
 
 			g_term_console.setup(&iface, &kill, admin_nick);
 
@@ -1251,7 +1251,7 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 		try {
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec, false,
-					UDPSocket(bind_addr), true);
+					UDPSocket::Create(bind_addr), true);
 			server.start();
 
 			// Run server
@@ -1352,7 +1352,8 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 		return false;
 	}
 	const std::string &backend = world_mt.get("backend");
-	Server server(game_params.world_path, game_params.game_spec, false, UDPSocket(Address(u32(0), 0)), false);
+	Server server(game_params.world_path, game_params.game_spec, false,
+			UDPSocket::CreateEphemeral(false), false);
 	MapDatabase *db = ServerMap::createDatabase(backend, game_params.world_path, world_mt);
 
 	u32 count = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1212,9 +1212,8 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 		volatile auto &kill = *porting::signal_handler_killstatus();
 
 		try {
-			// Create server
 			Server server(game_params.world_path, game_params.game_spec,
-					false, bind_addr, true, &iface);
+					false, UDPSocket(bind_addr), true, &iface);
 
 			g_term_console.setup(&iface, &kill, admin_nick);
 
@@ -1230,6 +1229,10 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 		} catch (const ServerError &e) {
 			g_term_console.stopAndWaitforThread();
 			errorstream << "ServerError: " << e.what() << std::endl;
+			return false;
+		} catch (const SocketException &e) {
+			g_term_console.stopAndWaitforThread();
+			errorstream << "SocketException: " << e.what() << std::endl;
 			return false;
 		}
 
@@ -1248,7 +1251,7 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 		try {
 			// Create server
 			Server server(game_params.world_path, game_params.game_spec, false,
-				bind_addr, true);
+					UDPSocket(bind_addr), true);
 			server.start();
 
 			// Run server
@@ -1260,6 +1263,9 @@ static bool run_dedicated_server(const GameParams &game_params, const Settings &
 			return false;
 		} catch (const ServerError &e) {
 			errorstream << "ServerError: " << e.what() << std::endl;
+			return false;
+		} catch (SocketException &e) {
+			errorstream << "SocketException: " << e.what() << std::endl;
 			return false;
 		}
 	}
@@ -1346,7 +1352,7 @@ static bool recompress_map_database(const GameParams &game_params, const Setting
 		return false;
 	}
 	const std::string &backend = world_mt.get("backend");
-	Server server(game_params.world_path, game_params.game_spec, false, Address(), false);
+	Server server(game_params.world_path, game_params.game_spec, false, UDPSocket(Address(u32(0), 0)), false);
 	MapDatabase *db = ServerMap::createDatabase(backend, game_params.world_path, world_mt);
 
 	u32 count = 0;

--- a/src/network/connection.cpp
+++ b/src/network/connection.cpp
@@ -7,11 +7,11 @@
 namespace con
 {
 
-IConnection *createMTP(float timeout, bool ipv6, PeerHandler *handler)
+IConnection *createMTP(bool is_server, UDPSocket &&socket, PeerHandler *handler)
 {
 	// safe minimum across internet networks for ipv4 and ipv6
 	constexpr u32 MAX_PACKET_SIZE = 512;
-	return new con::Connection(MAX_PACKET_SIZE, timeout, ipv6, handler);
+	return new con::Connection(MAX_PACKET_SIZE, CONNECTION_TIMEOUT, std::move(socket), is_server, handler);
 }
 
 }

--- a/src/network/connection.h
+++ b/src/network/connection.h
@@ -5,7 +5,7 @@
 
 #include "irrlichttypes.h"
 #include "networkprotocol.h" // session_t
-#include "socket.h" // Address
+#include "socket.h" // Address, UDPSocket
 
 class NetworkPacket;
 class PeerHandler;
@@ -48,7 +48,6 @@ class IConnection
 public:
 	virtual ~IConnection() = default;
 
-	virtual void Serve(Address bind_addr) = 0;
 	virtual void Connect(Address address) = 0;
 	virtual bool Connected() = 0;
 	virtual void Disconnect() = 0;
@@ -68,6 +67,6 @@ public:
 };
 
 // MTP = Minetest Protocol
-IConnection *createMTP(float timeout, bool ipv6, PeerHandler *handler);
+IConnection *createMTP(bool is_server, UDPSocket &&socket, PeerHandler *handler);
 
 } // namespace

--- a/src/network/mtp/impl.cpp
+++ b/src/network/mtp/impl.cpp
@@ -547,13 +547,6 @@ ConnectionCommandPtr ConnectionCommand::create(ConnectionCommandType type)
 	return ConnectionCommandPtr(new ConnectionCommand(type));
 }
 
-ConnectionCommandPtr ConnectionCommand::serve(Address address)
-{
-	auto c = create(CONNCMD_SERVE);
-	c->address = address;
-	return c;
-}
-
 ConnectionCommandPtr ConnectionCommand::connect(Address address)
 {
 	auto c = create(CONNCMD_CONNECT);
@@ -1237,8 +1230,6 @@ const char *ConnectionEvent::describe() const
 		return "CONNEVENT_PEER_ADDED";
 	case CONNEVENT_PEER_REMOVED:
 		return "CONNEVENT_PEER_REMOVED";
-	case CONNEVENT_BIND_FAILED:
-		return "CONNEVENT_BIND_FAILED";
 	}
 	return "Invalid ConnectionEvent";
 }
@@ -1274,18 +1265,13 @@ ConnectionEventPtr ConnectionEvent::peerRemoved(session_t peer_id, bool is_timeo
 	return e;
 }
 
-ConnectionEventPtr ConnectionEvent::bindFailed()
-{
-	return create(CONNEVENT_BIND_FAILED);
-}
-
 /*
 	Connection
 */
 
 Connection::Connection(u32 max_packet_size, float timeout,
-		bool ipv6, PeerHandler *peerhandler) :
-	m_udpSocket(ipv6),
+		UDPSocket &&socket, bool is_server, PeerHandler *peerhandler) :
+	m_udpSocket(std::move(socket)),
 	m_protocol_id(PROTOCOL_ID),
 	m_sendThread(new ConnectionSendThread(max_packet_size, timeout)),
 	m_receiveThread(new ConnectionReceiveThread()),
@@ -1295,6 +1281,8 @@ Connection::Connection(u32 max_packet_size, float timeout,
 	/* Amount of time Receive() will wait for data, this is entirely different
 	 * from the connection timeout */
 	m_udpSocket.setTimeoutMs(500);
+	if (is_server)
+		SetPeerID(PEER_ID_SERVER);
 
 	m_sendThread->setParent(this);
 	m_receiveThread->setParent(this);
@@ -1421,11 +1409,6 @@ void Connection::putCommand(ConnectionCommandPtr c)
 	}
 }
 
-void Connection::Serve(Address bind_addr)
-{
-	putCommand(ConnectionCommand::serve(bind_addr));
-}
-
 void Connection::Connect(Address address)
 {
 	putCommand(ConnectionCommand::connect(address));
@@ -1492,9 +1475,6 @@ bool Connection::ReceiveTimeoutMs(NetworkPacket *pkt, u32 timeout_ms)
 				m_bc_peerhandler->deletingPeer(&tmp, e.timeout);
 			continue;
 		}
-		case CONNEVENT_BIND_FAILED:
-			throw ConnectionBindFailed("Failed to bind socket "
-					"(port already in use?)");
 		}
 	}
 	return false;

--- a/src/network/mtp/impl.h
+++ b/src/network/mtp/impl.h
@@ -52,8 +52,7 @@ enum ConnectionEventType {
 	CONNEVENT_NONE,
 	CONNEVENT_DATA_RECEIVED,
 	CONNEVENT_PEER_ADDED,
-	CONNEVENT_PEER_REMOVED,
-	CONNEVENT_BIND_FAILED,
+	CONNEVENT_PEER_REMOVED
 };
 
 struct ConnectionEvent;
@@ -75,7 +74,6 @@ struct ConnectionEvent
 	static ConnectionEventPtr dataReceived(session_t peer_id, const Buffer<u8> &data);
 	static ConnectionEventPtr peerAdded(session_t peer_id, Address address);
 	static ConnectionEventPtr peerRemoved(session_t peer_id, bool is_timeout, Address address);
-	static ConnectionEventPtr bindFailed();
 
 	const char *describe() const;
 
@@ -226,8 +224,8 @@ public:
 	friend class ConnectionSendThread;
 	friend class ConnectionReceiveThread;
 
-	Connection(u32 max_packet_size, float timeout, bool ipv6,
-			PeerHandler *peerhandler);
+	Connection(u32 max_packet_size, float timeout, UDPSocket &&socket,
+			bool is_server, PeerHandler *peerhandler);
 	~Connection();
 
 	/* Interface */
@@ -235,7 +233,6 @@ public:
 
 	void putCommand(ConnectionCommandPtr c);
 
-	void Serve(Address bind_addr);
 	void Connect(Address address);
 	bool Connected();
 	void Disconnect();

--- a/src/network/mtp/internal.h
+++ b/src/network/mtp/internal.h
@@ -317,7 +317,6 @@ private:
 
 enum ConnectionCommandType{
 	CONNCMD_NONE,
-	CONNCMD_SERVE,
 	CONNCMD_CONNECT,
 	CONNCMD_DISCONNECT,
 	CONNCMD_DISCONNECT_PEER,
@@ -342,7 +341,6 @@ struct ConnectionCommand
 
 	DISABLE_CLASS_COPY(ConnectionCommand);
 
-	static ConnectionCommandPtr serve(Address address);
 	static ConnectionCommandPtr connect(Address address);
 	static ConnectionCommandPtr disconnect();
 	static ConnectionCommandPtr disconnect_peer(session_t peer_id);

--- a/src/network/mtp/threads.cpp
+++ b/src/network/mtp/threads.cpp
@@ -447,7 +447,6 @@ void ConnectionSendThread::processReliableCommand(ConnectionCommandPtr &c)
 			return;
 		}
 
-		case CONNCMD_SERVE:
 		case CONNCMD_CONNECT:
 		case CONNCMD_DISCONNECT:
 		case CONCMD_ACK:
@@ -468,12 +467,6 @@ void ConnectionSendThread::processNonReliableCommand(ConnectionCommandPtr &c_ptr
 		case CONNCMD_NONE:
 			LOG(dout_con << m_connection->getDesc()
 				<< " UDP processing CONNCMD_NONE" << std::endl);
-			return;
-		case CONNCMD_SERVE:
-			LOG(dout_con << m_connection->getDesc()
-				<< " UDP processing CONNCMD_SERVE port="
-				<< c.address.serializeString() << std::endl);
-			serve(c.address);
 			return;
 		case CONNCMD_CONNECT:
 			LOG(dout_con << m_connection->getDesc()
@@ -516,20 +509,6 @@ void ConnectionSendThread::processNonReliableCommand(ConnectionCommandPtr &c_ptr
 		default:
 			LOG(dout_con << m_connection->getDesc()
 				<< " Invalid command type: " << c.type << std::endl);
-	}
-}
-
-void ConnectionSendThread::serve(Address bind_address)
-{
-	LOG(dout_con << m_connection->getDesc()
-		<< "UDP serving at port " << bind_address.serializeString() << std::endl);
-	try {
-		m_connection->m_udpSocket.Bind(bind_address);
-		m_connection->SetPeerID(PEER_ID_SERVER);
-	}
-	catch (SocketException &e) {
-		// Create event
-		m_connection->putEvent(ConnectionEvent::bindFailed());
 	}
 }
 

--- a/src/network/mtp/threads.cpp
+++ b/src/network/mtp/threads.cpp
@@ -523,14 +523,6 @@ void ConnectionSendThread::connect(Address address)
 	// Create event
 	m_connection->putEvent(ConnectionEvent::peerAdded(peer->id, peer->address));
 
-	Address bind_addr;
-	if (address.isIPv6())
-		bind_addr.setAddress(static_cast<IPv6AddressBytes*>(nullptr));
-	else
-		bind_addr.setAddress(static_cast<u32>(0));
-
-	m_connection->m_udpSocket.Bind(bind_addr);
-
 	// Send a dummy packet to server with peer_id = PEER_ID_INEXISTENT
 	m_connection->SetPeerID(PEER_ID_INEXISTENT);
 	NetworkPacket pkt(0, 0);

--- a/src/network/mtp/threads.h
+++ b/src/network/mtp/threads.h
@@ -66,7 +66,6 @@ private:
 
 	void processReliableCommand(ConnectionCommandPtr &c);
 	void processNonReliableCommand(ConnectionCommandPtr &c);
-	void serve(Address bind_address);
 	void connect(Address address);
 	void disconnect();
 	void disconnect_peer(session_t peer_id);

--- a/src/network/networkexceptions.h
+++ b/src/network/networkexceptions.h
@@ -24,12 +24,6 @@ public:
 	ConnectionException(const char *s) : BaseException(s) {}
 };
 
-class ConnectionBindFailed : public BaseException
-{
-public:
-	ConnectionBindFailed(const char *s) : BaseException(s) {}
-};
-
 class InvalidIncomingDataException : public BaseException
 {
 public:

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -59,19 +59,14 @@ void sockets_cleanup()
 	UDPSocket
 */
 
-bool UDPSocket::init(bool ipv6, bool noExceptions)
+void UDPSocket::Init(bool ipv6)
 {
 	if (!g_sockets_initialized) {
-		verbosestream << "Sockets not initialized" << std::endl;
-		return false;
+		throw SocketException("Sockets not initialized");
 	}
 
 	if (m_handle >= 0) {
-		auto msg = "Cannot initialize socket twice";
-		verbosestream << msg << std::endl;
-		if (noExceptions)
-			return false;
-		throw SocketException(msg);
+		throw SocketException("Cannot initialize socket twice");
 	}
 
 	// Use IPv6 if specified
@@ -82,14 +77,10 @@ bool UDPSocket::init(bool ipv6, bool noExceptions)
 		auto msg = std::string("Failed to create socket: ") +
 			SOCKET_ERR_STR(LAST_SOCKET_ERR());
 		verbosestream << msg << std::endl;
-		if (noExceptions)
-			return false;
 		throw SocketException(msg);
 	}
 
 	setTimeoutMs(0);
-
-	return true;
 }
 
 void UDPSocket::Close()
@@ -106,6 +97,8 @@ void UDPSocket::Close()
 
 void UDPSocket::Bind(Address addr)
 {
+	if (m_handle == -1)
+		Init(addr.isIPv6());
 	if (addr.getFamily() != m_addr_family) {
 		const char *errmsg =
 				"Socket and bind address families do not match";
@@ -158,7 +151,7 @@ void UDPSocket::Bind(Address addr)
 	}
 }
 
-Address UDPSocket::GetBindAddress()
+Address UDPSocket::GetLocalAddress()
 {
 	struct sockaddr_storage addr;
 	socklen_t addr_len = sizeof(addr);

--- a/src/network/socket.cpp
+++ b/src/network/socket.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <cstring>
 #include "util/numeric.h"
-#include "address.h"
 #include "constants.h"
 #include "log.h"
 #include "networkexceptions.h"
@@ -60,11 +59,6 @@ void sockets_cleanup()
 	UDPSocket
 */
 
-UDPSocket::UDPSocket(bool ipv6)
-{
-	init(ipv6, false);
-}
-
 bool UDPSocket::init(bool ipv6, bool noExceptions)
 {
 	if (!g_sockets_initialized) {
@@ -98,7 +92,7 @@ bool UDPSocket::init(bool ipv6, bool noExceptions)
 	return true;
 }
 
-UDPSocket::~UDPSocket()
+void UDPSocket::Close()
 {
 	if (m_handle >= 0) {
 #ifdef _WIN32
@@ -107,6 +101,7 @@ UDPSocket::~UDPSocket()
 		close(m_handle);
 #endif
 	}
+	m_handle = -1;
 }
 
 void UDPSocket::Bind(Address addr)
@@ -160,6 +155,31 @@ void UDPSocket::Bind(Address addr)
 		tracestream << (int)m_handle << ": Bind failed: "
 			<< SOCKET_ERR_STR(LAST_SOCKET_ERR()) << std::endl;
 		throw SocketException("Failed to bind socket");
+	}
+}
+
+Address UDPSocket::GetBindAddress()
+{
+	struct sockaddr_storage addr;
+	socklen_t addr_len = sizeof(addr);
+	assert(m_handle >= 0);
+
+	if (getsockname(m_handle, (struct sockaddr*)&addr, &addr_len) != 0)
+		throw SocketException(std::string("Failed to get socket port: ") +  SOCKET_ERR_STR(LAST_SOCKET_ERR()));
+
+	if (addr.ss_family == AF_INET6) {
+		 auto *addr_v6 = reinterpret_cast<struct sockaddr_in6*>(&addr);
+		u16 port = ntohs(addr_v6->sin6_port);
+		IPv6AddressBytes bytes;
+		memcpy(bytes.bytes, addr_v6->sin6_addr.s6_addr, sizeof(bytes.bytes));
+
+		return Address(&bytes, port);
+	} else {
+		struct sockaddr_in *addr_v4 = (struct sockaddr_in *)&addr;
+		u32 ip4 = ntohl(addr_v4->sin_addr.s_addr);
+		u16 port = ntohs(addr_v4->sin_port);
+
+		return Address(ip4, port);
 	}
 }
 

--- a/src/network/socket.h
+++ b/src/network/socket.h
@@ -5,8 +5,7 @@
 #pragma once
 
 #include "irrlichttypes.h"
-
-class Address;
+#include "address.h"
 
 void sockets_init();
 void sockets_cleanup();
@@ -15,11 +14,41 @@ class UDPSocket
 {
 public:
 	UDPSocket() = default;
-	UDPSocket(bool ipv6); // calls init()
-	~UDPSocket();
+	UDPSocket(bool ipv6)
+	{
+		init(ipv6, false);
+	}
+	UDPSocket(Address addr)
+	{
+		init(addr.isIPv6(), false);
+		Bind(addr);
+	}
+	UDPSocket(UDPSocket &&other):
+		m_handle(other.m_handle),
+		m_timeout_ms(other.m_timeout_ms),
+		m_addr_family(other.m_addr_family)
+	{
+		other.m_handle = -1;
+	}
+	~UDPSocket()
+	{
+		Close();
+	}
+	UDPSocket &operator=(UDPSocket &&other)
+	{
+		Close();
+		m_handle = other.m_handle;
+		m_timeout_ms = other.m_timeout_ms;
+		m_addr_family = other.m_addr_family;
+		other.m_handle = -1;
+		return *this;
+	}
 	bool init(bool ipv6, bool noExceptions = false);
 
 	void Bind(Address addr);
+	void Close();
+
+	Address GetBindAddress();
 
 	void Send(const Address &destination, const void *data, int size);
 	// Returns -1 if there is no data

--- a/src/network/socket.h
+++ b/src/network/socket.h
@@ -14,15 +14,6 @@ class UDPSocket
 {
 public:
 	UDPSocket() = default;
-	UDPSocket(bool ipv6)
-	{
-		init(ipv6, false);
-	}
-	UDPSocket(Address addr)
-	{
-		init(addr.isIPv6(), false);
-		Bind(addr);
-	}
 	UDPSocket(UDPSocket &&other):
 		m_handle(other.m_handle),
 		m_timeout_ms(other.m_timeout_ms),
@@ -43,12 +34,27 @@ public:
 		other.m_handle = -1;
 		return *this;
 	}
-	bool init(bool ipv6, bool noExceptions = false);
 
+	static UDPSocket Create(Address addr)
+	{
+		UDPSocket socket;
+		socket.Bind(addr);
+		return socket;
+	}
+
+	static UDPSocket CreateEphemeral(bool ipv6)
+	{
+		if (ipv6)
+			return Create(Address(nullptr, 0));
+		else
+			return Create(Address(u32(0), 0));
+	}
+
+	void Init(bool ipv6);
 	void Bind(Address addr);
 	void Close();
 
-	Address GetBindAddress();
+	Address GetLocalAddress();
 
 	void Send(const Address &destination, const void *data, int size);
 	// Returns -1 if there is no data

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -124,8 +124,6 @@ void *ServerThread::run()
 	auto framemarker = FrameMarker("ServerThread::run()-frame").started();
 	try {
 		m_server->AsyncRunStep(0.0f, true);
-	} catch (con::ConnectionBindFailed &e) {
-		m_server->setAsyncFatalError(e.what());
 	} catch (LuaError &e) {
 		m_server->setAsyncFatalError(e);
 	} catch (ModError &e) {
@@ -159,8 +157,6 @@ void *ServerThread::run()
 			infostream<<"Server: PeerNotFoundException"<<std::endl;
 		} catch (ClientNotFoundException &e) {
 			infostream<<"Server: ClientNotFoundException"<<std::endl;
-		} catch (con::ConnectionBindFailed &e) {
-			m_server->setAsyncFatalError(e.what());
 		} catch (LuaError &e) {
 			m_server->setAsyncFatalError(e);
 		} catch (ModError &e) {
@@ -285,17 +281,17 @@ Server::Server(
 		const std::string &path_world,
 		const SubgameSpec &gamespec,
 		bool simple_singleplayer_mode,
-		Address bind_addr,
+		UDPSocket &&socket,
 		bool dedicated,
 		ChatInterface *iface,
 		std::string *shutdown_errmsg
 	):
-	m_bind_addr(bind_addr),
+	m_bind_addr(socket.GetBindAddress()),
 	m_path_world(path_world),
 	m_gamespec(gamespec),
 	m_simple_singleplayer_mode(simple_singleplayer_mode),
 	m_dedicated(dedicated),
-	m_con(con::createMTP(CONNECTION_TIMEOUT, m_bind_addr.isIPv6(), this)),
+	m_con(con::createMTP(/*is_server=*/true, std::move(socket), this)),
 	m_itemdef(createItemDefManager()),
 	m_nodedef(createNodeDefManager()),
 	m_craftdef(createCraftDefManager()),
@@ -608,9 +604,6 @@ void Server::start()
 
 	// Stop thread if already running
 	m_thread->stop();
-
-	// Initialize connection
-	m_con->Serve(m_bind_addr);
 
 	// Start thread
 	m_thread->start();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -286,7 +286,7 @@ Server::Server(
 		ChatInterface *iface,
 		std::string *shutdown_errmsg
 	):
-	m_bind_addr(socket.GetBindAddress()),
+	m_bind_addr(socket.GetLocalAddress()),
 	m_path_world(path_world),
 	m_gamespec(gamespec),
 	m_simple_singleplayer_mode(simple_singleplayer_mode),

--- a/src/server.h
+++ b/src/server.h
@@ -10,6 +10,7 @@
 #include "gamedef.h"
 #include "content/subgames.h"
 #include "network/peerhandler.h"
+#include "network/socket.h"
 #include "util/thread.h"
 #include "util/basic_macros.h"
 #include "util/metricsbackend.h"
@@ -185,7 +186,7 @@ public:
 		const std::string &path_world,
 		const SubgameSpec &gamespec,
 		bool simple_singleplayer_mode,
-		Address bind_addr,
+		UDPSocket &&socket,
 		bool dedicated,
 		ChatInterface *iface = nullptr,
 		std::string *shutdown_errmsg = nullptr

--- a/src/unittest/mock_server.h
+++ b/src/unittest/mock_server.h
@@ -13,8 +13,7 @@ class MockServer : public Server
 public:
 	/* Set `path_world` to a real existing folder if you plan to initialize scripting! */
 	MockServer(const std::string &path_world = "fakepath") :
-		Server(path_world, SubgameSpec("fakespec", "fakespec"), true,
-			Address(), true, nullptr
+		Server(path_world, SubgameSpec("fakespec", "fakespec"), true, UDPSocket(Address(u32(0), 0)), true, nullptr
 		)
 	{}
 

--- a/src/unittest/mock_server.h
+++ b/src/unittest/mock_server.h
@@ -13,7 +13,8 @@ class MockServer : public Server
 public:
 	/* Set `path_world` to a real existing folder if you plan to initialize scripting! */
 	MockServer(const std::string &path_world = "fakepath") :
-		Server(path_world, SubgameSpec("fakespec", "fakespec"), true, UDPSocket(Address(u32(0), 0)), true, nullptr
+		Server(path_world, SubgameSpec("fakespec", "fakespec"),
+			   true, UDPSocket::CreateEphemeral(false), true, nullptr
 		)
 	{}
 

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -181,10 +181,12 @@ void TestConnection::testConnectSendReceive()
 	}
 
 	infostream << "** Creating server Connection" << std::endl;
-	con::Connection server(512, 5.0f, UDPSocket(address), true, &hand_server);
+	UDPSocket server_socket = UDPSocket::Create(address);
+	con::Connection server(512, 5.0f, std::move(server_socket), true, &hand_server);
 
 	infostream << "** Creating client Connection" << std::endl;
-	con::Connection client(512, 5.0f, UDPSocket(address.isIPv6()), false, &hand_client);
+	UDPSocket client_socket = UDPSocket::CreateEphemeral(address.isIPv6());
+	con::Connection client(512, 5.0f, std::move(client_socket), false, &hand_client);
 
 	UASSERT(hand_server.count == 0);
 	UASSERT(hand_client.count == 0);

--- a/src/unittest/test_connection.cpp
+++ b/src/unittest/test_connection.cpp
@@ -181,11 +181,10 @@ void TestConnection::testConnectSendReceive()
 	}
 
 	infostream << "** Creating server Connection" << std::endl;
-	con::Connection server(512, 5.0f, false, &hand_server);
-	server.Serve(address);
+	con::Connection server(512, 5.0f, UDPSocket(address), true, &hand_server);
 
 	infostream << "** Creating client Connection" << std::endl;
-	con::Connection client(512, 5.0f, false, &hand_client);
+	con::Connection client(512, 5.0f, UDPSocket(address.isIPv6()), false, &hand_client);
 
 	UASSERT(hand_server.count == 0);
 	UASSERT(hand_client.count == 0);

--- a/src/unittest/test_socket.cpp
+++ b/src/unittest/test_socket.cpp
@@ -60,8 +60,7 @@ void TestSocket::testIPv4Socket()
 	} catch (ResolveError &e) {
 	}
 
-	UDPSocket socket(false);
-	socket.Bind(address);
+	UDPSocket socket = UDPSocket::Create(address);
 
 	const char sendbuffer[] = "hello world!";
 	/*
@@ -98,15 +97,17 @@ void TestSocket::testIPv6Socket()
 	Address address6((IPv6AddressBytes *)NULL, port);
 	UDPSocket socket6;
 
-	if (!socket6.init(true, true)) {
+	try {
+		socket6.Init(true);
+	} catch (SocketException &e) {
 		/* Note: Failing to create an IPv6 socket is not technically an
 		   error because the OS may not support IPv6 or it may
 		   have been disabled. IPv6 is not /required/ by
-		   minetest and therefore this should not cause the unit
+		   Luanti and therefore this should not cause the unit
 		   test to fail
 		*/
-		dstream << "WARNING: IPv6 socket creation failed (unit test)"
-			<< std::endl;
+		dstream << "WARNING: IPv6 socket creation failed (unit test): "
+				<< e.what() << std::endl;
 		return;
 	}
 


### PR DESCRIPTION
Resolves #11832, Address and UDPSocket class could be cleaned up further but this seems sufficient for a bug fix.

With these changes the socket is created before the server object, and then passed to the server using std::move. The UDP socket class is also fixed so that it's no longer copyable but is still movable (never should have been copyable). Bit of a re-architecture but not much. 

- If you have used an LLM/AI to help with code or assets, you must disclose this.
  Please refer to the [AI policy](https://github.com/luanti-org/luanti/blob/master/doc/developing/ai_policy.md). Rubber ducky when debugging, code review to look for missed dead code.

## To do

This PR is Ready for Review.
<!-- ^ delete one -->

## How to test

- Test single player works, make sure you can't connect from another client to it
- Test locally hosted multiplayer works
- Test you can join public servers/servers running stock code
- Test dedicated server works
- Test ncurses server works
- Test setting a custom bind address works
<!-- Example code or instructions -->
