### PR TITLE
Unify RecursiveDelete with std::filesystem

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -4,7 +4,6 @@
 
 #include "filesys.h"
 #include "util/string.h"
-#include <iostream>
 #include <filesystem>
 #include <cstdio>
 #include <cstdlib>
@@ -33,7 +32,6 @@
 #include <sys/types.h>
 #include <dirent.h>
 #include <sys/stat.h>
-#include <sys/wait.h>
 #include <unistd.h>
 #include <fcntl.h>
 #endif
@@ -141,40 +139,6 @@ bool IsExecutable(const std::string &path)
 {
 	DWORD type;
 	return GetBinaryType(path.c_str(), &type) != 0;
-}
-
-bool RecursiveDelete(const std::string &path)
-{
-	assert(IsPathAbsolute(path));
-	if (!PathExists(path))
-		return true;
-
-	bool is_file = !IsDir(path);
-	infostream << "Recursively deleting " << (is_file ? "file" : "directory")
-		<< " \"" << path << "\"" << std::endl;
-	if (is_file) {
-		if (!DeleteFile(path.c_str())) {
-			errorstream << "RecursiveDelete: Failed to delete file \""
-					<< path << "\": " << LAST_OS_ERROR() << std::endl;
-			return false;
-		}
-		return true;
-	}
-	std::vector<DirListNode> content = GetDirListing(path);
-	for (const auto &n : content) {
-		std::string fullpath = path + DIR_DELIM + n.name;
-		if (!RecursiveDelete(fullpath)) {
-			errorstream << "RecursiveDelete: Failed to recurse to \""
-					<< fullpath << "\"" << std::endl;
-			return false;
-		}
-	}
-	if (!RemoveDirectory(path.c_str())) {
-		errorstream << "RecursiveDelete: Failed to delete directory \""
-					<< path << "\": " << LAST_OS_ERROR() << std::endl;
-		return false;
-	}
-	return true;
 }
 
 bool DeleteSingleFileOrEmptyDirectory(const std::string &path, bool log_error)
@@ -364,49 +328,6 @@ bool IsExecutable(const std::string &path)
 	return access(path.c_str(), X_OK) == 0;
 }
 
-bool RecursiveDelete(const std::string &path)
-{
-	assert(IsPathAbsolute(path));
-	if (!PathExists(path))
-		return true;
-
-	// Execute the 'rm' command directly, by fork() and execve()
-
-	infostream << "Removing \"" << path << "\"" << std::endl;
-
-	const pid_t child_pid = fork();
-	if (child_pid == -1) {
-		errorstream << "fork errno: " << errno << ": " << strerror(errno)
-			<< std::endl;
-		return false;
-	}
-
-	if (child_pid == 0) {
-		// Child
-		std::array<const char*, 4> argv = {
-			"rm",
-			"-rf",
-			path.c_str(),
-			nullptr
-		};
-
-		execvp(argv[0], const_cast<char**>(argv.data()));
-
-		// note: use cerr because our logging won't flush in forked process
-		std::cerr << "exec errno: " << errno << ": " << strerror(errno)
-			<< std::endl;
-		_exit(1);
-	} else {
-		// Parent
-		int status;
-		pid_t tpid;
-		do
-			tpid = waitpid(child_pid, &status, 0);
-		while (tpid != child_pid);
-		return WIFEXITED(status) && WEXITSTATUS(status) == 0;
-	}
-}
-
 bool DeleteSingleFileOrEmptyDirectory(const std::string &path, bool log_error)
 {
 	if (IsDir(path)) {
@@ -552,6 +473,49 @@ bool CopyFileContents(const std::string &source, const std::string &target)
 /****************************
  * portable implementations *
  ****************************/
+
+bool RecursiveDelete(const std::string &path)
+{
+	assert(IsPathAbsolute(path));
+
+	std::filesystem::path p;
+	try {
+		// On Windows, this throws if `path` is not valid UTF-8.
+		p = std::filesystem::path(path);
+	} catch (const std::exception &e) {
+		errorstream << "RecursiveDelete: Invalid path \"" << path << "\": "
+				<< e.what() << std::endl;
+		return false;
+	}
+
+	std::error_code ec;
+
+	// A dangling symlink still counts as existing and will be removed below.
+	auto status = std::filesystem::symlink_status(p, ec);
+
+	// Check for `not_found` first, since `ec` may also be set in this case.
+	if (status.type() == std::filesystem::file_type::not_found)
+		return true;
+
+	if (ec) {
+		errorstream << "RecursiveDelete: Failed to inspect \"" << path
+				<< "\": " << ec.message() << std::endl;
+		return false;
+	}
+
+	bool is_dir = status.type() == std::filesystem::file_type::directory;
+	infostream << "Recursively deleting " << (is_dir ? "directory" : "file")
+		<< " \"" << path << "\"" << std::endl;
+
+	// Deletes symlinks instead of following them.
+	std::filesystem::remove_all(p, ec);
+	if (ec) {
+		errorstream << "RecursiveDelete: Failed to delete \"" << path
+				<< "\": " << ec.message() << std::endl;
+		return false;
+	}
+	return true;
+}
 
 void GetRecursiveDirs(std::vector<std::string> &dirs, const std::string &dir)
 {

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -147,6 +147,7 @@ bool DeleteSingleFileOrEmptyDirectory(const std::string &path, bool log_error)
 		bool ok = DeleteFile(path.c_str()) != 0;
 		if (!ok && log_error)
 			errorstream << "DeleteFile failed: " << LAST_OS_ERROR() << std::endl;
+		return ok;
 	}
 	bool ok = RemoveDirectory(path.c_str()) != 0;
 	if (!ok && log_error)

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -506,9 +506,7 @@ bool RecursiveDelete(const std::string &path)
 		return false;
 	}
 
-	bool is_dir = std::filesystem::is_directory(status);
-	infostream << "Recursively deleting " << (is_dir ? "directory" : "file")
-		<< " \"" << path << "\"" << std::endl;
+	infostream << "Recursively deleting \"" << path << "\"" << std::endl;
 
 	// Deletes symlinks instead of following them.
 	std::filesystem::remove_all(p, ec);

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -494,6 +494,8 @@ bool RecursiveDelete(const std::string &path)
 	auto status = std::filesystem::symlink_status(p, ec);
 
 	// Check for `not_found` first, since `ec` may also be set in this case.
+	// Note that std::filesystem::exists(status) would be wrong here, because
+	// it would return false if a real OS error occurred in symlink_status.
 	if (status.type() == std::filesystem::file_type::not_found)
 		return true;
 
@@ -503,7 +505,7 @@ bool RecursiveDelete(const std::string &path)
 		return false;
 	}
 
