### PR TITLE
Make explicit that Luanti translates only from English

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -4740,6 +4740,11 @@ Translations
 Texts can be translated client-side with the help of `core.translate` and
 translation files.
 
+Luanti is currently a monolingual translation system. All translations occur
+from English and into a target language other than English, so you can translate
+English to Spanish but not Spanish to English, for instance. This is filed as
+[issue #6503](https://github.com/luanti-org/luanti/issues/6503)
+
 Translating a string
 --------------------
 


### PR DESCRIPTION
We should make it explicit so that developers like [this one from the forums](https://forum.luanti.org/viewtopic.php?p=452716) will not be confused with their introduction to the translation system.

Other may wish to review the wording and information given, but I have tried to be brief.