### PR TITLE
Rename my_sha256 functions

### DIFF
--- a/lib/sha256/my_sha256.h
+++ b/lib/sha256/my_sha256.h
@@ -90,11 +90,11 @@ typedef struct SHA256state_st {
 	unsigned int num, md_len;
 } SHA256_CTX;
 
-int SHA256_Init(SHA256_CTX *c);
-int SHA256_Update(SHA256_CTX *c, const void *data, size_t len);
-int SHA256_Final(unsigned char *md, SHA256_CTX *c);
-unsigned char *SHA256(const unsigned char *d, size_t n, unsigned char *md);
-void SHA256_Transform(SHA256_CTX *c, const unsigned char *data);
+int my_SHA256_Init(SHA256_CTX *c);
+int my_SHA256_Update(SHA256_CTX *c, const void *data, size_t len);
+int my_SHA256_Final(unsigned char *md, SHA256_CTX *c);
+unsigned char *my_SHA256(const unsigned char *d, size_t n, unsigned char *md);
+void my_SHA256_Transform(SHA256_CTX *c, const unsigned char *data);
 
 #ifdef  __cplusplus
 }

--- a/lib/sha256/sha256.c
+++ b/lib/sha256/sha256.c
@@ -421,7 +421,7 @@ sha256_block_data_order(SHA256_CTX *ctx, const void *_in, size_t num)
 }
 
 int
-SHA256_Init(SHA256_CTX *c)
+my_SHA256_Init(SHA256_CTX *c)
 {
 	memset(c, 0, sizeof(*c));
 
@@ -438,10 +438,10 @@ SHA256_Init(SHA256_CTX *c)
 
 	return 1;
 }
-LCRYPTO_ALIAS(SHA256_Init);
+LCRYPTO_ALIAS(my_SHA256_Init);
 
 int
-SHA256_Update(SHA256_CTX *c, const void *data_, size_t len)
+my_SHA256_Update(SHA256_CTX *c, const void *data_, size_t len)
 {
 	const unsigned char *data = data_;
 	unsigned char *p;
@@ -493,17 +493,17 @@ SHA256_Update(SHA256_CTX *c, const void *data_, size_t len)
 	}
 	return 1;
 }
-LCRYPTO_ALIAS(SHA256_Update);
+LCRYPTO_ALIAS(my_SHA256_Update);
 
 void
-SHA256_Transform(SHA256_CTX *c, const unsigned char *data)
+my_SHA256_Transform(SHA256_CTX *c, const unsigned char *data)
 {
 	sha256_block_data_order(c, data, 1);
 }
-LCRYPTO_ALIAS(SHA256_Transform);
+LCRYPTO_ALIAS(my_SHA256_Transform);
 
 int
-SHA256_Final(unsigned char *md, SHA256_CTX *c)
+my_SHA256_Final(unsigned char *md, SHA256_CTX *c)
 {
 	unsigned char *p = (unsigned char *)c->data;
 	size_t n = c->num;
@@ -554,10 +554,10 @@ SHA256_Final(unsigned char *md, SHA256_CTX *c)
 
 	return 1;
 }
-LCRYPTO_ALIAS(SHA256_Final);
+LCRYPTO_ALIAS(my_SHA256_Final);
 
 unsigned char *
-SHA256(const unsigned char *d, size_t n, unsigned char *md)
+my_SHA256(const unsigned char *d, size_t n, unsigned char *md)
 {
 	SHA256_CTX c;
 	static unsigned char m[SHA256_DIGEST_LENGTH];
@@ -565,12 +565,12 @@ SHA256(const unsigned char *d, size_t n, unsigned char *md)
 	if (md == NULL)
 		md = m;
 
-	SHA256_Init(&c);
-	SHA256_Update(&c, d, n);
-	SHA256_Final(md, &c);
+	my_SHA256_Init(&c);
+	my_SHA256_Update(&c, d, n);
+	my_SHA256_Final(md, &c);
 
 	memset(&c, 0, sizeof(c));
 
 	return (md);
 }
-LCRYPTO_ALIAS(SHA256);
+LCRYPTO_ALIAS(my_SHA256);

