### PR TITLE
Optimization hints for sanity_check/FATAL_ERROR_IF

### DIFF
--- a/src/debug.h
+++ b/src/debug.h
@@ -14,6 +14,24 @@
 	#define FUNCTION_NAME __PRETTY_FUNCTION__
 #endif
 
+// Abort branches should always be marked unlikely, non-inline and cold,
+// so that the compiler can reduce their performance impact.
+#if defined(__GNUC__) || defined(__clang__)
+	#define COLD_FUNC       __attribute__((cold, noinline))
+	#define LIKELY(expr)    (__builtin_expect(!!(expr), 1))
+	#define UNLIKELY(expr)  (__builtin_expect(!!(expr), 0))
+#elif defined(_MSC_VER)
+	// MSVC has no exact cold equivalent. It supports [[likely]]
+	// and [[unlikely]], but we don't use C++20 yet.
+	#define COLD_FUNC       __declspec(noinline)
+	#define LIKELY(expr)    (expr)
+	#define UNLIKELY(expr)  (expr)
+#else
+	#define COLD_FUNC
+	#define LIKELY(expr)    (expr)
+	#define UNLIKELY(expr)  (expr)
+#endif
+
 // Whether to catch all std::exceptions.
 // When "catching", the program will abort with an error message.
 // In debug mode, leave these for the debugger and don't catch them.
@@ -25,7 +43,7 @@
 
 /* Abort program execution immediately
  */
-[[noreturn]] extern void fatal_error_fn(
+[[noreturn]] extern COLD_FUNC void fatal_error_fn(
 		const char *msg, const char *file,
 		unsigned int line, const char *function);
 
@@ -33,7 +51,7 @@
 	fatal_error_fn((msg), __FILE__, __LINE__, FUNCTION_NAME)
 
 #define FATAL_ERROR_IF(expr, msg) \
-	((expr) \
+	(UNLIKELY(expr) \
 	? fatal_error_fn((msg), __FILE__, __LINE__, FUNCTION_NAME) \
 	: (void)(0))
 
@@ -43,12 +61,12 @@
 	defined)
 */
 
-[[noreturn]] extern void sanity_check_fn(
+[[noreturn]] extern COLD_FUNC void sanity_check_fn(
 		const char *assertion, const char *file,
 		unsigned int line, const char *function);
 
 #define SANITY_CHECK(expr) \
-	((expr) \
+	(LIKELY(expr) \
 	? (void)(0) \
 	: sanity_check_fn(#expr, __FILE__, __LINE__, FUNCTION_NAME))
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -18,8 +18,8 @@
 // so that the compiler can reduce their performance impact.
 #if defined(__GNUC__) || defined(__clang__)
 	#define COLD_FUNC       __attribute__((cold, noinline))
-	#define LIKELY(expr)    (__builtin_expect(!!(expr), 1))
-	#define UNLIKELY(expr)  (__builtin_expect(!!(expr), 0))
+	#define LIKELY(expr)    (__builtin_expect((expr) ? 1 : 0, 1))
+	#define UNLIKELY(expr)  (__builtin_expect((expr) ? 1 : 0, 0))
 #elif defined(_MSC_VER)
 	// MSVC has no exact cold equivalent. It supports [[likely]]
 	// and [[unlikely]], but we don't use C++20 yet.

--- a/src/debug.h
+++ b/src/debug.h
@@ -16,20 +16,21 @@
 
 // Abort branches should always be marked unlikely, non-inline and cold,
 // so that the compiler can reduce their performance impact.
+#define EXPR_BOOL(expr)         ((expr) ? 1 : 0)
 #if defined(__GNUC__) || defined(__clang__)
 	#define COLD_FUNC       __attribute__((cold, noinline))
-	#define LIKELY(expr)    (__builtin_expect((expr) ? 1 : 0, 1))
-	#define UNLIKELY(expr)  (__builtin_expect((expr) ? 1 : 0, 0))
+	#define LIKELY(expr)    (__builtin_expect(EXPR_BOOL(expr), 1))
+	#define UNLIKELY(expr)  (__builtin_expect(EXPR_BOOL(expr), 0))
 #elif defined(_MSC_VER)
 	// MSVC has no exact cold equivalent. It supports [[likely]]
 	// and [[unlikely]], but we don't use C++20 yet.
 	#define COLD_FUNC       __declspec(noinline)
-	#define LIKELY(expr)    (expr)
-	#define UNLIKELY(expr)  (expr)
+	#define LIKELY(expr)    EXPR_BOOL(expr)
+	#define UNLIKELY(expr)  EXPR_BOOL(expr)
 #else
 	#define COLD_FUNC
-	#define LIKELY(expr)    (expr)
-	#define UNLIKELY(expr)  (expr)
+	#define LIKELY(expr)    EXPR_BOOL(expr)
+	#define UNLIKELY(expr)  EXPR_BOOL(expr)
 #endif
 
 // Whether to catch all std::exceptions.


### PR DESCRIPTION
`sanity_check` and `FATAL_ERROR_IF` are present in release builds, so we care about their performance.

With these hints, the compiler will emit code that is fast in the common case (sanity check passes, no abort), by making the uncommon case (fatal error, abort) slower. That's the trade-off we want.

**AI Disclosure:** I used AI to research and implement this change.