### PR TITLE
[no squash] Make some previously deprecated things an error

### DIFF
--- a/builtin/game/register.lua
+++ b/builtin/game/register.lua
@@ -256,12 +256,11 @@ function core.register_item(name, itemdef)
 		error("Unable to register item: Type is invalid: " .. dump(itemdef))
 	end
 	local old_mt = getmetatable(itemdef)
-	-- TODO most of these checks should become an error after a while (maybe in 2026?)
 	if old_mt ~= nil and next(old_mt) ~= nil then
 		-- Note that even registering multiple identical items with the same table
-		-- is not allowed, due to the 'name' property.
+		-- is not possible, due to the 'name' property.
 		if old_mt.__index == defaults then
-			core.log("warning", "Item definition table was reused between registrations. "..
+			error("Item definition table was reused between registrations. "..
 				"This is unsupported and broken: " .. name)
 		else
 			core.log("warning", "Item definition has a metatable, this is "..

--- a/src/script/common/c_converter.cpp
+++ b/src/script/common/c_converter.cpp
@@ -30,13 +30,10 @@ static v3d check_v3d(lua_State *L, int index);
 		} \
 	} while(0)
 
-// TODO: this should be turned into an error in 2026.
-// Just revert the commit that added this line.
 #define CHECK_NOT_NIL(index, name) do { \
 		if (lua_isnoneornil(L, (index))) { \
-			auto msg = std::string("Invalid ") + (name) + \
-				" (value is nil)."; \
-			log_deprecated(L, msg, 1, true); \
+			throw LuaError(std::string("Invalid ") + (name) + \
+				" (value is nil)."); \
 		} \
 	} while(0)
 

--- a/src/script/lua_api/l_env.cpp
+++ b/src/script/lua_api/l_env.cpp
@@ -271,11 +271,11 @@ int ModApiEnv::l_get_node_raw(lua_State *L)
 	// mirrors the implementation of read_v3s16 (with the exact same rounding)
 	{
 		if (lua_isnoneornil(L, 1))
-			log_deprecated(L, "X position is nil", 1, true);
+			throw LuaError("X position is nil");
 		if (lua_isnoneornil(L, 2))
-			log_deprecated(L, "Y position is nil", 1, true);
+			throw LuaError("Y position is nil");
 		if (lua_isnoneornil(L, 3))
-			log_deprecated(L, "Z position is nil", 1, true);
+			throw LuaError("Z position is nil");
 		double x = lua_tonumber(L, 1);
 		double y = lua_tonumber(L, 2);
 		double z = lua_tonumber(L, 3);

--- a/src/unittest/test_scriptapi.cpp
+++ b/src/unittest/test_scriptapi.cpp
@@ -162,6 +162,10 @@ void TestScriptApi::testVectorReadErr(MyScriptApi *script)
 
 	// both methods should reject these
 	const char *errs1[] = {
+		"return {y=1, z=3}",
+		"return {x=1, z=3}",
+		"return {x=1, y=3}",
+		"return {}",
 		"return 'bamboo'",
 		"return function() end",
 		"return nil",
@@ -181,10 +185,6 @@ void TestScriptApi::testVectorReadMix(MyScriptApi *script)
 
 	// read_v3s16 should allow these, but check_v3s16 should not
 	const std::pair<const char*, v3s16> pairs2[] = {
-		{"return {}",                         {0, 0, 0}},
-		{"return {y=1, z=3}",                 {0, 1, 3}},
-		{"return {x=1, z=3}",                 {1, 0, 3}},
-		{"return {x=1, y=3}",                 {1, 3, 0}},
 		{"return {x='3', y='2.9', z=3}",      {3, 3, 3}},
 		{"return {x=false, y=0, z=0}",        {0, 0, 0}},
 		{"return {x='?', y=0, z=0}",          {0, 0, 0}},


### PR DESCRIPTION
follows up on:
* #16158: nil components in vectors
  * (warning since 5.13.0)
* #15938: reusing tables when registering items
  * (warning since 5.12.0)

## To do

This PR is Ready for Review.


## How to test

:fishing_pole_and_fish: 
