### PR TITLE
Remove drawtype consistent members from `NodeVisuals`

### DIFF
--- a/src/client/clientmap.cpp
+++ b/src/client/clientmap.cpp
@@ -402,7 +402,7 @@ void ClientMap::updateDrawList()
 	bool occlusion_culling_enabled = mesh_grid.cell_size < 4;
 	if (m_control.allow_noclip) {
 		MapNode n = getNode(cam_pos_nodes);
-		if (n.getContent() == CONTENT_IGNORE || m_nodedef->get(n).visuals->solidness == 2)
+		if (n.getContent() == CONTENT_IGNORE || NDT_solidness[m_nodedef->get(n).drawtype] == 2)
 			occlusion_culling_enabled = false;
 	}
 
@@ -1396,7 +1396,7 @@ void ClientMap::renderPostFx(CameraMode cam_mode)
 
 	// If the camera is in a solid node, make everything black.
 	// (first person mode only)
-	if (features.visuals->solidness == 2 && cam_mode == CAMERA_MODE_FIRST &&
+	if (NDT_solidness[features.drawtype] == 2 && cam_mode == CAMERA_MODE_FIRST &&
 			!m_control.allow_noclip) {
 		post_color = video::SColor(255, 0, 0, 0);
 	}

--- a/src/client/content_mapblock.cpp
+++ b/src/client/content_mapblock.cpp
@@ -468,7 +468,8 @@ void MapblockMeshGenerator::drawSolidNode()
 				const ContentFeatures &f_side =
 						nodedef->get(data->m_vmanip.getNodeRefUnsafeCheckFlags(p2 + d));
 
-				bool side_is_translucent = !(f_side.visuals->solidness || f_side.visuals->visual_solidness);
+				bool side_is_translucent =
+					!(NDT_solidness[f_side.drawtype] || NDT_visual_solidness[f_side.drawtype]);
 				bool side_is_same_flowing_liquid =
 					f_side.drawtype == NDT_FLOWINGLIQUID && cur_node.f->sameLiquidRender(f_side);
 
@@ -482,13 +483,13 @@ void MapblockMeshGenerator::drawSolidNode()
 		}
 		if (n2 != CONTENT_AIR) {
 			const ContentFeatures &f2 = nodedef->get(n2);
-			if (f2.visuals->solidness == 2 && !liquid_needs_top_face)
+			if (NDT_solidness[f2.drawtype] == 2 && !liquid_needs_top_face)
 				continue;
 			if (cur_node.f->drawtype == NDT_LIQUID) {
 				if (cur_node.f->sameLiquidRender(f2))
 					continue;
-				backface_culling =
-					!liquid_needs_top_face && (f2.visuals->solidness || f2.visuals->visual_solidness);
+				backface_culling = !liquid_needs_top_face &&
+						(NDT_solidness[f2.drawtype] || NDT_visual_solidness[f2.drawtype]);
 			}
 		}
 		faces |= 1 << face;
@@ -599,7 +600,7 @@ void MapblockMeshGenerator::prepareLiquidNodeDrawing()
 			&& (nbottom.getContent() != cur_liquid.c_source);
 	if (cur_liquid.draw_bottom) {
 		const ContentFeatures &f2 = nodedef->get(nbottom.getContent());
-		if (f2.visuals->solidness > 1)
+		if (NDT_solidness[f2.drawtype] > 1)
 			cur_liquid.draw_bottom = false;
 	}
 
@@ -741,7 +742,7 @@ void MapblockMeshGenerator::drawLiquidSides()
 
 		const ContentFeatures &neighbor_features = nodedef->get(neighbor.content);
 		// Don't draw face if neighbor is blocking the view
-		if (neighbor_features.visuals->solidness == 2)
+		if (NDT_solidness[neighbor_features.drawtype] == 2)
 			continue;
 
 		video::S3DVertex vertices[4];

