### PR TITLE
Remove touchscreen icon cache

### DIFF
--- a/src/gui/touchscreeneditor.cpp
+++ b/src/gui/touchscreeneditor.cpp
@@ -42,11 +42,6 @@ GUITouchscreenLayout::GUITouchscreenLayout(gui::IGUIEnvironment* env,
 		core::recti(), this, -1, wstrgettext("Remove").c_str()));
 }
 
-GUITouchscreenLayout::~GUITouchscreenLayout()
-{
-	ButtonLayout::clearTextureCache();
-}
-
 void GUITouchscreenLayout::regenerateGui(v2u32 screensize)
 {
 	DesiredRect = core::recti(0, 0, screensize.X, screensize.Y);

--- a/src/gui/touchscreeneditor.h
+++ b/src/gui/touchscreeneditor.h
@@ -23,7 +23,6 @@ public:
 	GUITouchscreenLayout(gui::IGUIEnvironment* env,
 			gui::IGUIElement* parent, s32 id,
 			IMenuManager *menumgr, ISimpleTextureSource *tsrc);
-	~GUITouchscreenLayout();
 
 	void regenerateGui(v2u32 screensize);
 	void drawMenu();

--- a/src/gui/touchscreenlayout.cpp
+++ b/src/gui/touchscreenlayout.cpp
@@ -233,27 +233,14 @@ ButtonLayout ButtonLayout::loadFromSettings()
 	return loadDefault();
 }
 
-std::unordered_map<touch_gui_button_id, irr_ptr<video::ITexture>> ButtonLayout::texture_cache;
-
 video::ITexture *ButtonLayout::getTexture(touch_gui_button_id btn, ISimpleTextureSource *tsrc)
 {
-	if (texture_cache.count(btn) > 0)
-		return texture_cache.at(btn).get();
-
 	video::ITexture *tex = tsrc->getTexture(button_image_names[btn]);
 	if (!tex)
 		// necessary in the mainmenu
 		tex = tsrc->getTexture(porting::path_share + "/textures/base/pack/" +
 				button_image_names[btn]);
-	irr_ptr<video::ITexture> ptr;
-	ptr.grab(tex);
-	texture_cache[btn] = ptr;
 	return tex;
-}
-
-void ButtonLayout::clearTextureCache()
-{
-	texture_cache.clear();
 }
 
 core::recti ButtonLayout::getRect(touch_gui_button_id btn,

--- a/src/gui/touchscreenlayout.h
+++ b/src/gui/touchscreenlayout.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "irr_ptr.h"
 #include "irrlichttypes_bloated.h"
 #include "rect.h"
 #include "util/enum_string.h"
@@ -99,7 +98,6 @@ struct ButtonLayout {
 	static ButtonLayout loadFromSettings();
 
 	static video::ITexture *getTexture(touch_gui_button_id btn, ISimpleTextureSource *tsrc);
-	static void clearTextureCache();
 
 	ButtonMap layout;
 
@@ -123,8 +121,6 @@ private:
 	static const ButtonMap default_data;
 	static ButtonMap deserializeJson(std::istream &is);
 	static ButtonLayout postProcessLoaded(const ButtonMap &map);
-
-	static std::unordered_map<touch_gui_button_id, irr_ptr<video::ITexture>> texture_cache;
 };
 
 void layout_button_grid(v2u32 screensize, ISimpleTextureSource *tsrc,


### PR DESCRIPTION
## Goal

Prevent the touchscreen icon cache from accessing destroyed graphics objects during shutdown.

Fixes #16882.

## How it works

Luanti kept touchscreen icons inside a global cache. The cache could remain alive after the graphics driver was destroyed, then access dead graphics objects during shutdown and crash.

This change removes the redundant cache and its manual cleanup. The existing texture sources continue to handle texture ownership and caching.

Four files were changed and 23 unsafe or redundant lines were removed.

## Testing

* `git diff --check` passed.
* Syntax compilation passed for:

  * `src/gui/touchscreenlayout.cpp`
  * `src/gui/touchscreeneditor.cpp`
  * `src/gui/touchcontrols.cpp`

Android runtime testing was not performed and remains UNDEFINED until CI or device testing is completed.

## AI disclosure

AI was used in conjunction with GDN for codebase exploration, debugging, and verification. GDN is my independent verification system. I reviewed and understood the changes and approve them.
