### PR TITLE
Add CA bundle for TLS verification.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'de.undercouch.download'
 
 android {
 	ndkVersion "$ndk_version"
@@ -80,9 +81,23 @@ tasks.register("compileTranslations") {
 	dependsOn localeTasks
 }
 
+def output_folder = layout.buildDirectory.get().asFile
+def ca_bundle_url = 'https://curl.se/ca/cacert.pem'
+
+tasks.register('fetchCABundle', Download) {
+	description = 'Grab up to date version of cacert.pem'
+
+	src ca_bundle_url
+	dest new File(output_folder, "cacert.pem")
+	overwrite true
+	onlyIfModified true
+	useETag true
+}
+
 def assetsFolder = layout.buildDirectory.dir("assets").get().asFile
 tasks.register("prepareAssets") {
 	dependsOn tasks.named("compileTranslations")
+	dependsOn tasks.named("fetchCABundle")
 
 	doFirst {
 		logger.lifecycle('Preparing assets at {}', assetsFolder)
@@ -96,6 +111,9 @@ tasks.register("prepareAssets") {
 		}
 		copy {
 			from "${projRoot}/builtin" exclude "**/CMakeLists.txt" into "${assetsFolder}/builtin"
+		}
+		copy {
+			from "${output_folder}/cacert.pem" into "${assetsFolder}/client"
 		}
 		copy {
 			from "${projRoot}/client/shaders" into "${assetsFolder}/client/shaders"

--- a/src/defaultsettings.cpp
+++ b/src/defaultsettings.cpp
@@ -584,8 +584,6 @@ void set_default_settings()
 	// still set these two settings in case someone wants to enable it
 	settings->setDefault("debanding", "false");
 	settings->setDefault("post_processing_texture_bits", "8");
-	// We don't have working certificate verification...
-	settings->setDefault("curl_verify_cert", "false");
 
 	// Apply settings according to screen size
 	float x_inches = (float) porting::getDisplaySize().X /

--- a/src/httpfetch.cpp
+++ b/src/httpfetch.cpp
@@ -18,6 +18,7 @@
 #include "util/numeric.h"
 #include "version.h"
 #include "settings.h"
+#include "filesys.h"
 
 static std::mutex g_httpfetch_mutex;
 static std::unordered_map<u64, std::queue<HTTPFetchResult>>
@@ -250,6 +251,16 @@ HTTPFetchOngoing::HTTPFetchOngoing(const HTTPFetchRequest &request_,
 	curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 3L);
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, ""); // = all supported ones
 
+	// on android we need to setup our own CA
+#if defined(__ANDROID__)
+	const std::string cainfo_path = porting::getDataPath("client" DIR_DELIM "cacert.pem");
+	const CURLcode ca_error = curl_easy_setopt(curl, CURLOPT_CAINFO, cainfo_path.c_str());
+	if (ca_error != CURLE_OK) {
+		errorstream << "Failed to configure CA, HTTPS will not work, error=" <<
+				curl_easy_strerror(ca_error) <<
+				" please report this issue." <<std::endl;
+	}
+#endif
 	std::string bind_address = g_settings->get("bind_address");
 	curl_easy_setopt(curl, CURLOPT_INTERFACE,
 		bind_address.empty() ? nullptr : bind_address.c_str());


### PR DESCRIPTION
Code adapted from #16712, I decided to follow what that did and vendor in a copy of the CA bundle into the tree but it can just be fetched from https://curl.se/ca/cacert.pem and the build script will attempt to fetch an updated version if it can. The etag is used per the recommendations of https://curl.se/docs/caextract.html to avoid fetching the CA bundle if it hasn't changed.

>  We do not mind you downloading the PEM file from us in an automated fashion.
> A suitable curl command line to only download it when it has changed: 
> ....

Android build was only tested on Windows but I don't see why it won't work on Linux too.

~~Ideally this should just work, if curl.se stops serving the CA bundle it will just mean the version in the source tree will be used.~~

## AI usage
Google search

## How to test

Build for android, deploy and check log cat output with peer validation enabled and disabled. I set the content DB URL to https://untrusted-root.badssl.com/ for easy of testing but could test in a mod instead. Check that standard contentDB and the serverlist still work with this change.

Failure if certificate validation is on

```
ERROR[CurlFetch]: HTTPFetch for https://untrusted-root.badssl.com/api/packages/?type=mod&type=game&type=txp&protocol_version=53&engine_version=5.18.0-dev-debug&hide=nonfree&hide=android_default failed: Error
```

Failure without certificate validation

```
ERROR[CurlFetch]: HTTPFetch for https://untrusted-root.badssl.com/api/packages/?type=mod&type=game&type=txp&protocol_version=53&engine_version=5.18.0-dev-debug&hide=nonfree&hide=android_default returned response code 404
VERBOSE[AsyncWorker-1]: httpfetch_caller_free: freeing 12914032104091905524
ERROR[AsyncWorker-1]: Failed to parse json data: * Line 1, Column 1
ERROR[AsyncWorker-1]:   Syntax error: value, object or array expected.
ERROR[AsyncWorker-1]: data: "<html>
ERROR[AsyncWorker-1]: <head><title>404 Not Found</title></head>
ERROR[AsyncWorker-1]: <body bgcolor="white">
ERROR[AsyncWorker-1]: <center><h1>404 Not Found"... (truncated)
```