--- a/src/util/hashing.cpp
+++ b/src/util/hashing.cpp
@@ -6,11 +6,9 @@
 
 #define IN_HASHING_CPP
 
-#include "debug.h"
 #include "config.h"
 #if USE_OPENSSL
 #include <openssl/sha.h>
-#include <openssl/evp.h>
 #else
 #include "util/sha1.h"
 #include "my_sha256.h"
@@ -40,11 +38,9 @@ std::string sha256(std::string_view data)
 	auto src = reinterpret_cast<const uint8_t *>(data.data());
 	auto dst = reinterpret_cast<uint8_t *>(digest.data());
 #if USE_OPENSSL
-	// can't call SHA256(), because it's defined by our sha256.c fallback
-	auto success = EVP_Digest(src, data.size(), dst, nullptr, EVP_sha256(), nullptr) == 1;
-	FATAL_ERROR_IF(!success, "sha256 failed");
-#else
 	SHA256(src, data.size(), dst);
+#else
+	my_SHA256(src, data.size(), dst);
 #endif
 	return digest;
 }

--- a/src/util/srp.cpp
+++ b/src/util/srp.cpp
@@ -249,7 +249,7 @@ static int hash_init(SRP_HashAlgorithm alg, HashCTX *c)
 		case SRP_SHA224: return SHA224_Init(&c->sha256);
 		*/
 #ifdef CSRP_USE_SHA256
-		case SRP_SHA256: return SHA256_Init(&c->sha256);
+		case SRP_SHA256: return my_SHA256_Init(&c->sha256);
 #endif
 		/*
 		case SRP_SHA384: return SHA384_Init(&c->sha512);
@@ -268,7 +268,7 @@ static int hash_update( SRP_HashAlgorithm alg, HashCTX *c, const void *data, siz
 		case SRP_SHA224: return SHA224_Update(&c->sha256, data, len);
 		*/
 #ifdef CSRP_USE_SHA256
-		case SRP_SHA256: return SHA256_Update(&c->sha256, data, len);
+		case SRP_SHA256: return my_SHA256_Update(&c->sha256, data, len);
 #endif
 		/*
 		case SRP_SHA384: return SHA384_Update(&c->sha512, data, len);
@@ -287,7 +287,7 @@ static int hash_final( SRP_HashAlgorithm alg, HashCTX *c, unsigned char *md )
 		case SRP_SHA224: return SHA224_Final(md, &c->sha256);
 		*/
 #ifdef CSRP_USE_SHA256
-		case SRP_SHA256: return SHA256_Final(md, &c->sha256);
+		case SRP_SHA256: return my_SHA256_Final(md, &c->sha256);
 #endif
 		/*
 		case SRP_SHA384: return SHA384_Final(md, &c->sha512);
@@ -306,7 +306,7 @@ static unsigned char *hash(SRP_HashAlgorithm alg, const unsigned char *d, size_t
 		case SRP_SHA224: return SHA224( d, n, md );
 		*/
 #ifdef CSRP_USE_SHA256
-		case SRP_SHA256: return SHA256(d, n, md);
+		case SRP_SHA256: return my_SHA256(d, n, md);
 #endif
 		/*
 		case SRP_SHA384: return SHA384( d, n, md );


### PR DESCRIPTION
Luanti contains bundled SHA256* functions with identical names to those provided by OpenSSL. This is normally harmless because OpenSSL is dynamically linked, internally versioned, and provides an alternative method (EVP_Digest) to reach the same code. But there are situations where this could be a problem:

- Static linking: always results in duplicate symbols
- Alternative SSL libraries: if they don't use symbol versioning internally, their SHA256 functions would be completely shadowed (because of -rdynamic, and sha256.c appearing first in the link order).
- Additional uses of SHA256* will automatically use the bundled methods, even when my_sha256.h is not explicitly included.

This change renames the bundled SHA256* functions so that there is never any ambiguity.

The motivation for this change is compatibility with Emscripten, where static linking is the default. It could also benefit people who statically link luantiserver.

NOTE: srp.cpp always uses the bundled methods, even when USE_OPENSSL is defined. This PR does not change that.

Disclosure: I used AI to research and implement this change.