### PR TITLE
Replace AbsolutePath with std::filesystem::canonical

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -852,27 +852,14 @@ std::string RemoveRelativePathComponents(std::string path)
 
 std::string AbsolutePath(const std::string &path)
 {
-#ifdef _WIN32
-	// handle behavior differences on windows
 	if (path.empty())
 		return "";
-	else if (!PathExists(path))
-		return "";
-	char *abs_path = _fullpath(NULL, path.c_str(), MAX_PATH);
-#else
-	char *abs_path = realpath(path.c_str(), NULL);
-#endif
-	if (!abs_path)
-		return "";
-	std::filesystem::path absolute_path(abs_path, std::filesystem::path::format::native_format);
-	free(abs_path);
 
-	// remove any trailing delim before return
-	std::string abs_path_str = absolute_path.string();
-	std::string root_string = absolute_path.root_path().string();
-	while (abs_path_str.length() > root_string.length() && IsDirDelimiter(abs_path_str.back()))
-		abs_path_str.pop_back();
-	return abs_path_str;
+	std::error_code ec;
+	std::filesystem::path absolute_path = std::filesystem::canonical(path, ec);
+	if (ec)
+		return "";
+	return absolute_path.string();
 }
 
 std::string AbsolutePathPartial(const std::string &path)

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -390,8 +390,12 @@ void TestFileSys::testAbsolutePath()
 		const auto dir_path2 = getTestTempFile();
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2), ""); // doesn't exist
 		fs::CreateDir(dir_path2);
+		const auto file_path = getTestTempFile();
+		open_ofstream(file_path.c_str(), false).close();
 		const auto absolute_dir_path = fs::AbsolutePath(dir_path2);
-		UASSERTCMP(auto, !=, absolute_dir_path, "");// now it does
+		UASSERTCMP(auto, !=, absolute_dir_path, ""); // now it does
+		const auto absolute_file_path = fs::AbsolutePath(file_path);
+		UASSERTCMP(auto, !=, absolute_file_path, ""); // absolute path works on actual files
 		const std::filesystem::path absolute_path(absolute_dir_path,
 				std::filesystem::path::format::native_format);
 		const std::string root_path = absolute_path.root_path().string();
@@ -402,6 +406,15 @@ void TestFileSys::testAbsolutePath()
 		// excess . and / are removed
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + p("//..")), fs::AbsolutePath(dir_path));
 		UASSERTEQ(auto, fs::AbsolutePath(dir_path2 + p("/./.././//")), fs::AbsolutePath(dir_path));
+		// test symlinks are actually resolved
+		std::error_code ec;
+		std::filesystem::path link = getTestTempFile();
+		std::filesystem::create_directory_symlink(absolute_dir_path, link, ec);
+		if (ec) {
+			warningstream << "Symlink test skipped: " << ec.message() << std::endl;
+		} else {
+			UASSERTEQ(auto, fs::AbsolutePath(link.string()), absolute_dir_path);
+		}
 	}
 
 	/* AbsolutePathPartial */


### PR DESCRIPTION
- Goal of the PR
   Next step of Filesys conversion to std::filesytem
- How does the PR work?
   Wrote regression testing then implemented std:;filesystem::canonical to replace current AbsolutePath functionality
- If not a bug fix, why is this PR needed? What usecases does it solve?
   This is the next step of modernization and switching to std::filesystem
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  LLM reviewed code I wrote for errors and formatting

This PR is ready for review

Run Unit Tests

