### PR TITLE
Pin stable Prometheus with Submodules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache git build-base cmake curl-dev zlib-dev zstd-dev \
 
 WORKDIR /usr/src/
 
-ADD https://github.com/jupp0r/prometheus-cpp.git?branch=master /usr/src/prometheus-cpp
+ADD https://github.com/jupp0r/prometheus-cpp.git#b9366fc3b28292e553ce4820c8929287cdf8e04d /usr/src/prometheus-cpp
 ADD https://github.com/libspatialindex/libspatialindex.git?branch=main /usr/src/libspatialindex
 ADD --keep-git-dir https://luajit.org/git/luajit.git?branch=${LUAJIT_VERSION} /usr/src/luajit
 


### PR DESCRIPTION
- Goal of the PR
   Fix Docker failure of Prometheus
- How does the PR work?
   Pin v1.3.0 and recursively fetch submodules according to build instructions
- Does it resolve any reported issue?
   Clean local docker build end to end
- Does this relate to a goal in [the roadmap](https://github.com/luanti-org/luanti/blob/master/doc/direction.md)?
   This fixes a current CI issue
- If not a bug fix, why is this PR needed? What usecases does it solve?
   Fixes current CI issue

This PR is ready for review

If CI builds green this PR is successful
