### PR TITLE
Fix noticable typo in irrlicht comment

### DIFF
--- a/irr/src/CGUIEditBox.cpp
+++ b/irr/src/CGUIEditBox.cpp
@@ -1470,7 +1470,7 @@ void CGUIEditBox::calculateScrollPos()
 
 		if (txtWidth < FrameRect.getWidth()) {
 			// TODO: Needs a clean left and right gap removal depending on HAlign, similar to vertical scrolling tests for top/bottom.
-			// This check just fixes the case where it was most noticable (text smaller than clipping area).
+			// This check just fixes the case where it was most noticeable (text smaller than clipping area).
 
 			HScrollPos = 0;
 			setTextRect(cursLine);


### PR DESCRIPTION
Corrects the misspelling `noticable` -> `noticeable` in `irr/src/CGUIEditBox.cpp`.

Documentation only, no behaviour change.