### PR TITLE
Chat: Fix incorrect RETURN key handling

### DIFF
--- a/src/client/inputhandler.cpp
+++ b/src/client/inputhandler.cpp
@@ -260,11 +260,12 @@ bool MyEventReceiver::OnEvent(const SEvent &event)
 	else if (event.EventType == EET_TOUCH_INPUT_EVENT)
 		last_pointer_type = PointerType::Touch;
 
-	// Let the menu handle events, if one is active.
+	bool ret = g_menumgr.runPreprocessEvent(event);
 	if (isMenuActive()) {
 		if (g_touchcontrols)
 			g_touchcontrols->setVisible(false);
-		return g_menumgr.preprocessEvent(event);
+		// Let the menu handle events, if one is active.
+		return ret;
 	}
 
 	// Remember whether each key is down or up

--- a/src/gui/guiChatConsole.cpp
+++ b/src/gui/guiChatConsole.cpp
@@ -472,7 +472,7 @@ bool GUIChatConsole::OnEvent(const SEvent& event)
 		else if(event.KeyInput.Key == KEY_RETURN)
 		{
 			// Avoid triggering actions when releasing the key
-			m_menumgr->inhibitKeyEvent(event.KeyInput.Key);
+			m_menumgr->inhibitKeyPress(event.KeyInput.Key);
 
 			prompt.addToHistory(prompt.getLine());
 			std::wstring text = prompt.replace(L"");

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -77,17 +77,17 @@ public:
 	}
 
 	// Returns true to prevent further processing
-	virtual bool preprocessEvent(const SEvent& event)
+	bool runPreprocessEvent(const SEvent &event)
 	{
-		if (m_stack.empty())
-			return false;
-
 		if (event.EventType == EET_KEY_INPUT_EVENT) {
 			bool ret = event.KeyInput.Key == m_inhibited_key && m_inhibited_key != KEY_UNKNOWN;
 			m_inhibited_key = KEY_UNKNOWN;
 			if (ret)
 				return true;
 		}
+
+		if (m_stack.empty())
+			return false;
 
 		GUIModalMenu *mm = dynamic_cast<GUIModalMenu*>(m_stack.back());
 		return mm && mm->preprocessEvent(event);

--- a/src/gui/mainmenumanager.h
+++ b/src/gui/mainmenumanager.h
@@ -71,7 +71,7 @@ public:
 		}
 	}
 
-	void inhibitKeyEvent(EKEY_CODE key) override
+	void inhibitKeyPress(EKEY_CODE key) override
 	{
 		m_inhibited_key = key;
 	}
@@ -81,7 +81,10 @@ public:
 	{
 		if (event.EventType == EET_KEY_INPUT_EVENT) {
 			bool ret = event.KeyInput.Key == m_inhibited_key && m_inhibited_key != KEY_UNKNOWN;
-			m_inhibited_key = KEY_UNKNOWN;
+			if (!event.KeyInput.PressedDown) {
+				// The OS may repeat key down events, hence only reset upon release.
+				m_inhibited_key = KEY_UNKNOWN;
+			}
 			if (ret)
 				return true;
 		}

--- a/src/gui/modalMenu.h
+++ b/src/gui/modalMenu.h
@@ -28,7 +28,8 @@ public:
 	// A GUIModalMenu calls these when this class is passed as a parameter
 	virtual void createdMenu(gui::IGUIElement *menu) = 0;
 	virtual void deletingMenu(gui::IGUIElement *menu) = 0;
-	virtual void inhibitKeyEvent(EKEY_CODE key) = 0;
+	/// Ignores all events of the specified key until (and including) it is released
+	virtual void inhibitKeyPress(EKEY_CODE key) = 0;
 };
 
 // Remember to drop() the menu after creating, so that it can


### PR DESCRIPTION
Fixes #17538

Bug introduced in #17449.

Moving this functionality to `MyEventReceiver` would probably be nicer. However, `guiChatConsole` is currently independent from that class, which seems fine too.

## To do

This PR is Ready for Review.

## How to test

1. Open chat
2. Type stuff and ENTER
3. Reopen chat
4. Type stuff and ENTER
5. Use https://github.com/luanti-org/luanti/issues/17156
6. Enter `/test`. There must be no DCL event fired.