--- a/src/client/mapblock_mesh.cpp
+++ b/src/client/mapblock_mesh.cpp
@@ -164,8 +164,8 @@ static u16 getSmoothLightCombined(const v3s16 &p,
 		const ContentFeatures &f = ndef->get(n);
 		if (f.light_source > light_source_max)
 			light_source_max = f.light_source;
-		// Check f.solidness because fast-style leaves look better this way
-		if (f.param_type == CPT_LIGHT && f.visuals->solidness != 2) {
+		// Check solidness because fast-style leaves look better this way
+		if (f.param_type == CPT_LIGHT && NDT_solidness[f.drawtype] != 2) {
 			u8 light_level_day = n.getLight(LIGHTBANK_DAY, f.getLightingFlags());
 			u8 light_level_night = n.getLight(LIGHTBANK_NIGHT, f.getLightingFlags());
 			if (light_level_day == LIGHT_SUN)
@@ -955,7 +955,7 @@ u8 get_solid_sides(MeshMakeData *data)
 
 		for (u8 k = 0; k < 6; k++) {
 			const MapNode &top = data->m_vmanip.getNodeRefUnsafe(blockpos_nodes + positions[k]);
-			if (ndef->get(top).visuals->solidness != 2)
+			if (NDT_solidness[ndef->get(top).drawtype] != 2)
 				result &= ~(1 << k);
 		}
 	}

--- a/src/client/node_visuals.cpp
+++ b/src/client/node_visuals.cpp
@@ -292,69 +292,40 @@ void NodeVisuals::updateTextures(ContentFeatures &f, ITextureSource *tsrc,
 		tdef_spec[j] = tiledef_special[j];
 	}
 
-	bool is_liquid = false;
-
 	MaterialType material_type = alpha_mode_to_material_type(alpha);
 
 	switch (drawtype) {
-	default:
-	case NDT_NORMAL:
-		solidness = 2;
-		break;
-	case NDT_AIRLIKE:
-		solidness = 0;
-		break;
 	case NDT_LIQUID:
-		if (!tsettings.translucent_liquids)
-			alpha = ALPHAMODE_OPAQUE;
-		solidness = 1;
-		is_liquid = true;
-		break;
 	case NDT_FLOWINGLIQUID:
-		solidness = 0;
 		if (!tsettings.translucent_liquids)
 			alpha = ALPHAMODE_OPAQUE;
-		is_liquid = true;
-		break;
-	case NDT_GLASSLIKE:
-		solidness = 0;
-		visual_solidness = 1;
-		break;
-	case NDT_GLASSLIKE_FRAMED:
-		solidness = 0;
-		visual_solidness = 1;
+		if (waving == 3) {
+			material_type = alpha == ALPHAMODE_OPAQUE ?
+				TILE_MATERIAL_WAVING_LIQUID_OPAQUE : (alpha == ALPHAMODE_CLIP ?
+				TILE_MATERIAL_WAVING_LIQUID_BASIC : TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT);
+		} else {
+			material_type = alpha == ALPHAMODE_OPAQUE ? TILE_MATERIAL_LIQUID_OPAQUE :
+				TILE_MATERIAL_LIQUID_TRANSPARENT;
+		}
 		break;
 	case NDT_GLASSLIKE_FRAMED_OPTIONAL:
-		solidness = 0;
-		visual_solidness = 1;
 		drawtype = tsettings.connected_glass ? NDT_GLASSLIKE_FRAMED : NDT_GLASSLIKE;
-		break;
-	case NDT_ALLFACES:
-		solidness = 0;
-		visual_solidness = 1;
 		break;
 	case NDT_ALLFACES_OPTIONAL:
 		if (tsettings.leaves_style == LEAVES_FANCY) {
 			drawtype = NDT_ALLFACES;
-			solidness = 0;
-			visual_solidness = 1;
 		} else if (tsettings.leaves_style == LEAVES_SIMPLE) {
 			for (u32 j = 0; j < 6; j++) {
 				if (!tdef_spec[j].name.empty())
 					tdef[j].name = tdef_spec[j].name;
 			}
 			drawtype = NDT_GLASSLIKE;
-			solidness = 0;
-			visual_solidness = 1;
 		} else {
 			if (waving >= 1) {
 				// waving nodes must make faces so there are no gaps
 				drawtype = NDT_ALLFACES;
-				solidness = 0;
-				visual_solidness = 1;
 			} else {
 				drawtype = NDT_NORMAL;
-				solidness = 2;
 			}
 			for (TileDef &td : tdef)
 				td.name += std::string("^[noalpha");
@@ -363,16 +334,11 @@ void NodeVisuals::updateTextures(ContentFeatures &f, ITextureSource *tsrc,
 			material_type = TILE_MATERIAL_WAVING_LEAVES;
 		break;
 	case NDT_PLANTLIKE:
-		solidness = 0;
 		if (waving >= 1)
 			material_type = TILE_MATERIAL_WAVING_PLANTS;
 		break;
-	case NDT_FIRELIKE:
-		solidness = 0;
-		break;
 	case NDT_MESH:
 	case NDT_NODEBOX:
-		solidness = 0;
 		if (waving == 1) {
 			material_type = TILE_MATERIAL_WAVING_PLANTS;
 		} else if (waving == 2) {
@@ -383,26 +349,18 @@ void NodeVisuals::updateTextures(ContentFeatures &f, ITextureSource *tsrc,
 				TILE_MATERIAL_WAVING_LIQUID_BASIC : TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT);
 		}
 		break;
+	case NDT_NORMAL:
+	case NDT_GLASSLIKE:
+	case NDT_GLASSLIKE_FRAMED:
+	case NDT_ALLFACES:
+	case NDT_FIRELIKE:
 	case NDT_TORCHLIKE:
 	case NDT_SIGNLIKE:
 	case NDT_FENCELIKE:
 	case NDT_RAILLIKE:
-		solidness = 0;
-		break;
 	case NDT_PLANTLIKE_ROOTED:
-		solidness = 2;
+	default:
 		break;
-	}
-
-	if (is_liquid) {
-		if (waving == 3) {
-			material_type = alpha == ALPHAMODE_OPAQUE ?
-				TILE_MATERIAL_WAVING_LIQUID_OPAQUE : (alpha == ALPHAMODE_CLIP ?
-				TILE_MATERIAL_WAVING_LIQUID_BASIC : TILE_MATERIAL_WAVING_LIQUID_TRANSPARENT);
-		} else {
-			material_type = alpha == ALPHAMODE_OPAQUE ? TILE_MATERIAL_LIQUID_OPAQUE :
-				TILE_MATERIAL_LIQUID_TRANSPARENT;
-		}
 	}
 
 	GetShaderCallback tile_shader = [&] (bool array_texture) {

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -20,55 +20,48 @@ namespace scene
 // Used when choosing which face is drawn
 constexpr std::array<u8, NodeDrawType_END> NDT_solidness = [] {
 	std::array<u8, NodeDrawType_END> solidness{};
-	for (u8 drawtype = 0; drawtype < NodeDrawType_END; drawtype++) {
-		switch ((NodeDrawType) drawtype) {
-		default:
-		case NDT_NORMAL:
-		case NDT_PLANTLIKE_ROOTED:
-			solidness[drawtype] = 2;
-			break;
-		case NDT_LIQUID:
-			solidness[drawtype] = 1;
-			break;
-		case NDT_AIRLIKE:
-		case NDT_FLOWINGLIQUID:
-		case NDT_GLASSLIKE:
-		case NDT_GLASSLIKE_FRAMED:
-		case NDT_GLASSLIKE_FRAMED_OPTIONAL:
-		case NDT_PLANTLIKE:
-		case NDT_TORCHLIKE:
-		case NDT_SIGNLIKE:
-		case NDT_FENCELIKE:
-		case NDT_RAILLIKE:
-		case NDT_FIRELIKE:
-		case NDT_MESH:
-		case NDT_NODEBOX:
-		case NDT_ALLFACES:
-		case NDT_ALLFACES_OPTIONAL:
-			solidness[drawtype] = 0;
-			break;
-		}
-	}
+	solidness[NDT_NORMAL] = 2;
+	solidness[NDT_AIRLIKE] = 0;
+	solidness[NDT_LIQUID] = 1;
+	solidness[NDT_FLOWINGLIQUID] = 0;
+	solidness[NDT_GLASSLIKE] = 0;
+	solidness[NDT_ALLFACES] = 0;
+	solidness[NDT_ALLFACES_OPTIONAL] = 0;
+	solidness[NDT_TORCHLIKE] = 0;
+	solidness[NDT_SIGNLIKE] = 0;
+	solidness[NDT_PLANTLIKE] = 0;
+	solidness[NDT_FENCELIKE] = 0;
+	solidness[NDT_RAILLIKE] = 0;
+	solidness[NDT_NODEBOX] = 0;
+	solidness[NDT_GLASSLIKE_FRAMED] = 0;
+	solidness[NDT_FIRELIKE] = 0;
+	solidness[NDT_GLASSLIKE_FRAMED_OPTIONAL] = 0;
+	solidness[NDT_MESH] = 0;
+	solidness[NDT_PLANTLIKE_ROOTED] = 2;
 	return solidness;
 }();
 
 // When solidness=0, this tells how it looks like
 constexpr std::array<u8, NodeDrawType_END> NDT_visual_solidness = [] {
 	std::array<u8, NodeDrawType_END> visual_solidness{};
-	for (u8 drawtype = 0; drawtype < NodeDrawType_END; drawtype++) {
-		switch ((NodeDrawType) drawtype) {
-		case NDT_GLASSLIKE:
-		case NDT_GLASSLIKE_FRAMED:
-		case NDT_GLASSLIKE_FRAMED_OPTIONAL:
-		case NDT_ALLFACES:
-		case NDT_ALLFACES_OPTIONAL:
-			visual_solidness[drawtype] = 1;
-			break;
-		default:
-			visual_solidness[drawtype] = 0;
-			break;
-		}
-	}
+	visual_solidness[NDT_NORMAL] = 0;
+	visual_solidness[NDT_AIRLIKE] = 0;
+	visual_solidness[NDT_LIQUID] = 0;
+	visual_solidness[NDT_FLOWINGLIQUID] = 0;
+	visual_solidness[NDT_GLASSLIKE] = 1;
+	visual_solidness[NDT_ALLFACES] = 1;
+	visual_solidness[NDT_ALLFACES_OPTIONAL] = 1;
+	visual_solidness[NDT_TORCHLIKE] = 0;
+	visual_solidness[NDT_SIGNLIKE] = 0;
+	visual_solidness[NDT_PLANTLIKE] = 0;
+	visual_solidness[NDT_FENCELIKE] = 0;
+	visual_solidness[NDT_RAILLIKE] = 0;
+	visual_solidness[NDT_NODEBOX] = 0;
+	visual_solidness[NDT_GLASSLIKE_FRAMED] = 0;
+	visual_solidness[NDT_FIRELIKE] = 0;
+	visual_solidness[NDT_GLASSLIKE_FRAMED_OPTIONAL] = 1;
+	visual_solidness[NDT_MESH] = 0;
+	visual_solidness[NDT_PLANTLIKE_ROOTED] = 0;
 	return visual_solidness;
 }();
 

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -21,22 +21,7 @@ namespace scene
 constexpr std::array<u8, NodeDrawType_END> NDT_solidness = [] {
 	std::array<u8, NodeDrawType_END> solidness{};
 	solidness[NDT_NORMAL] = 2;
-	solidness[NDT_AIRLIKE] = 0;
 	solidness[NDT_LIQUID] = 1;
-	solidness[NDT_FLOWINGLIQUID] = 0;
-	solidness[NDT_GLASSLIKE] = 0;
-	solidness[NDT_ALLFACES] = 0;
-	solidness[NDT_ALLFACES_OPTIONAL] = 0;
-	solidness[NDT_TORCHLIKE] = 0;
-	solidness[NDT_SIGNLIKE] = 0;
-	solidness[NDT_PLANTLIKE] = 0;
-	solidness[NDT_FENCELIKE] = 0;
-	solidness[NDT_RAILLIKE] = 0;
-	solidness[NDT_NODEBOX] = 0;
-	solidness[NDT_GLASSLIKE_FRAMED] = 0;
-	solidness[NDT_FIRELIKE] = 0;
-	solidness[NDT_GLASSLIKE_FRAMED_OPTIONAL] = 0;
-	solidness[NDT_MESH] = 0;
 	solidness[NDT_PLANTLIKE_ROOTED] = 2;
 	return solidness;
 }();
@@ -44,24 +29,11 @@ constexpr std::array<u8, NodeDrawType_END> NDT_solidness = [] {
 // When solidness=0, this tells how it looks like
 constexpr std::array<u8, NodeDrawType_END> NDT_visual_solidness = [] {
 	std::array<u8, NodeDrawType_END> visual_solidness{};
-	visual_solidness[NDT_NORMAL] = 0;
-	visual_solidness[NDT_AIRLIKE] = 0;
-	visual_solidness[NDT_LIQUID] = 0;
-	visual_solidness[NDT_FLOWINGLIQUID] = 0;
 	visual_solidness[NDT_GLASSLIKE] = 1;
 	visual_solidness[NDT_ALLFACES] = 1;
 	visual_solidness[NDT_ALLFACES_OPTIONAL] = 1;
-	visual_solidness[NDT_TORCHLIKE] = 0;
-	visual_solidness[NDT_SIGNLIKE] = 0;
-	visual_solidness[NDT_PLANTLIKE] = 0;
-	visual_solidness[NDT_FENCELIKE] = 0;
-	visual_solidness[NDT_RAILLIKE] = 0;
-	visual_solidness[NDT_NODEBOX] = 0;
-	visual_solidness[NDT_GLASSLIKE_FRAMED] = 0;
-	visual_solidness[NDT_FIRELIKE] = 0;
+	visual_solidness[NDT_GLASSLIKE_FRAMED] = 1;
 	visual_solidness[NDT_GLASSLIKE_FRAMED_OPTIONAL] = 1;
-	visual_solidness[NDT_MESH] = 0;
-	visual_solidness[NDT_PLANTLIKE_ROOTED] = 0;
 	return visual_solidness;
 }();
 

--- a/src/client/node_visuals.h
+++ b/src/client/node_visuals.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
+#include <array>
 #include <unordered_set>
-#include "nodedef.h" // CF_SPECIAL_COUNT
+#include "nodedef.h"
 #include "tile.h"
 
 class Client;
@@ -15,6 +16,62 @@ namespace scene
 	class IMeshManipulator;
 	struct SMesh;
 }
+
+// Used when choosing which face is drawn
+constexpr std::array<u8, NodeDrawType_END> NDT_solidness = [] {
+	std::array<u8, NodeDrawType_END> solidness{};
+	for (u8 drawtype = 0; drawtype < NodeDrawType_END; drawtype++) {
+		switch ((NodeDrawType) drawtype) {
+		default:
+		case NDT_NORMAL:
+		case NDT_PLANTLIKE_ROOTED:
+			solidness[drawtype] = 2;
+			break;
+		case NDT_LIQUID:
+			solidness[drawtype] = 1;
+			break;
+		case NDT_AIRLIKE:
+		case NDT_FLOWINGLIQUID:
+		case NDT_GLASSLIKE:
+		case NDT_GLASSLIKE_FRAMED:
+		case NDT_GLASSLIKE_FRAMED_OPTIONAL:
+		case NDT_PLANTLIKE:
+		case NDT_TORCHLIKE:
+		case NDT_SIGNLIKE:
+		case NDT_FENCELIKE:
+		case NDT_RAILLIKE:
+		case NDT_FIRELIKE:
+		case NDT_MESH:
+		case NDT_NODEBOX:
+		case NDT_ALLFACES:
+		case NDT_ALLFACES_OPTIONAL:
+			solidness[drawtype] = 0;
+			break;
+		}
+	}
+	return solidness;
+}();
+
+// When solidness=0, this tells how it looks like
+constexpr std::array<u8, NodeDrawType_END> NDT_visual_solidness = [] {
+	std::array<u8, NodeDrawType_END> visual_solidness{};
+	for (u8 drawtype = 0; drawtype < NodeDrawType_END; drawtype++) {
+		switch ((NodeDrawType) drawtype) {
+		case NDT_GLASSLIKE:
+		case NDT_GLASSLIKE_FRAMED:
+		case NDT_GLASSLIKE_FRAMED_OPTIONAL:
+		case NDT_ALLFACES:
+		case NDT_ALLFACES_OPTIONAL:
+			visual_solidness[drawtype] = 1;
+			break;
+		default:
+			visual_solidness[drawtype] = 0;
+			break;
+		}
+	}
+	return visual_solidness;
+}();
+
 
 // Stores client only data needed to draw nodes, like textures and meshes
 // Contained in ContentFeatures
@@ -26,9 +83,6 @@ struct NodeVisuals
 	TileSpec tiles[6];
 	// Special tiles
 	TileSpec special_tiles[CF_SPECIAL_COUNT];
-	u8 solidness = 2; // Used when choosing which face is drawn
-	u8 visual_solidness = 0; // When solidness=0, this tells how it looks like
-	bool backface_culling = true;
 	scene::SMesh *mesh_ptr = nullptr; // mesh in case of mesh node
 	video::SColor minimap_color;
 	std::vector<video::SColor> *palette = nullptr;

--- a/src/unittest/test_content_mapblock.cpp
+++ b/src/unittest/test_content_mapblock.cpp
@@ -71,7 +71,6 @@ public:
 		f.visuals = std::make_unique<NodeVisuals>();
 		f.name = itemdef.name;
 		f.drawtype = NDT_NORMAL;
-		f.visuals->solidness = 2;
 		f.alpha = ALPHAMODE_OPAQUE;
 		for (TileDef &tiledef : f.tiledef)
 			tiledef.name = name + ".png";
@@ -92,7 +91,6 @@ public:
 		f.visuals = std::make_unique<NodeVisuals>();
 		f.name = itemdef.name;
 		f.drawtype = NDT_LIQUID;
-		f.visuals->solidness = 1;
 		f.alpha = ALPHAMODE_BLEND;
 		f.light_propagates = true;
 		f.param_type = CPT_LIGHT;
@@ -120,7 +118,6 @@ public:
 		f.visuals = std::make_unique<NodeVisuals>();
 		f.name = itemdef.name;
 		f.drawtype = NDT_FLOWINGLIQUID;
-		f.visuals->solidness = 0;
 		f.alpha = ALPHAMODE_BLEND;
 		f.light_propagates = true;
 		f.param_type = CPT_LIGHT;


### PR DESCRIPTION
Stores `solidness` and `visual_solidness` in global lookup tables, since they are properties of the drawtype, not the node itself.

Removes `backface_culling`, it's a tile property not a node property, and was completely unused anyway.

## To do

Ready for Review.

## How to test

Read the code
