### PR TITLE
Adjust sensitivity for directional buttons in player:get_player_control()

### DIFF
--- a/doc/lua_api.md
+++ b/doc/lua_api.md
@@ -9348,6 +9348,12 @@ You **must not** mix names and track numbers to refer to the same animation.
         * They take both keyboard and joystick input into account.
         * You should prefer them over `up`, `down`, `left` and `right` to
           support different input methods correctly.
+        * Starting from version 5.17.0, the `up`, `down`, `left`, and `right`
+          fields are strictly filled out based on the actual movement; the
+          value of these fields is only true if the movement in the corresponding
+          direction is significant compared to the orthogonal direction. In
+          particular, newer clients never report keys in opposing directions as
+          being held down simultaneously.
     * Returns an empty table `{}` if the object is not a player.
 * `get_player_control_bits()`: returns integer with bit packed player pressed
   keys.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -170,10 +170,6 @@ void PlayerControl::setMovementFromKeys()
 u32 PlayerControl::getKeysPressed() const
 {
 	u32 keypress_bits =
-		( (u32)((up    > 0) & 1) << 0) |
-		( (u32)((down  > 0) & 1) << 1) |
-		( (u32)((left  > 0) & 1) << 2) |
-		( (u32)((right > 0) & 1) << 3) |
 		( (u32)(jump  & 1) << 4) |
 		( (u32)(aux1  & 1) << 5) |
 		( (u32)(sneak & 1) << 6) |
@@ -181,6 +177,15 @@ u32 PlayerControl::getKeysPressed() const
 		( (u32)(place & 1) << 8) |
 		( (u32)(zoom  & 1) << 9)
 	;
+
+	if (isMoving()) {
+		float angular_threshold = 3.0f/8.0f * M_PI;
+		keypress_bits |=
+			((u32)(std::abs(movement_direction) < angular_threshold) << 0) | // Forward
+			((u32)(std::abs(M_PI - movement_direction) < angular_threshold) << 1) | // Backward
+			((u32)(std::abs(M_PI_2 + movement_direction) < angular_threshold) << 2) | // Left
+			((u32)(std::abs(M_PI_2 - movement_direction) < angular_threshold) << 3); // Right
+	}
 
 	return keypress_bits;
 }


### PR DESCRIPTION
- Goal of the PR
  See title
- How does the PR work?
  - The directional keys are set if the difference between the axis and the actual movement direction is less than 67.5 degrees.
  - The API documentation is updated to reflect this adjustment. Note that certain documented behavior (i.e. that the buttons are _strictly_ computed from the movement direction) was introduced in #17219, not this PR.
- Does it resolve any reported issue?
  Fixes #17519.
- If you have used an LLM/AI to help with code or assets, you must disclose this.
  I did _not_ use an AI for this PR.

## To do

This PR is a Ready for Review.

## How to test

See linked issue