-	bool is_dir = status.type() == std::filesystem::file_type::directory;
+	bool is_dir = std::filesystem::is_directory(status);
 	infostream << "Recursively deleting " << (is_dir ? "directory" : "file")
 		<< " \"" << path << "\"" << std::endl;
 

--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -494,9 +494,12 @@ bool RecursiveDelete(const std::string &path)
 	// A dangling symlink still counts as existing and will be removed below.
 	auto status = std::filesystem::symlink_status(p, ec);
 
-	// Check for `not_found` first, since `ec` may also be set in this case.
-	// Note that std::filesystem::exists(status) would be wrong here, because
-	// it would return false if a real OS error occurred in symlink_status.
+	// If the file does not exist, `status` will have type `not_found` and
+	// `ec` may or may not be set. So we must check the status type first.
+	//
+	// Note that we can't use std::filesystem::exists(status) here, because
+	// if a genuine error occurs (such as access denied or out-of-memory),
+	// status will have type `none`, and `exists()` returns false for that.
 	if (status.type() == std::filesystem::file_type::not_found)
 		return true;
 

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -718,7 +718,6 @@ void TestFileSys::testUnicodePathsFuzz()
 	for (int i = 0; i < NUM_PATHS; i++)
 		names.push_back(fresh(20));
 
-
 	std::vector<std::string> contents;
 	contents.reserve(NUM_CONTENTS);
 	for (int i = 0; i < NUM_CONTENTS; i++)

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -724,7 +724,7 @@ void TestFileSys::testUnicodePathsFuzz()
 		contents.push_back(std::to_string(i));
 
 	std::map<std::string, size_t> cached_index;
