### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -161,7 +161,6 @@ jobs:
         run: |
           $proc = start .\bin\Release\luanti.exe --run-unittests -NoNewWindow -Wait -PassThru
           exit $proc.ExitCode
-        continue-on-error: true # FIXME!!
 
       - name: CPack
         run: |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -918,7 +918,7 @@ if(MSVC)
 	# Visual Studio
 	add_compile_definitions(_WIN32_WINNT=0x0601 WIN32_LEAN_AND_MEAN _CRT_SECURE_NO_WARNINGS)
 	# EHa enables SEH exceptions (used for catching segfaults)
-	set(CMAKE_CXX_FLAGS_RELEASE "/EHa /Ox /MD /GS- /Zi /fp:fast /D NDEBUG /D _HAS_ITERATOR_DEBUGGING=0")
+	set(CMAKE_CXX_FLAGS_RELEASE "/EHa /Ox /MD /GS- /Zi /fp:precise /fp:except- /D NDEBUG /D _HAS_ITERATOR_DEBUGGING=0")
 	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:SSE")
 	endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -919,9 +919,6 @@ if(MSVC)
 	add_compile_definitions(_WIN32_WINNT=0x0601 WIN32_LEAN_AND_MEAN _CRT_SECURE_NO_WARNINGS)
 	# EHa enables SEH exceptions (used for catching segfaults)
 	set(CMAKE_CXX_FLAGS_RELEASE "/EHa /Ox /MD /GS- /Zi /fp:precise /fp:except- /D NDEBUG /D _HAS_ITERATOR_DEBUGGING=0")
-	if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /arch:SSE")
-	endif()
 
 	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup")
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -143,25 +143,27 @@ std::string wide_to_utf8(std::wstring_view input)
 
 std::wstring utf8_to_wide(std::string_view input)
 {
-	size_t outbuf_size = input.size() + 1;
-	wchar_t *outbuf = new wchar_t[outbuf_size];
-	memset(outbuf, 0, outbuf_size * sizeof(wchar_t));
-	MultiByteToWideChar(CP_UTF8, 0, input.data(), input.size(),
-		outbuf, outbuf_size);
-	std::wstring out(outbuf);
-	delete[] outbuf;
+	if (input.empty())
+		return L"";
+	std::wstring out(input.size(), L'\0');
+	int len = MultiByteToWideChar(CP_UTF8, 0, input.data(), input.size(),
+		out.data(), out.size());
+	if (len <= 0)
+		return L"";
+	out.resize(len);
 	return out;
 }
 
 std::string wide_to_utf8(std::wstring_view input)
 {
-	size_t outbuf_size = (input.size() + 1) * 6;
-	char *outbuf = new char[outbuf_size];
-	memset(outbuf, 0, outbuf_size);
-	WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
-		outbuf, outbuf_size, NULL, NULL);
-	std::string out(outbuf);
-	delete[] outbuf;
+	if (input.empty())
+		return "";
+	std::string out(input.size() * 4, '\0');
+	int len = WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
+		out.data(), out.size(), NULL, NULL);
+	if (len <= 0)
+		return "";
+	out.resize(len);
 	return out;
 }
 

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -158,7 +158,7 @@ std::string wide_to_utf8(std::wstring_view input)
 {
 	if (input.empty())
 		return "";
-	 // 1 wchar can expand to at most 4 utf-8 bytes
+	// 1 wchar can expand to at most 4 utf-8 bytes
 	std::string out(input.size() * 4, '\0');
 	int len = WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
 		out.data(), out.size(), NULL, NULL);

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -158,6 +158,7 @@ std::string wide_to_utf8(std::wstring_view input)
 {
 	if (input.empty())
 		return "";
+	 // 1 wchar can expand to at most 4 utf-8 bytes
 	std::string out(input.size() * 4, '\0');
 	int len = WideCharToMultiByte(CP_UTF8, 0, input.data(), input.size(),
 		out.data(), out.size(), NULL, NULL);


### PR DESCRIPTION
Fix the failing unit tests on MSVC x64, and re-enable build failures when the tests fail.

Three tests were failing due to a mismatch in the behavior of floating points:

`TestSerialization::testStreamRead`
`TestUtilities::testIsBlockInSight`
`TestUtilities::testMyDoubleStringConversions`

I believe /fp:precise /fp:except- more closely matches the semantics of other platforms (linux), although at a small performance cost.

The translation failures were due to `utf8_to_wide` and `wide_to_utf8` not handling null characters inside a string correctly. Null characters would result in truncated output.

Disclosure: I used AI to research and implement this change.

EDIT:
Added an additional fix for MSVC x86. Removed `/arch:SSE` because that causes floating point math to use the X87 coprocessor, which has very different precision. Without that flag, the default is SSE2, which (to the best of my knowledge) all X86-32 processors since 2006 have.