-	auto content_for = [&] (const std::string &path) {
+	auto content_for = [&] (const std::string &path) -> const std::string & {
 		auto it = cached_index.find(path);
 		if (it == cached_index.end()) {
 			it = cached_index.emplace(path, rnd.range(0, NUM_CONTENTS - 1)).first;
@@ -826,7 +826,7 @@ void TestFileSys::testUnicodePathsFuzz()
 	for (int i = 0; i + 1 < NUM_PATHS; i += 2) {
 		const std::string src = pairs + DIR_DELIM + names[i];
 		const std::string dst = pairs + DIR_DELIM + names[i + 1];
-		const std::string content = content_for(src);
+		const std::string &content = content_for(src);
 
 		{
 			auto ofs = open_ofstream(src.c_str(), true);
@@ -862,7 +862,7 @@ void TestFileSys::testUnicodePathsFuzz()
 		const std::string top = deep + DIR_DELIM + fresh(6);
 		const std::string dir = top + DIR_DELIM + n1 + DIR_DELIM + n2;
 		const std::string file = dir + DIR_DELIM + n3;
-		const std::string content = content_for(file);
+		const std::string &content = content_for(file);
 		const std::string sub = n1 + DIR_DELIM + n2 + DIR_DELIM + n3;
 
 		UASSERT(fs::CreateAllDirs(dir));

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -713,7 +713,7 @@ void TestFileSys::testUnicodePathsFuzz()
 	// This could be a pure ascii path.
 	const std::string base = getTestTempDirectory() + DIR_DELIM "unicodefuzz";
 
-	// Scratch subdirectories with unicode names.
+	rawstream << "-------- Creating scratch directories" << std::endl;
 	const std::string flat = base + DIR_DELIM + fresh(8);
 	const std::string pairs = base + DIR_DELIM + fresh(8);
 	const std::string deep = base + DIR_DELIM + fresh(8);
@@ -724,6 +724,7 @@ void TestFileSys::testUnicodePathsFuzz()
 
 	// Fill `flat` using the generated names.
 	// Even ones are files, odd ones are a directory holding a file.
+	rawstream << "-------- Populating 'flat' scratch directory" << std::endl;
 	std::map<std::string, bool> expect_dir;
 	for (int i = 0; i < NUM_PATHS; i++) {
 		const std::string path = flat + DIR_DELIM + names[i];
@@ -758,7 +759,7 @@ void TestFileSys::testUnicodePathsFuzz()
 	}
 	UASSERTEQ(size_t, expect_dir.size(), NUM_PATHS);
 
-	// Test ReadFile
+	rawstream << "-------- Test ReadFile" << std::endl;
 	for (int i = 0; i < NUM_PATHS; i++) {
 		std::string path = flat + DIR_DELIM + names[i];
 		if (i % 2 == 1)
@@ -768,7 +769,7 @@ void TestFileSys::testUnicodePathsFuzz()
 		UASSERTEQ(auto, actual, content_for(path));
 	}
 
-	// Test GetDirListing
+	rawstream << "-------- Testing GetDirListing" << std::endl;
 	{
 		const auto listing = fs::GetDirListing(flat);
 		UASSERTEQ(size_t, listing.size(), expect_dir.size());
@@ -781,7 +782,7 @@ void TestFileSys::testUnicodePathsFuzz()
 		}
 	}
 
-	// Test GetRecursiveSubPaths
+	rawstream << "-------- Testing GetRecursiveSubPaths" << std::endl;
 	{
 		std::vector<std::string> subpaths;
 		fs::GetRecursiveSubPaths(flat, subpaths, true);
@@ -797,8 +798,9 @@ void TestFileSys::testUnicodePathsFuzz()
 		}
 	}
 
-	// Use a new scratch directory `pairs`.
-	// Test renaming, copying, and deleting
+	// Uses a different scratch directory, `pairs`.
+	rawstream << "-------- Testing Rename, CopyFileContents, and "
+		<< "DeleteSingleFileOrEmptyDirectory" << std::endl;
 	for (int i = 0; i + 1 < NUM_PATHS; i += 2) {
 		const std::string src = pairs + DIR_DELIM + names[i];
 		const std::string dst = pairs + DIR_DELIM + names[i + 1];
@@ -828,7 +830,7 @@ void TestFileSys::testUnicodePathsFuzz()
 	}
 	UASSERT(fs::GetDirListing(pairs).empty());
 
-	// Nested directories where every component is unicode
+	rawstream << "-------- Testing nested unicode paths" << std::endl;
 	const std::string abs_deep = fs::AbsolutePath(deep);
 	UASSERT(!abs_deep.empty());
 	for (int i = 0; i < 20; i++) {
@@ -880,7 +882,7 @@ void TestFileSys::testUnicodePathsFuzz()
 		UASSERT(!fs::PathExists(moved));
 	}
 
-	// RecursiveDelete should leave it clean
+	rawstream << "-------- Final cleanup with RecursiveDelete" << std::endl;
 	UASSERT(fs::RecursiveDelete(base));
 	UASSERT(!fs::PathExists(base));
 }

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -685,6 +685,20 @@ void TestFileSys::testUnicodePathsFuzz()
 {
 	constexpr int NUM_PATHS = 1000;
 
+	// On Windows, file open blocks until Defender clears its contents.
+	// This takes time:
+	//    ~ 0.03 ms - File has not been modified since last scanned.
+	//    ~ 0.8  ms - File modified, but content hash is cached.
+	//    ~ 8    ms - File modified and content is new.
+	//
+	// If the content of each file is unique, writing and re-opening 1000 files
+	// would take over 8 secs!
+	//
+	// So instead, we re-use 32 distinct content strings at random. This allows
+	// us to catch content mismatches 96% of the time, while reducing the total
+	// open time to ~ 256 ms.
+	constexpr int NUM_CONTENTS = 32;
+
 	// Fixed seed, so that a failure can be reproduced exactly.
 	PcgRandom rnd(0x9E3779B9, 0x5BF03635);
 
@@ -704,10 +718,19 @@ void TestFileSys::testUnicodePathsFuzz()
 	for (int i = 0; i < NUM_PATHS; i++)
 		names.push_back(fresh(20));
 
-	// The content contains the path it was written to, so an operation that
-	// ends up on the wrong path is caught when reading it back.
-	auto content_for = [] (const std::string &path) {
-		return "unicode fuzz\n" + path;
+
+	std::vector<std::string> contents;
+	contents.reserve(NUM_CONTENTS);
+	for (int i = 0; i < NUM_CONTENTS; i++)
+		contents.push_back(std::to_string(i));
+
+	std::map<std::string, size_t> cached_index;
+	auto content_for = [&] (const std::string &path) {
+		auto it = cached_index.find(path);
+		if (it == cached_index.end()) {
+			it = cached_index.emplace(path, rnd.range(0, NUM_CONTENTS - 1)).first;
+		}
+		return contents[it->second];
 	};
 
 	// This could be a pure ascii path.

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -616,7 +616,7 @@ const CodepointRange ascii_ranges[] = {
 const CodepointRange unicode_ranges[] = {
 	// two bytes in utf8
 	{0x00A1, 0x00A9}, {0x00AB, 0x00AC}, {0x00AE, 0x00B4},
-	{0x00B6, 0x00B9}, // skips µ (U+00B5), which case folds to μ
+	{0x00B6, 0x00B9}, // skips U+00B5 which case folds
 	{0x00BB, 0x00BB}, {0x00BF, 0x00BF}, {0x00D7, 0x00D7}, {0x00F7, 0x00F7},
 	{0x05D0, 0x05EA}, // Hebrew letters
 	{0x0627, 0x063A}, // Arabic letters, skipping the ones that decompose

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -7,6 +7,8 @@
 #include <sstream>
 #include <algorithm>
 #include <filesystem>
+#include <map>
+#include <set>
 
 #include "log.h"
 #include "serialization.h"
@@ -34,6 +36,7 @@ public:
 	void testNonExist();
 	void testRecursiveDelete();
 	void testGetRecursiveSubPaths();
+	void testUnicodePathsFuzz();
 };
 
 static TestFileSys g_test_instance;
@@ -53,6 +56,7 @@ void TestFileSys::runTests(IGameDef *gamedef)
 	TEST(testNonExist);
 	TEST(testRecursiveDelete);
 	TEST(testGetRecursiveSubPaths);
+	TEST(testUnicodePathsFuzz);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -588,4 +592,295 @@ void TestFileSys::testGetRecursiveSubPaths()
 	UASSERT(CONTAINS(dst, files[0]));
 	UASSERT(CONTAINS(dst, files[1]));
 	UASSERTEQ(size_t, dst.size(), 2+2);
+}
+
+/* Unicode path fuzzing */
+
+namespace {
+
+struct CodepointRange { u32 first, last; };
+
+/*
+  To make exact comparison easy, code points are intentionally restricted
+  to characters that are assigned and printable, caseless, and canonically
+  stable (NFC and NFD are the same).
+*/
+
+// Lower case only, see above. Omit '.' so no name can be "." or ".."
+const CodepointRange ascii_ranges[] = {
+	{'a', 'z'}, {'0', '9'}, {'-', '-'}, {'_', '_'},
+};
+
+// Includes code points outside the BMP which turn into surrogate pairs when
+// Windows converts them to UTF-16.
+const CodepointRange unicode_ranges[] = {
+	// two bytes in utf8
+	{0x00A1, 0x00A9}, {0x00AB, 0x00AC}, {0x00AE, 0x00B4},
+	{0x00B6, 0x00B9}, // skips µ (U+00B5), which case folds to μ
+	{0x00BB, 0x00BB}, {0x00BF, 0x00BF}, {0x00D7, 0x00D7}, {0x00F7, 0x00F7},
+	{0x05D0, 0x05EA}, // Hebrew letters
+	{0x0627, 0x063A}, // Arabic letters, skipping the ones that decompose
+	{0x0641, 0x064A},
+	// three bytes in utf8
+	{0x0E01, 0x0E2E}, // Thai consonants
+	{0x2600, 0x26B0}, // miscellaneous symbols
+	{0x3400, 0x4DB5}, // CJK extension A
+	{0x4E00, 0x9FA5}, // CJK
+	// four bytes in utf8
+	{0x1F600, 0x1F64F}, // emoticons
+	{0x20000, 0x2A6D6}, // CJK extension B
+};
+
+void appendUtf8(std::string &out, u32 cp)
+{
+	if (cp < 0x80) {
+		out += static_cast<char>(cp);
+	} else if (cp < 0x800) {
+		out += static_cast<char>(0xC0 | (cp >> 6));
+		out += static_cast<char>(0x80 | (cp & 0x3F));
+	} else if (cp < 0x10000) {
+		out += static_cast<char>(0xE0 | (cp >> 12));
+		out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+		out += static_cast<char>(0x80 | (cp & 0x3F));
+	} else {
+		out += static_cast<char>(0xF0 | (cp >> 18));
+		out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+		out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+		out += static_cast<char>(0x80 | (cp & 0x3F));
+	}
+}
+
+template <size_t N>
+u32 randomCodepoint(PcgRandom &rnd, const CodepointRange (&ranges)[N])
+{
+	// Ranges are picked uniformly, not weighted by size, so that short
+	// ranges are well represented.
+	const auto &range = ranges[rnd.range(0, static_cast<s32>(N) - 1)];
+	return rnd.range(range.first, range.last);
+}
+
+// Random name of at most `max_cp` code points (so up to 4*max_cp bytes).
+// This must stay below the 255 byte limit for a single name, and entire
+// paths must stay below MAX_PATH.
+//
+// Forces at least one non-ASCII character to prevent accidental use of device
+// names (con, nul, com1, ...)
+std::string randomUnicodeName(PcgRandom &rnd, int max_cp)
+{
+	const int len = rnd.range(1, max_cp);
+	const int forced = rnd.range(0, len - 1);
+	std::string name;
+	for (int i = 0; i < len; i++) {
+		if (i == forced || rnd.range(0, 3) != 0)
+			appendUtf8(name, randomCodepoint(rnd, unicode_ranges));
+		else
+			appendUtf8(name, randomCodepoint(rnd, ascii_ranges));
+	}
+	return name;
+}
+
+}
+
+void TestFileSys::testUnicodePathsFuzz()
+{
+	constexpr int NUM_PATHS = 1000;
+
+	// Fixed seed, so that a failure can be reproduced exactly.
+	PcgRandom rnd(0x9E3779B9, 0x5BF03635);
+
+	std::set<std::string> seen;
+
+	// Unique random name with up to `max_cp` codepoints
+	auto fresh = [&] (int max_cp) {
+		std::string name;
+		do {
+			name = randomUnicodeName(rnd, max_cp);
+		} while (!seen.insert(name).second);
+		return name;
+	};
+
+	std::vector<std::string> names;
+	names.reserve(NUM_PATHS);
+	for (int i = 0; i < NUM_PATHS; i++)
+		names.push_back(fresh(20));
+
+	// The content contains the path it was written to, so an operation that
+	// ends up on the wrong path is caught when reading it back.
+	auto content_for = [] (const std::string &path) {
+		return "unicode fuzz\n" + path;
+	};
+
+	// This could be a pure ascii path.
+	const std::string base = getTestTempDirectory() + DIR_DELIM "unicodefuzz";
+
+	// Scratch subdirectories with unicode names.
+	const std::string flat = base + DIR_DELIM + fresh(8);
+	const std::string pairs = base + DIR_DELIM + fresh(8);
+	const std::string deep = base + DIR_DELIM + fresh(8);
+	for (auto &it : {flat, pairs, deep}) {
+		UASSERT(fs::CreateAllDirs(it));
+		UASSERT(fs::IsDir(it));
+	}
+
+	// Fill `flat` using the generated names.
+	// Even ones are files, odd ones are a directory holding a file.
+	std::map<std::string, bool> expect_dir;
+	for (int i = 0; i < NUM_PATHS; i++) {
+		const std::string path = flat + DIR_DELIM + names[i];
+		if (i % 2 == 0) {
+			expect_dir[names[i]] = false;
+			// alternate between two ways of writing the file
+			if (i % 4 == 0) {
+				UASSERT(fs::safeWriteToFile(path, content_for(path)));
+			} else {
+				auto ofs = open_ofstream(path.c_str(), true);
+				UASSERT(ofs.good());
+				ofs << content_for(path);
+				ofs.close();
+				UASSERT(!ofs.fail());
+			}
+			UASSERT(fs::IsFile(path));
+			UASSERT(!fs::IsDir(path));
+		} else {
+			expect_dir[names[i]] = true;
+			UASSERT(fs::CreateDir(path));
+			UASSERT(fs::IsDir(path));
+			UASSERT(!fs::IsFile(path));
+			// reuse the name of the file created in the previous iteration
+			const std::string inner = path + DIR_DELIM + names[i - 1];
+			auto ofs = open_ofstream(inner.c_str(), true);
+			UASSERT(ofs.good());
+			ofs << content_for(inner);
+			ofs.close();
+			UASSERT(!ofs.fail());
+		}
+		UASSERT(fs::PathExists(path));
+	}
+	UASSERTEQ(size_t, expect_dir.size(), NUM_PATHS);
+
+	// Test ReadFile
+	for (int i = 0; i < NUM_PATHS; i++) {
+		std::string path = flat + DIR_DELIM + names[i];
+		if (i % 2 == 1)
+			path += DIR_DELIM + names[i - 1];
+		std::string actual;
+		UASSERT(fs::ReadFile(path, actual, true));
+		UASSERTEQ(auto, actual, content_for(path));
+	}
+
+	// Test GetDirListing
+	{
+		const auto listing = fs::GetDirListing(flat);
+		UASSERTEQ(size_t, listing.size(), expect_dir.size());
+		std::set<std::string> uniq;
+		for (const auto &node : listing) {
+			UTEST(expect_dir.count(node.name) == 1,
+				"unexpected name in listing: %s", node.name.c_str());
+			UASSERT(uniq.insert(node.name).second);
+			UASSERTEQ(bool, node.dir, expect_dir[node.name]);
+		}
+	}
+
+	// Test GetRecursiveSubPaths
+	{
+		std::vector<std::string> subpaths;
+		fs::GetRecursiveSubPaths(flat, subpaths, true);
+		// every entry, plus the file inside each of the directories
+		UASSERTEQ(size_t, subpaths.size(), NUM_PATHS + NUM_PATHS / 2);
+		const std::set<std::string> got(subpaths.begin(), subpaths.end());
+		UASSERTEQ(size_t, got.size(), subpaths.size());
+		for (int i = 0; i < NUM_PATHS; i++) {
+			const std::string path = flat + DIR_DELIM + names[i];
+			UASSERT(got.count(path) == 1);
+			if (i % 2 == 1)
+				UASSERT(got.count(path + DIR_DELIM + names[i - 1]) == 1);
+		}
+	}
+
+	// Use a new scratch directory `pairs`.
+	// Test renaming, copying, and deleting
+	for (int i = 0; i + 1 < NUM_PATHS; i += 2) {
+		const std::string src = pairs + DIR_DELIM + names[i];
+		const std::string dst = pairs + DIR_DELIM + names[i + 1];
+		const std::string content = content_for(src);
+
+		{
+			auto ofs = open_ofstream(src.c_str(), true);
+			UASSERT(ofs.good());
+			ofs << content;
+		}
+		UASSERT(fs::IsFile(src));
+
+		UASSERT(fs::Rename(src, dst));
+		UASSERT(!fs::PathExists(src));
+		UASSERT(fs::IsFile(dst));
+		std::string actual;
+		UASSERT(fs::ReadFile(dst, actual, true));
+		UASSERTEQ(auto, actual, content);
+
+		UASSERT(fs::CopyFileContents(dst, src));
+		actual.clear();
+		UASSERT(fs::ReadFile(src, actual, true));
+		UASSERTEQ(auto, actual, content);
+
+		UASSERT(fs::DeleteSingleFileOrEmptyDirectory(src, true));
+		UASSERT(fs::DeleteSingleFileOrEmptyDirectory(dst, true));
+	}
+	UASSERT(fs::GetDirListing(pairs).empty());
+
+	// Nested directories where every component is unicode
+	const std::string abs_deep = fs::AbsolutePath(deep);
+	UASSERT(!abs_deep.empty());
+	for (int i = 0; i < 20; i++) {
+		const std::string n1 = fresh(6);
+		const std::string n2 = fresh(6);
+		const std::string n3 = fresh(6);
+		const std::string top = deep + DIR_DELIM + fresh(6);
+		const std::string dir = top + DIR_DELIM + n1 + DIR_DELIM + n2;
+		const std::string file = dir + DIR_DELIM + n3;
+		const std::string content = content_for(file);
+		const std::string sub = n1 + DIR_DELIM + n2 + DIR_DELIM + n3;
+
+		UASSERT(fs::CreateAllDirs(dir));
+		UASSERT(fs::IsDir(dir));
+		UASSERT(fs::safeWriteToFile(file, content));
+		UASSERT(fs::IsFile(file));
+
+		// Test PathStartsWith
+		UASSERT(fs::PathStartsWith(fs::AbsolutePath(dir), abs_deep));
+
+		// Test MakePathRelativeTo
+		UASSERTEQ(auto, fs::MakePathRelativeTo(file, top), sub);
+
+		// Test RemoveLastPathComponent
+		std::string removed;
+		UASSERTEQ(auto, fs::RemoveLastPathComponent(file, &removed), dir);
+		UASSERTEQ(auto, removed, n3);
+
+		// Test CopyDir
+		const std::string copy = deep + DIR_DELIM + fresh(6);
+		UASSERT(fs::CopyDir(top, copy));
+		std::string actual;
+		UASSERT(fs::ReadFile(copy + DIR_DELIM + sub, actual, true));
+		UASSERTEQ(auto, actual, content);
+		UASSERT(fs::IsFile(file)); // source untouched
+
+		// Test MoveDir
+		const std::string moved = deep + DIR_DELIM + fresh(6);
+		UASSERT(fs::MoveDir(copy, moved));
+		UASSERT(!fs::PathExists(copy));
+		actual.clear();
+		UASSERT(fs::ReadFile(moved + DIR_DELIM + sub, actual, true));
+		UASSERTEQ(auto, actual, content);
+
+		// Test RecursiveDelete, and clean up.
+		UASSERT(fs::RecursiveDelete(top));
+		UASSERT(!fs::PathExists(top));
+		UASSERT(fs::RecursiveDelete(moved));
+		UASSERT(!fs::PathExists(moved));
+	}
+
+	// RecursiveDelete should leave it clean
+	UASSERT(fs::RecursiveDelete(base));
+	UASSERT(!fs::PathExists(base));
 }

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -683,19 +683,28 @@ std::string randomUnicodeName(PcgRandom &rnd, int max_cp)
 
 void TestFileSys::testUnicodePathsFuzz()
 {
+	// Number of paths (files) to generate as the base for this test.
+	// The actual number of files written is about 1.5x this.
 	constexpr int NUM_PATHS = 1000;
 
-	// On Windows, file open blocks until Defender clears its contents.
-	// This takes time:
-	//    ~ 0.03 ms - File has not been modified since last scanned.
-	//    ~ 0.8  ms - File modified, but content hash is cached.
-	//    ~ 8    ms - File modified and content is new.
+	// Number of distinct file contents written by this test.
 	//
-	// If the content of each file is unique, writing and re-opening 1000 files
-	// would take over 8 secs!
+	// On Windows, opening a file is blocked until Defender scans its contents.
+	// This adds a delay depending on the scan history of the file. For example:
+	//
+	//    File has not been modified since last scan     :   0.03 ms
+	//    File modified, but contents previously scanned :   0.8  ms
+	//    File modified, and contents are novel          :   8    ms
+	//
+	// (Measured on 2026-09-05 using a machine with Win 11, AMD Ryzen 9 3900X,
+	//  Samsung SSD 990 Pro. May change in future versions of defender/windows.)
+	//
+	// Since this test generates over 1000 files, if the content of each file
+	// were to be unique, writing and re-opening those 1000 files would take an
+	// additional 8 seconds!
 	//
 	// So instead, we re-use 32 distinct content strings at random. This allows
-	// us to catch content mismatches 96% of the time, while reducing the total
+	// us to catch a content mismatch 96% of the time, while reducing the total
 	// open time to ~ 256 ms.
 	constexpr int NUM_CONTENTS = 32;
 

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -699,13 +699,9 @@ void TestFileSys::testUnicodePathsFuzz()
 	// (Measured on 2026-09-05 using a machine with Win 11, AMD Ryzen 9 3900X,
 	//  Samsung SSD 990 Pro. May change in future versions of defender/windows.)
 	//
-	// Since this test generates over 1000 files, if the content of each file
-	// were to be unique, writing and re-opening those 1000 files would take an
-	// additional 8 seconds!
-	//
-	// So instead, we re-use 32 distinct content strings at random. This allows
-	// us to catch a content mismatch 96% of the time, while reducing the total
-	// open time to ~ 256 ms.
+	// Because previously scanned contents perform noticeably better, reuse
+	// 32 distinct file contents across the tests to only spend 32 * 8 ms initially.
+	// This still allows us to catch a content mismatch (1 - 1/32 =) 96% of the time.
 	constexpr int NUM_CONTENTS = 32;
 
 	// Fixed seed, so that a failure can be reproduced exactly.

--- a/src/unittest/test_filesys.cpp
+++ b/src/unittest/test_filesys.cpp
@@ -710,7 +710,7 @@ void TestFileSys::testUnicodePathsFuzz()
 	std::set<std::string> seen;
 
 	// Unique random name with up to `max_cp` codepoints
-	auto fresh = [&] (int max_cp) {
+	auto new_name = [&] (int max_cp) {
 		std::string name;
 		do {
 			name = randomUnicodeName(rnd, max_cp);
@@ -721,7 +721,7 @@ void TestFileSys::testUnicodePathsFuzz()
 	std::vector<std::string> names;
 	names.reserve(NUM_PATHS);
 	for (int i = 0; i < NUM_PATHS; i++)
-		names.push_back(fresh(20));
+		names.push_back(new_name(20));
 
 	std::vector<std::string> contents;
 	contents.reserve(NUM_CONTENTS);
@@ -740,21 +740,21 @@ void TestFileSys::testUnicodePathsFuzz()
 	// This could be a pure ascii path.
 	const std::string base = getTestTempDirectory() + DIR_DELIM "unicodefuzz";
 
-	rawstream << "-------- Creating scratch directories" << std::endl;
-	const std::string flat = base + DIR_DELIM + fresh(8);
-	const std::string pairs = base + DIR_DELIM + fresh(8);
-	const std::string deep = base + DIR_DELIM + fresh(8);
-	for (auto &it : {flat, pairs, deep}) {
+	rawstream << "-------- Creating base test directories" << std::endl;
+	const std::string dir_flat = base + DIR_DELIM + new_name(8);
+	const std::string dir_pairs = base + DIR_DELIM + new_name(8);
+	const std::string dir_deep = base + DIR_DELIM + new_name(8);
+	for (auto &it : {dir_flat, dir_pairs, dir_deep}) {
 		UASSERT(fs::CreateAllDirs(it));
 		UASSERT(fs::IsDir(it));
 	}
 
-	// Fill `flat` using the generated names.
+	// Fill `dir_flat` using the generated names.
 	// Even ones are files, odd ones are a directory holding a file.
-	rawstream << "-------- Populating 'flat' scratch directory" << std::endl;
+	rawstream << "-------- Populating `dir_flat` directory" << std::endl;
 	std::map<std::string, bool> expect_dir;
 	for (int i = 0; i < NUM_PATHS; i++) {
-		const std::string path = flat + DIR_DELIM + names[i];
+		const std::string path = dir_flat + DIR_DELIM + names[i];
 		if (i % 2 == 0) {
 			expect_dir[names[i]] = false;
 			// alternate between two ways of writing the file
@@ -788,7 +788,7 @@ void TestFileSys::testUnicodePathsFuzz()
 
 	rawstream << "-------- Test ReadFile" << std::endl;
 	for (int i = 0; i < NUM_PATHS; i++) {
-		std::string path = flat + DIR_DELIM + names[i];
+		std::string path = dir_flat + DIR_DELIM + names[i];
 		if (i % 2 == 1)
 			path += DIR_DELIM + names[i - 1];
 		std::string actual;
@@ -798,7 +798,7 @@ void TestFileSys::testUnicodePathsFuzz()
 
 	rawstream << "-------- Testing GetDirListing" << std::endl;
 	{
-		const auto listing = fs::GetDirListing(flat);
+		const auto listing = fs::GetDirListing(dir_flat);
 		UASSERTEQ(size_t, listing.size(), expect_dir.size());
 		std::set<std::string> uniq;
 		for (const auto &node : listing) {
@@ -812,25 +812,25 @@ void TestFileSys::testUnicodePathsFuzz()
 	rawstream << "-------- Testing GetRecursiveSubPaths" << std::endl;
 	{
 		std::vector<std::string> subpaths;
-		fs::GetRecursiveSubPaths(flat, subpaths, true);
+		fs::GetRecursiveSubPaths(dir_flat, subpaths, true);
 		// every entry, plus the file inside each of the directories
 		UASSERTEQ(size_t, subpaths.size(), NUM_PATHS + NUM_PATHS / 2);
 		const std::set<std::string> got(subpaths.begin(), subpaths.end());
 		UASSERTEQ(size_t, got.size(), subpaths.size());
 		for (int i = 0; i < NUM_PATHS; i++) {
-			const std::string path = flat + DIR_DELIM + names[i];
+			const std::string path = dir_flat + DIR_DELIM + names[i];
 			UASSERT(got.count(path) == 1);
 			if (i % 2 == 1)
 				UASSERT(got.count(path + DIR_DELIM + names[i - 1]) == 1);
 		}
 	}
 
-	// Uses a different scratch directory, `pairs`.
+	// Uses `dir_pairs` directory
 	rawstream << "-------- Testing Rename, CopyFileContents, and "
 		<< "DeleteSingleFileOrEmptyDirectory" << std::endl;
 	for (int i = 0; i + 1 < NUM_PATHS; i += 2) {
-		const std::string src = pairs + DIR_DELIM + names[i];
-		const std::string dst = pairs + DIR_DELIM + names[i + 1];
+		const std::string src = dir_pairs + DIR_DELIM + names[i];
+		const std::string dst = dir_pairs + DIR_DELIM + names[i + 1];
 		const std::string &content = content_for(src);
 
 		{
@@ -855,56 +855,81 @@ void TestFileSys::testUnicodePathsFuzz()
 		UASSERT(fs::DeleteSingleFileOrEmptyDirectory(src, true));
 		UASSERT(fs::DeleteSingleFileOrEmptyDirectory(dst, true));
 	}
-	UASSERT(fs::GetDirListing(pairs).empty());
+	UASSERT(fs::GetDirListing(dir_pairs).empty());
 
 	rawstream << "-------- Testing nested unicode paths" << std::endl;
-	const std::string abs_deep = fs::AbsolutePath(deep);
+	const std::string abs_deep = fs::AbsolutePath(dir_deep);
 	UASSERT(!abs_deep.empty());
 	for (int i = 0; i < 20; i++) {
-		const std::string n1 = fresh(6);
-		const std::string n2 = fresh(6);
-		const std::string n3 = fresh(6);
-		const std::string top = deep + DIR_DELIM + fresh(6);
-		const std::string dir = top + DIR_DELIM + n1 + DIR_DELIM + n2;
+		const std::string n1 = new_name(6);
+		const std::string n2 = new_name(6);
+		const std::string n3 = new_name(6);
+		// root = base directory for this iteration
+		const std::string root = dir_deep + DIR_DELIM + new_name(6);
+		// dir  = "/root/n1/n2"
+		const std::string dir = root + DIR_DELIM + n1 + DIR_DELIM + n2;
+		const std::string dir_relative_to_root = n1 + DIR_DELIM + n2;
+		// file = "/root/n1/n2/n3"
 		const std::string file = dir + DIR_DELIM + n3;
-		const std::string &content = content_for(file);
-		const std::string sub = n1 + DIR_DELIM + n2 + DIR_DELIM + n3;
+		const std::string file_relative_to_root = n1 + DIR_DELIM + n2 + DIR_DELIM + n3;
+		const std::string &file_content = content_for(file);
 
 		UASSERT(fs::CreateAllDirs(dir));
 		UASSERT(fs::IsDir(dir));
-		UASSERT(fs::safeWriteToFile(file, content));
+		UASSERT(fs::safeWriteToFile(file, file_content));
 		UASSERT(fs::IsFile(file));
-
-		// Test PathStartsWith
 		UASSERT(fs::PathStartsWith(fs::AbsolutePath(dir), abs_deep));
-
-		// Test MakePathRelativeTo
-		UASSERTEQ(auto, fs::MakePathRelativeTo(file, top), sub);
+		UASSERTEQ(auto, fs::MakePathRelativeTo(file, root), file_relative_to_root);
+		UASSERTEQ(auto, fs::MakePathRelativeTo(dir, root), dir_relative_to_root);
 
 		// Test RemoveLastPathComponent
 		std::string removed;
 		UASSERTEQ(auto, fs::RemoveLastPathComponent(file, &removed), dir);
 		UASSERTEQ(auto, removed, n3);
 
-		// Test CopyDir
-		const std::string copy = deep + DIR_DELIM + fresh(6);
-		UASSERT(fs::CopyDir(top, copy));
-		std::string actual;
-		UASSERT(fs::ReadFile(copy + DIR_DELIM + sub, actual, true));
-		UASSERTEQ(auto, actual, content);
-		UASSERT(fs::IsFile(file)); // source untouched
+		// Directory Copy Test
+		// -------------------------------------------------------
+		// We have directory `root` with `dir` and `file` inside.
+		// - Copy `root` to new path `copy`
+		// - Make sure dir and file were copied as well.
+		const std::string copy = dir_deep + DIR_DELIM + new_name(6);
+		UASSERT(fs::CopyDir(root, copy));
 
-		// Test MoveDir
-		const std::string moved = deep + DIR_DELIM + fresh(6);
+		// Source should be untouched
+		UASSERT(fs::IsDir(dir));
+		UASSERT(fs::IsFile(file));
+
+		// Copy should now exist
+		UASSERT(fs::IsDir(copy + DIR_DELIM + dir_relative_to_root));
+		UASSERT(fs::IsFile(copy + DIR_DELIM + file_relative_to_root));
+
+		// Copied file contents should match
+		std::string copy_contents;
+		UASSERT(fs::ReadFile(copy + DIR_DELIM + file_relative_to_root, copy_contents, true));
+		UASSERTEQ(auto, copy_contents, file_content);
+
+		// Directory Move Test
+		// ------------------------------------------------------------
+		// Move the copy to a new location
+		const std::string moved = dir_deep + DIR_DELIM + new_name(6);
 		UASSERT(fs::MoveDir(copy, moved));
-		UASSERT(!fs::PathExists(copy));
-		actual.clear();
-		UASSERT(fs::ReadFile(moved + DIR_DELIM + sub, actual, true));
-		UASSERTEQ(auto, actual, content);
 
-		// Test RecursiveDelete, and clean up.
-		UASSERT(fs::RecursiveDelete(top));
-		UASSERT(!fs::PathExists(top));
+		// Source should be gone
+		UASSERT(!fs::PathExists(copy));
+
+		// Move destination should now exist
+		UASSERT(fs::IsDir(moved + DIR_DELIM + dir_relative_to_root));
+		UASSERT(fs::IsFile(moved + DIR_DELIM + file_relative_to_root));
+
+		// Moved file contents should match
+		std::string moved_contents;
+		UASSERT(fs::ReadFile(moved + DIR_DELIM + file_relative_to_root, moved_contents, true));
+		UASSERTEQ(auto, moved_contents, file_content);
+
+		// Clean up everything
+		UASSERT(fs::RecursiveDelete(root));
+		UASSERT(!fs::PathExists(root));
+
 		UASSERT(fs::RecursiveDelete(moved));
 		UASSERT(!fs::PathExists(moved));
 	}


### PR DESCRIPTION
**Motivation**
RecursiveDelete() for windows uses windows api methods.
RecursiveDelete() for posix uses fork/execvp of "rm --rf".
Emscripten cannot do either of these, so it would need a third implementation.

**What this change does**
Provides a portable RecursiveDelete() implementation which uses std::filesystem (C++17).

Disclosure: I used AI to research and implement this change.